### PR TITLE
fix: (Gstreamer)修复klv录制花屏

### DIFF
--- a/src/gstrecord/gstrecordx.cpp
+++ b/src/gstrecord/gstrecordx.cpp
@@ -145,7 +145,7 @@ void GstRecordX::waylandGstStartRecord()
     wlarguments << "appsrc name=videoSrc";
     //此处需特别注意视频帧的格式，由于在wayland协议上，采集的画面，hw机和普通机器的像素格式有差异
     if (m_boardVendorType) {
-        wlarguments << QString("video/x-raw, format=RGB, framerate=%1/1, width=%2, height=%3").arg(m_framerate).arg(m_recordArea.width()).arg(m_recordArea.height());
+        wlarguments << QString("video/x-raw, format=BGRA, framerate=%1/1, width=%2, height=%3").arg(m_framerate).arg(m_recordArea.width()).arg(m_recordArea.height());
     } else {
         wlarguments << QString("video/x-raw, format=RGBA, framerate=%1/1, width=%2, height=%3").arg(m_framerate).arg(m_recordArea.width()).arg(m_recordArea.height());
     }


### PR DESCRIPTION
Description: 由于视频的像素格式不对

Log: 修复klv录制花屏

Bug: https://pms.uniontech.com/bug-view-129883.html