### PR TITLE
fix: don't hardcode /usr/bin path

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2809,7 +2809,7 @@ void MainWindow::sendNotify(SaveAction saveAction, QString saveFilePath, const b
         QString command, savepathcommand;
 
         tips = QString(tr("Saved to %1")).arg(saveFilePath);
-        if (QFile("/usr/bin/dde-file-manager").exists()) {
+        if (!QStandardPaths::findExecutable("dde-file-manager").isEmpty()) {
             savepathcommand = QString("dde-file-manager,--show-item,%1").arg(saveFilePath);
         }
         command = QString("xdg-open,%1").arg(saveFilePath);


### PR DESCRIPTION
避免硬编码查找路径，提高可移植性。

另外，对于在文件管理器中显示指定文件的需求，也应当考虑使用 DTK 中提供的 `DFileServices::showFileItem()`。

是解决 https://github.com/linuxdeepin/developer-center/issues/3374 问题的一部分。