### PR TITLE
fix(截图录屏): 工具栏初始化问题

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1701,7 +1701,9 @@ void MainWindow::wheelEvent(QWheelEvent *event)
 
 void MainWindow::pinScreenshotsLockScreen(bool isLocked)
 {
-    m_toolBar->setPinScreenshotsEnable(!isLocked);
+    if (m_toolBarInit) {
+        m_toolBar->setPinScreenshotsEnable(!isLocked);
+    }
 }
 
 void MainWindow::scrollShotLockScreen(bool isLocked)


### PR DESCRIPTION
Description: 注销系统后，进入桌面快速启动截图，截图退出

Log: https://pms.uniontech.com/bug-view-133401.html