### PR TITLE
fix: 添加超时机制，确保全局事件监听线程正常退出

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -41,6 +41,7 @@
 extern "C" {
 #endif
 #include "load_libs.h"
+#include "main_window.h"
 #ifdef __cplusplus
 }
 #endif
@@ -1414,6 +1415,12 @@ void MainWindow::showPreviewWidgetImage(QImage img)
     m_scrollShotSizeTips ->updateTips(QPoint(recordX, recordY), QSize(int(img.width() / m_pixelRatio + 2), int(img.height() / m_pixelRatio + 2)));
     m_previewWidget->updateImage(img);
 #endif
+}
+
+void MainWindow::onExitScreenCapture()
+{
+    qInfo() << __FUNCTION__ << __LINE__ << "已超时(3s) 强制退出截图录屏...";
+    _Exit(0);
 }
 
 void MainWindow::initLaunchMode(const QString &launchMode)
@@ -4677,18 +4684,19 @@ void MainWindow::exitScreenCuptureEvent()
 {
     qDebug() << "line: " << __LINE__ << " >>> function: " << __func__;
 #if !(defined (__mips__) || defined (__loongarch_64__) || defined (__loongarch__))
-    qInfo() << __FUNCTION__ << __LINE__ << "正在退出截图录屏全局事件监听线程...";
+//    qInfo() << __FUNCTION__ << __LINE__ << "正在退出截图录屏全局事件监听线程...";
     if (!m_isZhaoxin && m_pScreenCaptureEvent) {
-        qInfo() << __FUNCTION__ << __LINE__ << "正在释放截图录屏全局事件X11相关资源...";
-        m_pScreenCaptureEvent->releaseRes();
-        //m_pScreenCaptureEvent->terminate();
-        qInfo() << __FUNCTION__ << __LINE__ << "全局事件监听线程正在等待释放x11相关资源...";
-        m_pScreenCaptureEvent->wait();
-        qInfo() << __FUNCTION__ << __LINE__ << "已释放X11相关资源";
-        delete m_pScreenCaptureEvent;
-        m_pScreenCaptureEvent = nullptr;
+//            qInfo() << __FUNCTION__ << __LINE__ << "正在释放截图录屏全局事件X11相关资源...";
+//            m_pScreenCaptureEvent->releaseRes();
+//            //m_pScreenCaptureEvent->terminate();
+//            qInfo() << __FUNCTION__ << __LINE__ << "全局事件监听线程正在等待释放x11相关资源...";
+//            m_pScreenCaptureEvent->wait();
+//            qInfo() << __FUNCTION__ << __LINE__ << "已释放X11相关资源";
+//            delete m_pScreenCaptureEvent;
+//            m_pScreenCaptureEvent = nullptr;
+
     }
-    qInfo() << __FUNCTION__ << __LINE__ << "截图录屏全局事件监听线程已退出！";
+//    qInfo() << __FUNCTION__ << __LINE__ << "截图录屏全局事件监听线程已退出！";
 #endif
 }
 

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -160,13 +160,6 @@ public:
             delete m_devnumMonitor;
             m_devnumMonitor = nullptr;
         }
-        if (m_pScreenCaptureEvent) {
-            m_pScreenCaptureEvent->releaseRes();
-            //m_pScreenCaptureEvent->terminate();
-            m_pScreenCaptureEvent->wait();
-            delete m_pScreenCaptureEvent;
-            m_pScreenCaptureEvent = nullptr;
-        }
 #ifdef KF5_WAYLAND_FLAGE_ON
         if (Utils::isWaylandMode && m_connectionThread) {
 
@@ -249,7 +242,26 @@ public:
             delete m_keyButtonList.at(i);
         }
         m_keyButtonList.clear();
-
+        if (m_pScreenCaptureEvent) {
+            qInfo() << __FUNCTION__ << __LINE__ << "正在退出截图录屏全局事件监听线程...";
+            QTimer *delayTimer = new QTimer();
+            connect(delayTimer, &QTimer::timeout, this, &MainWindow::onExitScreenCapture);
+            qInfo() << __FUNCTION__ << __LINE__ << "启动3s超时监听";
+            delayTimer->start(3000);
+            qInfo() << __FUNCTION__ << __LINE__ << "正在释放截图录屏全局事件X11相关资源...";
+            m_pScreenCaptureEvent->releaseRes();
+            //m_pScreenCaptureEvent->terminate();
+            qInfo() << __FUNCTION__ << __LINE__ << "全局事件监听线程正在等待释放x11相关资源...";
+            m_pScreenCaptureEvent->wait();
+            qInfo() << __FUNCTION__ << __LINE__ << "已释放X11相关资源";
+            delete m_pScreenCaptureEvent;
+            m_pScreenCaptureEvent = nullptr;
+            qInfo() << __FUNCTION__ << __LINE__ << "截图录屏全局事件监听线程已退出！";
+            if (delayTimer) {
+                delayTimer->stop();
+                delete delayTimer;
+            }
+        }
         //以前的流程没执行到此处，没暴露延迟500ms的问题，以前的无用代码
         QThread::currentThread()->msleep(500);
     }
@@ -546,6 +558,11 @@ public slots:
      */
     void exitScreenCuptureEvent();
     void showPreviewWidgetImage(QImage img);//显示预览窗口和图片
+
+    /**
+     * @brief 有些时候退出全局事件监听线程会卡住，此时强退截图录屏
+     */
+    void onExitScreenCapture();
 protected:
     bool eventFilter(QObject *object, QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;


### PR DESCRIPTION
Description: 由于X11底层函数无法正常执行，导致截图录屏卡住，无法正常释放

Log: 添加超时机制，确保全局事件监听线程正常退出