### PR TITLE
fix:  (wayland)修复贴图工具栏可以单独拖动

### DIFF
--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -23,6 +23,7 @@
 #include "utils.h"
 
 #include <QActionGroup>
+#include <QMouseEvent>
 #include <DFontSizeManager>
 
 #define THEMETYPE 1 // 主题颜色为浅色
@@ -108,4 +109,10 @@ void ToolBarWidget::initToolBarWidget()
     setLayout(hLayout);
 }
 
+//重写鼠标移动事件：解决工具栏可以被拖动的问题
+void ToolBarWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    //qDebug() << event->button() << event->x() << event->y();
+    //QWidget::mouseMoveEvent(event);
+}
 

--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -112,6 +112,7 @@ void ToolBarWidget::initToolBarWidget()
 //重写鼠标移动事件：解决工具栏可以被拖动的问题
 void ToolBarWidget::mouseMoveEvent(QMouseEvent *event)
 {
+    Q_UNUSED(event);
     //qDebug() << event->button() << event->x() << event->y();
     //QWidget::mouseMoveEvent(event);
 }

--- a/src/pin_screenshots/ui/toolbarwidget.h
+++ b/src/pin_screenshots/ui/toolbarwidget.h
@@ -47,6 +47,12 @@ signals:
     void signalCloseButtonClicked();// 关闭按钮被点击
 protected:
     void initToolBarWidget(); //初始化工具栏
+    /**
+     * @brief 重写鼠标移动事件：解决工具栏可以被拖动的问题
+     * 工具栏暂无鼠标移动事件
+     * @param event
+     */
+    void mouseMoveEvent(QMouseEvent *event) override;
 private:
     SubToolWidget *m_subTool;
     DImageButton *m_closeButton;


### PR DESCRIPTION
Description:  由于贴图工具栏的鼠标移动事件未屏蔽

Log:  修复贴图工具栏可以单独拖动

Bug: https://pms.uniontech.com/bug-view-121331.html