### PR TITLE
fix: 优化截图录屏任务栏插件的默认显示位置

### DIFF
--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -99,6 +99,18 @@ QWidget *ShotStartPlugin::itemTipsWidget(const QString &itemKey)
     return m_tipsWidget.data();
 }
 
+int ShotStartPlugin::itemSortKey(const QString &itemKey)
+{
+    const QString key = QString("pos_%1_%2").arg(itemKey).arg(Dock::Efficient);
+    return m_proxyInter->getValue(this, key, 1).toInt();
+}
+
+void ShotStartPlugin::setSortKey(const QString &itemKey, const int order)
+{
+    const QString key = QString("pos_%1_%2").arg(itemKey).arg(Dock::Efficient);
+    m_proxyInter->saveValue(this, key, order);
+}
+
 const QString ShotStartPlugin::itemCommand(const QString &itemKey)
 {
     if (itemKey != ShotShartPlugin) return QString();

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.h
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.h
@@ -68,6 +68,9 @@ public:
     QWidget *itemWidget(const QString &itemKey) override;
     QWidget *itemTipsWidget(const QString &itemKey) override;
 
+    int itemSortKey(const QString &itemKey) override;
+    void setSortKey(const QString &itemKey, const int order) override;
+
     // 鼠标单击执行命令
     const QString itemCommand(const QString &itemKey) override;
 


### PR DESCRIPTION
Description: 之前位指定截图录屏的默认位置，导致位置可能不确定

Log: 优化截图录屏任务栏插件的默认显示位置

Bug: https://pms.uniontech.com/bug-view-130339.html