### PR TITLE
fix: missing opencv4 in PKGCONFIG array

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -21,7 +21,7 @@ isEqual(ARCH, mips64) {
 }
 
 CONFIG += link_pkgconfig c++11
-PKGCONFIG += xcb xcb-util dframeworkdbus
+PKGCONFIG += xcb xcb-util dframeworkdbus opencv4
 
 RESOURCES = ../assets/image/deepin-screen-recorder.qrc \
     ../assets/resources/resources.qrc \


### PR DESCRIPTION
This populates necessary `-I` flags properly and fixes the following build failure on Arch:

```
In file included from utils/scrollScreenshot.h:23,
                 from main_window.h:24,
                 from main_window.cpp:24:
utils/pixmergethread.h:31:9: fatal error: opencv2/opencv.hpp: No such file or directory
   31 | #include<opencv2/opencv.hpp>
      |         ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from utils/scrollScreenshot.h:23,
                 from main_window.h:24,
                 from main.cpp:24:
utils/pixmergethread.h:31:9: fatal error: opencv2/opencv.hpp: No such file or directory
   31 | #include<opencv2/opencv.hpp>
      |         ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:1888: main_window.o] Error 1
```