### PR TITLE
fix: 修复失败的单元测试用例

### DIFF
--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget.cpp
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget.cpp
@@ -62,14 +62,14 @@ TEST_F(TestTimeWidget, stop)
 
 TEST_F(TestTimeWidget, sizeHint)
 {
-    qDebug() << m_timeWidget->sizeHint();
+    qDebug() << "sizeHint >>>>> " << m_timeWidget->sizeHint();
     EXPECT_LT(0, m_timeWidget->sizeHint().width());
-    EXPECT_EQ(22, m_timeWidget->sizeHint().height());
+    EXPECT_EQ(23, m_timeWidget->sizeHint().height());
 }
 
 TEST_F(TestTimeWidget, sizeHint1)
 {
-    qDebug() << m_timeWidget->sizeHint();
+    qDebug() << "sizeHint1 >>>>> " << m_timeWidget->sizeHint();
     access_private_field::TimeWidgetm_position(*m_timeWidget) = 1;
     EXPECT_LT(0, m_timeWidget->sizeHint().width());
     EXPECT_EQ(22, m_timeWidget->sizeHint().height());


### PR DESCRIPTION
Description: 由于修改源码后未修改单元测试中对应的比较值

Log: 修复失败的单元测试用例

Bug: https://pms.uniontech.com/bug-view-144065.html