### PR TITLE
fix: (wayland) 优化剪贴板保存机制，加了一个1s超时机制

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1728,11 +1728,18 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
         QClipboard *cb = qApp->clipboard();
         qInfo() << __FUNCTION__ << __LINE__ << "将数据传递到剪贴板！";
         cb->setMimeData(t_imageData, QClipboard::Clipboard);
+        //添加超时机制，1s后退出事件循环
+        QTimer* tempTimer = new QTimer();
+        tempTimer->setSingleShot(true);
         if (Utils::isWaylandMode) {
             QEventLoop eventloop;
             connect(cb, SIGNAL(dataChanged()), &eventloop, SLOT(quit()));
+            connect(tempTimer, SIGNAL(timeout()), &eventloop, SLOT(quit()));
+            tempTimer->start(1000);
             eventloop.exec();
         }
+        tempTimer->stop();
+        delete tempTimer;
     }
     qInfo() << __FUNCTION__ << __LINE__ << "已保存到剪贴板！";
 }


### PR DESCRIPTION
Description:  由于在滚动截图模式中锁屏，保存到剪贴板被卡住，导致解锁后截图录屏程序没有退出，因此无法启动滚动截图

Log:  优化剪贴板保存机制，加了一个1s超时机制

Bug: https://pms.uniontech.com/bug-view-146103.html