### PR TITLE
fix:  优化录屏时获取真实声卡的方式

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -548,7 +548,7 @@ void RecordProcess::setSystemAudio(const bool status)
 void RecordProcess::startRecord()
 {
     //使用QtConcurrent::run受cpu核心线程数的影响，线程池默认大小为CPU核心线程数大小，由于程序中通过此方法启动的线程数超出4个，故再次设置线程池大小
-    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 6);
+    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 8);
     m_framerate = settings->value("recordConfig", "mkv_framerate").toString().toInt();
     qDebug() << "m_selectedMic: " << m_selectedMic;
     qDebug() << "m_selectedSystemAudio: " << m_selectedSystemAudio;

--- a/src/utils/audioutils.cpp
+++ b/src/utils/audioutils.cpp
@@ -254,6 +254,7 @@ QString AudioUtils::getDefaultDeviceName(DefaultAudioType mode)
             this)
     );
     if (mode == DefaultAudioType::Sink) {
+        //1.首先取出默认系统声卡
         QScopedPointer<com::deepin::daemon::audio::Sink> defaultSink;
         defaultSink.reset(
             new com::deepin::daemon::audio::Sink(
@@ -270,6 +271,33 @@ QString AudioUtils::getDefaultDeviceName(DefaultAudioType mode)
             device = defaultSink->name();
             if (!device.isEmpty() && !device.endsWith(".monitor")) {
                 device += ".monitor";
+            }
+        }
+        //2.如果默认系统声卡不是物理声卡和蓝牙声卡，需找出真实的物理声卡
+        if(!device.startsWith("alsa",Qt::CaseInsensitive) && !device.startsWith("blue",Qt::CaseInsensitive)){
+            QList<QScopedPointer<com::deepin::daemon::audio::Sink>> sinks;
+            QScopedPointer<com::deepin::daemon::audio::Sink> realSink;
+            for (int i=0;i<audioInterface->sinks().size();i++) {
+                realSink.reset(
+                    new com::deepin::daemon::audio::Sink(
+                        serviceName,
+                        audioInterface->sinks()[i].path(),
+                        QDBusConnection::sessionBus(),
+                        this)
+                );
+                if (realSink->isValid()) {
+                    qInfo() << "realSink name is : " << realSink->name();
+                    qInfo() << "realSink activePort name : " << realSink->activePort().name;
+                    qInfo() << "             activePort description : " << realSink->activePort().description;
+                    qInfo() << "             activePort availability : " << realSink->activePort().availability;
+                    device = realSink->name();
+                    if(device.startsWith("alsa",Qt::CaseInsensitive)){
+                        device += ".monitor";
+                        break;
+                    }else {
+                        device = "unknow";
+                    }
+                }
             }
         }
     } else if (mode == DefaultAudioType::Source) {

--- a/src/waylandrecord/avinputstream.cpp
+++ b/src/waylandrecord/avinputstream.cpp
@@ -84,18 +84,18 @@ bool CAVInputStream::openMicStream()
     m_pAudioInputFormat = avlibInterface::m_av_find_input_format("pulse"); //alsa
     assert(m_pAudioInputFormat != nullptr);
     if (m_pAudioInputFormat == nullptr) {
-        printf("did not find this audio input devices\n");
+        qWarning() << "did not find this audio input devices\n";
     }
     if (m_bMicAudio) {
         //Set own audio device's name
         if (avlibInterface::m_avformat_open_input(&m_pMicAudioFormatContext, m_micDeviceName.toLatin1(), m_pAudioInputFormat, &device_param) != 0) {
-            printf("Couldn't open input audio stream.（无法打开输入流）\n");
+            qWarning() << "Couldn't open input audio stream.（无法打开输入流）\n";
             return false;
         }
         qInfo() << "mic device's name is:" << m_micDeviceName;
         //input audio initialize
         if (avlibInterface::m_avformat_find_stream_info(m_pMicAudioFormatContext, nullptr) < 0) {
-            printf("Couldn't find audio stream information.（无法获取流信息）\n");
+            qWarning() << "Couldn't find audio stream information.（无法获取流信息）\n";
             return false;
         }
         m_micAudioindex = -1;
@@ -106,11 +106,11 @@ bool CAVInputStream::openMicStream()
             }
         }
         if (m_micAudioindex == -1) {
-            printf("Couldn't find a audio stream.（没有找到音频流）\n");
+            qWarning() << "Couldn't find a audio stream.（没有找到音频流）\n";
             return false;
         }
         if (avlibInterface::m_avcodec_open2(m_pMicAudioFormatContext->streams[m_micAudioindex]->codec, avlibInterface::m_avcodec_find_decoder(m_pMicAudioFormatContext->streams[m_micAudioindex]->codec->codec_id), nullptr) < 0) {
-            printf("Could not open audio codec.（无法打开解码器）\n");
+            qWarning() << "Could not open audio codec.（无法打开解码器）\n";
             return false;
         }
         /* print Video device information*/
@@ -136,7 +136,8 @@ bool CAVInputStream::openSysStream()
         }
         qInfo() << "sys device's name is:" << m_sysDeviceName;
         if (avlibInterface::m_avformat_find_stream_info(m_pSysAudioFormatContext, nullptr) < 0) {
-            printf("Couldn't find audio stream information.（无法获取流信息）\n");
+            qWarning() << "Couldn't find audio stream information.（无法获取流信息";
+//            printf("Couldn't find audio stream information.（无法获取流信息）\n");
             return false;
         }
         fflush(stdout);
@@ -148,12 +149,12 @@ bool CAVInputStream::openSysStream()
             }
         }
         if (m_sysAudioindex == -1) {
-            printf("Couldn't find a audio stream.（没有找到音频流）\n");
+            qWarning() << "Couldn't find a audio stream.（没有找到音频流）\n";
             return false;
         }
         ///Caution, m_pAudFmtCtx->streams[m_audioindex]->codec->codec_id =14, AV_CODEC_ID_RAWVIDEO
         if (avlibInterface::m_avcodec_open2(m_pSysAudioFormatContext->streams[m_sysAudioindex]->codec, avlibInterface::m_avcodec_find_decoder(m_pSysAudioFormatContext->streams[m_sysAudioindex]->codec->codec_id), nullptr) < 0) {
-            printf("Could not open audio codec.（无法打开解码器）\n");
+            qWarning() << "Could not open audio codec.（无法打开解码器）\n";
             return false;
         }
         /* print Video device information*/


### PR DESCRIPTION
Description:  由于klv上出现一个虚拟声卡，该虚拟声卡未适配导致ffmpeg无法获取声卡数据而卡死

Log:  优化录屏时获取真实声卡的方式

Bug: https://pms.uniontech.com/bug-view-140811.html