### PR TITLE
fix: 修复卸载ffmpeg时，会同时把截图录屏卸载

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: https://github.com/linuxdeepin/deepin-screen-recorder
 
 Package: deepin-screen-recorder
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ffmpeg, libgstreamer1.0-0 (>= 1.0.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libgstreamer1.0-0 (>= 1.0.0)
 Recommends: dde-session-ui,deepin-ocr
 Conflicts: deepin-screenshot
 Replaces: deepin-screenshot

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,15 +56,29 @@ static bool isWaylandProtocol()
 
 static bool CheckFFmpegEnv()
 {
+    bool flag = false;
     QDir dir;
     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
     dir.setPath(path);
     QStringList list = dir.entryList(QStringList() << (QString("libavcodec") + "*"), QDir::NoDotAndDotDot | QDir::Files);
     qDebug() << list;
+
     if (list.contains("libavcodec.so.58")) {
-        return true;
+        flag = true;
     }
-    return false;
+
+//    QString usrbinPath  = QStandardPaths::displayName(QStandardPaths::ApplicationsLocation);
+    qDebug()  <<     QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
+    //x11下需要检测ffmpeg应用是否存在
+    if (!isWaylandProtocol()) {
+        qDebug() << "QFile(/usr/bin/ffmpeg).exists(): " << QFile("/usr/bin/ffmpeg").exists();
+        if (QFile("/usr/bin/ffmpeg").exists()) {
+            flag = true;
+        } else {
+            flag = false;
+        }
+    }
+    return flag;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Description: 由于contral中强依赖于ffmpeg，x11录屏时如果没有ffmpeg应用将会使用gstreamer录屏

Log: 修复卸载ffmpeg时，会同时把截图录屏卸载

Bug: https://pms.uniontech.com/bug-view-141357.html