### PR TITLE
fix: 修复Gstreamer启动录屏后未选择webm格式

### DIFF
--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -385,10 +385,12 @@ void SubToolWidget::initRecordLabel()
     formatTitleAction->setText(tr("Format:"));
     gifAction->setText(tr("GIF"));
     gifAction->setCheckable(true);
-    if(Utils::isFFmpegEnv) {
+    if (Utils::isFFmpegEnv) {
         mp4Action->setText(tr("MP4"));
     } else {
         mp4Action->setText(tr("webm"));
+        //Gstreamer录屏时，不存在gif，避免此开关被打开
+        t_saveGif = false;
     }
     mp4Action->setCheckable(true);
 


### PR DESCRIPTION
Description: ffmeg录制gif时写入配置，切换到gstreamer时未进行判断

Log: 修复Gstreamer启动录屏后未选择webm格式

Bug: https://pms.uniontech.com/bug-view-128269.html