### PR TITLE
fix: (wayland)修复贴图工具栏可以单独拖动

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -508,6 +508,7 @@ void MainWindow::whileCheckTempFileArm()
     }
 }
 #endif
+//启动截图录屏时检测是否是锁屏状态
 void MainWindow::checkIsLockScreen()
 {
     QDBusInterface sessionManagerIntert("com.deepin.SessionManager",
@@ -2592,8 +2593,12 @@ void MainWindow::saveScreenShot()
         }
 #endif
     } else {
-        //普通截图保存图片
-        shotCurrentImg();
+        //除了滚动截图时，突然进入锁屏界面不会执行shotCurrentImg()函数，其他情况都会执行shotCurrentImg()
+        if (!(status::scrollshot == m_functionType && m_isLockedState)) {
+            qInfo() << "Shot currnet image!";
+            //普通截图保存图片
+            shotCurrentImg();
+        }
     }
     const bool r = saveAction(m_resultPixmap);
     save2Clipboard(m_resultPixmap);

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -505,7 +505,7 @@ public slots:
     void onScrollShotCheckScrollType(int autoScrollFlag);
 
     /**
-     * @brief 监听锁屏信号，滚动截图和贴图需要使用
+     * @brief 监听锁屏信号，滚动截图和贴图需要使用,贴图或滚动截图时突然锁频会触发此信号槽
      * @param msg
      */
     void onLockScreenEvent(QDBusMessage msg);

--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -32,9 +32,9 @@ const QSize MIN_TOOLBAR_WIDGET_SIZE = QSize(194, 60);
 
 ToolBarWidget::ToolBarWidget(DWidget *parent): DBlurEffectWidget(parent)
 {
-    if(Utils::isWaylandMode){
-        setWindowFlags(Qt::Sheet |Qt::WindowStaysOnTopHint| Qt::WindowDoesNotAcceptFocus);
-    }else {
+    if (Utils::isWaylandMode) {
+        setWindowFlags(Qt::Sheet | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
+    } else {
         setWindowFlags(Qt::ToolTip);
     }
 
@@ -112,6 +112,7 @@ void ToolBarWidget::initToolBarWidget()
 //重写鼠标移动事件：解决工具栏可以被拖动的问题
 void ToolBarWidget::mouseMoveEvent(QMouseEvent *event)
 {
+    Q_UNUSED(event);
     //qDebug() << event->button() << event->x() << event->y();
     //QWidget::mouseMoveEvent(event);
 }

--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -23,6 +23,7 @@
 #include "utils.h"
 
 #include <QActionGroup>
+#include <QMouseEvent>
 #include <DFontSizeManager>
 
 #define THEMETYPE 1 // 主题颜色为浅色
@@ -108,4 +109,10 @@ void ToolBarWidget::initToolBarWidget()
     setLayout(hLayout);
 }
 
+//重写鼠标移动事件：解决工具栏可以被拖动的问题
+void ToolBarWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    //qDebug() << event->button() << event->x() << event->y();
+    //QWidget::mouseMoveEvent(event);
+}
 

--- a/src/pin_screenshots/ui/toolbarwidget.h
+++ b/src/pin_screenshots/ui/toolbarwidget.h
@@ -47,6 +47,12 @@ signals:
     void signalCloseButtonClicked();// 关闭按钮被点击
 protected:
     void initToolBarWidget(); //初始化工具栏
+    /**
+     * @brief 重写鼠标移动事件：解决工具栏可以被拖动的问题
+     * 工具栏暂无鼠标移动事件
+     * @param event
+     */
+    void mouseMoveEvent(QMouseEvent *event) override;
 private:
     SubToolWidget *m_subTool;
     DImageButton *m_closeButton;


### PR DESCRIPTION
Description:  由于贴图工具栏的鼠标移动事件未屏蔽

Log:  修复贴图工具栏可以单独拖动

Bug: https://pms.uniontech.com/bug-view-121331.html