### PR TITLE
fix: 修复在选项区域上滑动鼠标，移出选项区域后，鼠标变成“+”

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -3641,6 +3641,10 @@ bool MainWindow::eventFilter(QObject *, QEvent *event)
 
                     needRepaint = true;
                 } else {
+                    //wayland模式下，第一次释放鼠标时需要重设光标的形状
+                    if (Utils::isWaylandMode) {
+                        resetCursor();
+                    }
                     if (recordButtonStatus == RECORD_BUTTON_NORMAL) {
                         //showRecordButton();
                         updateToolBarPos();


### PR DESCRIPTION
Description: 由于wayland上下拉菜单的焦点激活方式与x11有区别，做规避处理

Log: 修复在选项区域上滑动鼠标，移出选项区域后，鼠标变成“+”

Bug: https://pms.uniontech.com/bug-view-132763.html