### PR TITLE
fix: multiple screens cannot be recorded after set window scale

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -734,7 +734,17 @@ void MainWindow::startCountdown()
 {
     recordButtonStatus = RECORD_BUTTON_WAIT;
 
-    recordProcess.setRecordInfo(recordX, recordY, recordWidth, recordHeight, selectAreaName, rootWindowRect.width, rootWindowRect.height);
+    const qreal ratio = devicePixelRatioF();
+    const QPoint topLeft = geometry().topLeft();
+
+    QRect recordRect {
+        static_cast<int>(recordX * ratio + topLeft.x()),
+        static_cast<int>(recordY * ratio + topLeft.y()),
+        static_cast<int>(recordWidth * ratio),
+        static_cast<int>(recordHeight * ratio)
+    };
+
+    recordProcess.setRecordInfo(recordRect, selectAreaName);
     if (QSysInfo::currentCpuArchitecture().startsWith("x86")) {
         if (recordOptionPanel->isSaveAsGif()) {
             recordProcess.setRecordType(RecordProcess::RECORD_TYPE_GIF);

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -68,20 +68,10 @@ RecordProcess::RecordProcess(QObject *parent) : QThread(parent)
     settings->setOption("save_directory", saveDir);
 }
 
-void RecordProcess::setRecordInfo(int rx, int ry, int rw, int rh, QString name, int sw, int sh)
+void RecordProcess::setRecordInfo(const QRect &recordRect, const QString &filename)
 {
-    recordX = rx;
-    recordY = ry;
-    recordWidth = rx + rw <= sw ? rw : sw - rx;
-    recordHeight = ry + rh <= sh ? rh : sh - ry;
-
-    qreal devicePixelRatio = qApp->devicePixelRatio();
-    recordX = int(recordX * devicePixelRatio);
-    recordY = int(recordY * devicePixelRatio);
-    recordWidth = int(recordWidth * devicePixelRatio);
-    recordHeight = int(recordHeight * devicePixelRatio);
-
-    saveAreaName = name;
+    m_recordRect = recordRect;
+    saveAreaName = filename;
 }
 
 void RecordProcess::setRecordType(int type)
@@ -118,8 +108,8 @@ void RecordProcess::recordGIF()
 
     QStringList arguments;
     arguments << QString("--cursor");
-    arguments << QString("--x=%1").arg(recordX) << QString("--y=%1").arg(recordY);
-    arguments << QString("--width=%1").arg(recordWidth) << QString("--height=%1").arg(recordHeight);
+    arguments << QString("--x=%1").arg(m_recordRect.x()) << QString("--y=%1").arg(m_recordRect.y());
+    arguments << QString("--width=%1").arg(m_recordRect.width()) << QString("--height=%1").arg(m_recordRect.height());
     arguments << QString("--exec=%1").arg(sleepCommand);
     arguments << savePath;
 
@@ -150,13 +140,13 @@ void RecordProcess::recordVideo()
         qDebug() << "mkv framerate " << framerate;
 
         arguments << QString("-video_size");
-        arguments << QString("%1x%2").arg(recordWidth).arg(recordHeight);
+        arguments << QString("%1x%2").arg(m_recordRect.width()).arg(m_recordRect.height());
         arguments << QString("-framerate");
         arguments << QString("%1").arg(framerate);
         arguments << QString("-f");
         arguments << QString("x11grab");
         arguments << QString("-i");
-        arguments << QString("%1+%2,%3").arg(displayNumber).arg(recordX).arg(recordY);
+        arguments << QString("%1+%2,%3").arg(displayNumber).arg(m_recordRect.x()).arg(m_recordRect.y());
         arguments << QString("-c:v");
         arguments << QString("libx264");
         arguments << QString("-qp");
@@ -176,13 +166,13 @@ void RecordProcess::recordVideo()
         qDebug() << "mp4 framerate " << framerate;
 
         arguments << QString("-video_size");
-        arguments << QString("%1x%2").arg(recordWidth).arg(recordHeight);
+        arguments << QString("%1x%2").arg(m_recordRect.width()).arg(m_recordRect.height());
         arguments << QString("-framerate");
         arguments << QString("%1").arg(framerate);
         arguments << QString("-f");
         arguments << QString("x11grab");
         arguments << QString("-i");
-        arguments << QString("%1+%2,%3").arg(displayNumber).arg(recordX).arg(recordY);
+        arguments << QString("%1+%2,%3").arg(displayNumber).arg(m_recordRect.x()).arg(m_recordRect.y());
 
         // Most mobile mplayer can't decode yuv444p (ffempg default format) video, yuv420p looks good.
         arguments << QString("-pix_fmt");

--- a/src/record_process.h
+++ b/src/record_process.h
@@ -24,6 +24,7 @@
 #include "settings.h"
 #include <QProcess>
 #include <QThread>
+#include <QRect>
 #include <proc/readproc.h>
 #include <proc/sysinfo.h>
 
@@ -40,7 +41,7 @@ public:
     
     RecordProcess(QObject *parent = 0);
     
-    void setRecordInfo(int recordX, int recordY, int record_width, int recordHeight, QString areaName, int screenWidth, int screenHeight);
+    void setRecordInfo(const QRect &recordRect, const QString &filename);
     void setRecordType(int recordType);
     void startRecord();
     void stopRecord();
@@ -55,11 +56,9 @@ protected:
 private:
     QProcess* process;
 
-    int recordX;
-    int recordY;
-    int recordWidth;
-    int recordHeight;
     int recordType;
+
+    QRect m_recordRect;
     
     QString savePath;
     QString saveBaseName;


### PR DESCRIPTION
开启缩放以后，dtkwm提供了错误的坐标，录屏在计算时也计算错误，导致在非主屏上录像
永远是在主屏位置的信息。

fix dtkwm: https://github.com/linuxdeepin/dtkwm/pull/2