### PR TITLE
fix:Fix compilation error on Qt 5.15

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -27,6 +27,7 @@
 #include <QDebug>
 #include <QFontMetrics>
 #include <QPainter>
+#include <QPainterPath>
 #include <QDBusInterface>
 #include <QtX11Extras/QX11Info>
 #include <X11/extensions/shape.h>

--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -20,6 +20,7 @@
 #include "shapeswidget.h"
 #include <QApplication>
 #include <QPainter>
+#include <QPainterPath>
 #include <QDebug>
 
 #include "../utils/calculaterect.h"

--- a/src/widgets/tooltips.cpp
+++ b/src/widgets/tooltips.cpp
@@ -33,6 +33,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPainter>
+#include <QPainterPath>
 #include <QGraphicsDropShadowEffect>
 #include <QPropertyAnimation>
 #include <QGraphicsOpacityEffect>


### PR DESCRIPTION
Compilation error due to header file changes. 
`QPainterPath` includes have
been added manually.

```
../deepin-screen-recorder/src/widgets/shapeswidget.cpp: In member function ‘void ShapesWidget::paintRect(QPainter&, FourPoints, int, ShapesWidget::ShapeBlurStatus, bool, bool)’:
../deepin-screen-recorder/src/widgets/shapeswidget.cpp:1545:18: error: aggregate ‘QPainterPath rectPath’ has incomplete type and cannot be defined
 1545 |     QPainterPath rectPath;
      |                  ^~~~~~~~
../deepin-screen-recorder/src/widgets/shapeswidget.cpp: In member function ‘void ShapesWidget::paintEllipse(QPainter&, FourPoints, int, ShapesWidget::ShapeBlurStatus, bool, bool)’:
../deepin-screen-recorder/src/widgets/shapeswidget.cpp:1584:18: error: aggregate ‘QPainterPath ellipsePath’ has incomplete type and cannot be defined
 1584 |     QPainterPath ellipsePath;
      |                  ^~~~~~~~~~~
../deepin-screen-recorder/src/widgets/shapeswidget.cpp:1585:18: error: aggregate ‘QPainterPath rectPath’ has incomplete type and cannot be defined
 1585 |     QPainterPath rectPath;
      |                  ^~~~~~~~
../deepin-screen-recorder/src/widgets/shapeswidget.cpp: In member function ‘void ShapesWidget::paintArrow(QPainter&, QList<QPointF>, int, bool)’:
../deepin-screen-recorder/src/widgets/shapeswidget.cpp:1631:26: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
 1631 |             QPainterPath path;
      |                          ^~~~
../deepin-screen-recorder/src/widgets/shapeswidget.cpp: In member function ‘void ShapesWidget::paintLine(QPainter&, QList<QPointF>)’:
../deepin-screen-recorder/src/widgets/shapeswidget.cpp:1650:18: error: aggregate ‘QPainterPath linePaths’ has incomplete type and cannot be defined
 1650 |     QPainterPath linePaths;
      |                  ^~~~~~~~~
...
```