### PR TITLE
fix: 修复在通知设置中关闭截图录屏,贴图功能仍然有通知的提示信息

### DIFF
--- a/src/pin_screenshots/mainwindow.cpp
+++ b/src/pin_screenshots/mainwindow.cpp
@@ -652,7 +652,7 @@ void MainWindow::sendNotify(QString savePath, bool bSaveState)
     int timeout = -1;
     unsigned int id = 0;
     QList<QVariant> arg;
-    arg << tr("Pin Screenshots")                 // appname
+    arg << (QCoreApplication::applicationName()) //tr("Pin Screenshots")                 // appname
         << id                                                    // id
         << QString("deepin-screen-recorder")                     // icon
         << tr("Screenshot finished")                              // summary


### PR DESCRIPTION
Description:  由于贴图传递给通知的参数与截图录屏不一致

Log:  修复在通知设置中关闭截图录屏,贴图功能仍然有通知的提示信息

Bug: https://pms.uniontech.com/bug-view-139389.html