### PR TITLE
fix the collapse when using -f option

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1023,7 +1023,7 @@ void MainWindow::delayScreenshot(double num)
 
 void MainWindow::fullScreenshot()
 {
-    DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
+    //DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
     this->initAttributes();
     this->initLaunchMode("screenShot");
     this->showFullScreen();
@@ -1129,7 +1129,7 @@ void MainWindow::testScreenshot()
 
 void MainWindow::topWindow()
 {
-    DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
+    //DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
     this->initAttributes();
     this->initLaunchMode("screenShot");
     this->showFullScreen();


### PR DESCRIPTION
while I was using -f option to start this program under kde, the program would collapse since I did't install the sound effect. Comment this line can fix the bug. (I thought maybe I should use try-catch to fix the problem, but I found all the other of "playSystemSoundEffect" had been commented. So I just comment this line directly)