### PR TITLE
fix: (x11)修复调整捕捉区域后，录制的画面区域不正确

### DIFF
--- a/src/gstrecord/gstrecordx.cpp
+++ b/src/gstrecord/gstrecordx.cpp
@@ -92,14 +92,15 @@ void GstRecordX::x11GstStartRecord()
     QStringList areaList;
 
     //设置录制区域的大小及位置 show-pointer:是否录制光标
+    //这里录制区域有个ximagesrc的bug，endx或者endy只要有一个的大小为显示屏的大小。录制的视频最终结果都是全屏。因此需要减一个像素
     areaList << "ximagesrc"
              << "display-name=" + qgetenv("DISPLAY")
              << "use-damage=false"
              << "show-pointer=" + m_isRecordMouse //是否录制光标
              << "startx=" + QString::number(m_recordArea.x())
              << "starty=" + QString::number(m_recordArea.y())
-             << "endx=" + QString::number(m_recordArea.x() + m_recordArea.width())
-             << "endy=" + QString::number(m_recordArea.y() + m_recordArea.height());
+             << "endx=" + QString::number(m_recordArea.x() + m_recordArea.width() - 1)
+             << "endy=" + QString::number(m_recordArea.y() + m_recordArea.height() - 1);
     arguments << areaList.join(" ");
 
     //设置录屏的帧率

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -508,6 +508,7 @@ void MainWindow::whileCheckTempFileArm()
     }
 }
 #endif
+//启动截图录屏时检测是否是锁屏状态
 void MainWindow::checkIsLockScreen()
 {
     QDBusInterface sessionManagerIntert("com.deepin.SessionManager",
@@ -2592,8 +2593,12 @@ void MainWindow::saveScreenShot()
         }
 #endif
     } else {
-        //普通截图保存图片
-        shotCurrentImg();
+        //除了滚动截图时，突然进入锁屏界面不会执行shotCurrentImg()函数，其他情况都会执行shotCurrentImg()
+        if (!(status::scrollshot == m_functionType && m_isLockedState)) {
+            qInfo() << "Shot currnet image!";
+            //普通截图保存图片
+            shotCurrentImg();
+        }
     }
     const bool r = saveAction(m_resultPixmap);
     save2Clipboard(m_resultPixmap);

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -505,7 +505,7 @@ public slots:
     void onScrollShotCheckScrollType(int autoScrollFlag);
 
     /**
-     * @brief 监听锁屏信号，滚动截图和贴图需要使用
+     * @brief 监听锁屏信号，滚动截图和贴图需要使用,贴图或滚动截图时突然锁频会触发此信号槽
      * @param msg
      */
     void onLockScreenEvent(QDBusMessage msg);


### PR DESCRIPTION
Description: gstremer中ximagesrc的bug，录制区域的终点有问题

Log: 修复调整捕捉区域后，录制的画面区域不正确

Bug: https://pms.uniontech.com/bug-view-127641.html
        https://pms.uniontech.com/bug-view-127963.html