### PR TITLE
fix: 修复外接扩展屏在设置不同分辨率的情况下，使用截图录屏时工具栏无法在屏幕内正常显示的问题

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2032,15 +2032,16 @@ void MainWindow::updateToolBarPos()
     // 多屏情况下，横向，有可能在屏幕外面。
     if (m_isScreenVertical == false && m_screenInfo.size() >= 2) {
         for (int i = 0; i < m_screenInfo.size(); ++i) {
+            //qDebug() << "屏幕: " << m_screenInfo[i].name <<  m_screenInfo[i].x << m_screenInfo[i].y << m_screenInfo[i].width << m_screenInfo[i].height;
             //工具栏是否在屏幕内
             toolIsInScreen = toolbarPoint.x() >= m_screenInfo[i].x &&
                              toolbarPoint.x() < (m_screenInfo[i].x + m_screenInfo[i].width) &&
                              (toolbarPoint.y() - m_screenInfo[i].height) * m_pixelRatio + m_screenInfo[i].height >= m_screenInfo[i].y &&
                              (toolbarPoint.y() - m_screenInfo[i].height) * m_pixelRatio + m_screenInfo[i].height < (m_screenInfo[i].y + m_screenInfo[i].height);
-            bool recordIsInScreen =  recordX >= m_screenInfo[i].x &&
-                                     recordX < (m_screenInfo[i].x + m_screenInfo[i].width) &&
-                                     recordY >= m_screenInfo[i].y &&
-                                     recordY < (m_screenInfo[i].y + m_screenInfo[i].height);
+            bool recordIsInScreen =  recordX * m_pixelRatio >= m_screenInfo[i].x &&
+                                     recordX * m_pixelRatio < (m_screenInfo[i].x + m_screenInfo[i].width) &&
+                                     recordY * m_pixelRatio >= m_screenInfo[i].y &&
+                                     recordY * m_pixelRatio < (m_screenInfo[i].y + m_screenInfo[i].height);
             //取出捕捉区域所在的屏幕
             if (recordIsInScreen) {
                 tempScreen.setX(m_screenInfo[i].x);

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -942,6 +942,9 @@ private:
      */
     bool m_isShapesWidgetExist = false;
     bool m_isSideBarInside = false;
+    /**
+     * @brief m_isToolBarInside 工具栏在捕捉区域内部
+     */
     bool m_isToolBarInside = false;
 
 


### PR DESCRIPTION
Description: 修复外接扩展屏在设置不同分辨率的情况下，使用截图录屏时工具栏无法在屏幕内正常显示的问题

Log: 修复外接扩展屏在设置不同分辨率的情况下，使用截图录屏时工具栏无法在屏幕内正常显示的问题

Bug: https://pms.uniontech.com/bug-view-162523.html