### PR TITLE
fix: 修复录制视频打开摄像头后，影院窗口全屏会遮挡摄像头画面

### DIFF
--- a/3rdparty/libcam/libcam_v4l2core/v4l2_controls.c
+++ b/3rdparty/libcam/libcam_v4l2core/v4l2_controls.c
@@ -93,7 +93,7 @@ extern int verbosity;
 #define CSTR_PAN_RESET		N_("Pan, Reset")
 #define CSTR_TILT_RESET		N_("Tilt, Reset")
 #define CSTR_PAN_ABS		N_("Pan, Absolute")
-#define CSTR_TILT_ABS		N_"Tilt, Absolute")
+#define CSTR_TILT_ABS		N_("Tilt, Absolute")
 #define CSTR_FOCUS_ABS		N_("Focus, Absolute")
 #define CSTR_FOCUS_REL		N_("Focus, Relative")
 #define CSTR_FOCUS_AUTO		N_("Focus, Automatic")

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -203,6 +203,9 @@ void MainWindow::initAttributes()
     //Qt::X11BypassWindowManagerHint : 完全绕过窗口管理器。
     if (Utils::isWaylandMode) {
         setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+        if (this->windowHandle()) {
+            this->windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
+        }
         //取消onScreenDisplay，解决wayland截长图无法滚动的问题
         QDBusInterface sessionManagerIntert("com.deepin.SessionManager",
                                             "/com/deepin/SessionManager",


### PR DESCRIPTION
Description: wayland下截图录屏的窗口层级不在最顶层

Log: 修复录制视频打开摄像头后，影院窗口全屏会遮挡摄像头画面

Bug: https://pms.uniontech.com/bug-view-130443.html