### PR TITLE
fix: 添加gstreamer1.0-plugins-bad库的弱依赖

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,8 +12,8 @@ Homepage: https://github.com/linuxdeepin/deepin-screen-recorder
 
 Package: deepin-screen-recorder
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libgstreamer1.0-0 (>= 1.0.0), gstreamer1.0-plugins-bad
-Recommends: dde-session-ui,deepin-ocr
+Depends: ${shlibs:Depends}, ${misc:Depends}, libgstreamer1.0-0 (>= 1.0.0)
+Recommends: dde-session-ui,deepin-ocr, gstreamer1.0-plugins-bad
 Conflicts: deepin-screenshot
 Replaces: deepin-screenshot
 Description: Simple recorder tools for UOS


### PR DESCRIPTION
Description: 由于QCamera中会使用该库

Log: 添加gstreamer1.0-plugins-bad库的强依赖

Bug: https://pms.uniontech.com/bug-view-142517.html