### PR TITLE
fix: 修复使用截图工具：圆形、箭头等框出重要关键字，保存图片后所画的图形，箭头等形状停留在桌面上2s后消失

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -5089,44 +5089,44 @@ void MainWindow::shotCurrentImg()
     //m_drawNothing = true;
     update();
     //当存在编辑模式且编辑的内容有文本时，需要再截图一次
-    if (m_shapesWidget && m_shapesWidget->isExistsText()) {
-        int eventTime = 60;
-        QRect rect = QApplication::desktop()->screenGeometry();
-        if (rect.width()*rect.height() > 1920 * 1080) {
-            if (QSysInfo::currentCpuArchitecture().startsWith("x86") && m_isZhaoxin) {
-                eventTime = 120;
-            } else if (QSysInfo::currentCpuArchitecture().startsWith("mips")) {
-                eventTime = 260;
-            } else if (QSysInfo::currentCpuArchitecture().startsWith("arm")) {
-                eventTime = 220;
-            }
-        } else {
-            if (QSysInfo::currentCpuArchitecture().startsWith("mips")) {
-                eventTime = 160;
-            } else if (QSysInfo::currentCpuArchitecture().startsWith("arm")) {
-                eventTime = 120;
-            }
-        }
-        QEventLoop eventloop1;
-        QTimer::singleShot(eventTime, &eventloop1, SLOT(quit()));
-        eventloop1.exec();
+//    if (m_shapesWidget && m_shapesWidget->isExistsText()) {
+//        int eventTime = 0;
+//        QRect rect = QApplication::desktop()->screenGeometry();
+//        if (rect.width()*rect.height() > 1920 * 1080) {
+//            if (QSysInfo::currentCpuArchitecture().startsWith("x86") && m_isZhaoxin) {
+//                eventTime = 120;
+//            } else if (QSysInfo::currentCpuArchitecture().startsWith("mips")) {
+//                eventTime = 260;
+//            } else if (QSysInfo::currentCpuArchitecture().startsWith("arm")) {
+//                eventTime = 220;
+//            }
+//        } else {
+//            if (QSysInfo::currentCpuArchitecture().startsWith("mips")) {
+//                eventTime = 160;
+//            } else if (QSysInfo::currentCpuArchitecture().startsWith("arm")) {
+//                eventTime = 120;
+//            }
+//        }
+//        QEventLoop eventloop1;
+//        QTimer::singleShot(eventTime, &eventloop1, SLOT(quit()));
+//        eventloop1.exec();
 
-        if (m_isShapesWidgetExist) {
-            qInfo() << __FUNCTION__ << __LINE__ << "隐藏截图编辑界面！";
-            m_shapesWidget->hide();
-        }
-        m_sizeTips->hide();
-        shotFullScreen();
-        //qDebug() << recordX << "," << recordY << "," << recordWidth << "," << recordHeight << m_resultPixmap.rect() << m_pixelRatio;
-        QRect target(static_cast<int>(recordX * m_pixelRatio),
-                     static_cast<int>(recordY * m_pixelRatio),
-                     static_cast<int>(recordWidth * m_pixelRatio),
-                     static_cast<int>(recordHeight * m_pixelRatio));
+//        if (m_isShapesWidgetExist) {
+//            qInfo() << __FUNCTION__ << __LINE__ << "隐藏截图编辑界面！";
+//            m_shapesWidget->hide();
+//        }
+//        m_sizeTips->hide();
+//        shotFullScreen();
+//        //qDebug() << recordX << "," << recordY << "," << recordWidth << "," << recordHeight << m_resultPixmap.rect() << m_pixelRatio;
+//        QRect target(static_cast<int>(recordX * m_pixelRatio),
+//                     static_cast<int>(recordY * m_pixelRatio),
+//                     static_cast<int>(recordWidth * m_pixelRatio),
+//                     static_cast<int>(recordHeight * m_pixelRatio));
 
-        m_resultPixmap = m_resultPixmap.copy(target);
-    } else {
-        m_resultPixmap =  paintImage();
-    }
+//        m_resultPixmap = m_resultPixmap.copy(target);
+//    } else {
+    m_resultPixmap =  paintImage();
+//    }
     addCursorToImage();
     qInfo() << __FUNCTION__ << __LINE__ << "已截取当前图片！";
 }

--- a/src/utils/shapesutils.h
+++ b/src/utils/shapesutils.h
@@ -30,6 +30,8 @@ public:
     QList<QPointF> points;
     QList<QList<qreal>> portion;
     QPointF arrowRotatePos;
+
+    QString text; //当图形形状是文字时，此属性才会有值
     Toolshape();
     //~Toolshape();
 

--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -229,7 +229,7 @@ void ShapesWidget::saveActionTriggered()
     setAllTextEditReadOnly();
     clearSelected();
     m_clearAllTextBorder = true;
-    qInfo() << __FUNCTION__ << __LINE__ << "已清楚图形编辑界面";
+    qInfo() << __FUNCTION__ << __LINE__ << "已清除图形编辑界面";
 }
 
 //点击某个形状
@@ -1671,7 +1671,7 @@ void ShapesWidget::mouseMoveEvent(QMouseEvent *e)
     DFrame::mouseMoveEvent(e);
 }
 
-void ShapesWidget::updateTextRect(TextEdit *edit, QRectF newRect)
+void ShapesWidget::updateTextRect(TextEdit *edit, QRectF newRect, QString text, int fontsize)
 {
     int index = edit->getIndex();
     //qDebug() << "updateTextRect:" << newRect << index;
@@ -1683,6 +1683,8 @@ void ShapesWidget::updateTextRect(TextEdit *edit, QRectF newRect)
             m_shapes[j].mainPoints[2] = QPointF(newRect.x() + newRect.width(), newRect.y());
             m_shapes[j].mainPoints[3] = QPointF(newRect.x() + newRect.width(),
                                                 newRect.y() + newRect.height());
+            m_shapes[j].text = text;
+            m_shapes[j].fontSize = fontsize;
             m_currentShape = m_shapes[j];
             m_selectedShape = m_shapes[j];
             m_selectedIndex = m_shapes[j].index;
@@ -1844,7 +1846,18 @@ void ShapesWidget::paintText(QPainter &painter, FourPoints rectFPoints)
         painter.drawLine(rectFPoints[2], rectFPoints[0]);
     }
 }
-
+void ShapesWidget::paintText(QPainter &painter, FourPoints rectFPoints, QString text, int fontsize)
+{
+    qDebug() << "fontsize: " << fontsize;
+    QFont font = painter.font() ;
+    font.setPixelSize(fontsize);
+    painter.setFont(font);
+    QRect rect(static_cast<int>(rectFPoints[0].x()),
+               static_cast<int>(rectFPoints[0].y()),
+               static_cast<int>(rectFPoints[3].x() - rectFPoints[0].x()),
+               static_cast<int>(rectFPoints[3].y() - rectFPoints[0].y()));
+    painter.drawText(rect, Qt::AlignCenter, text);
+}
 void ShapesWidget::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
@@ -2122,8 +2135,10 @@ void ShapesWidget::setGlobalRect(QRect rect)
 //将编辑的内容绘制到图片上
 void ShapesWidget::paintImage(QImage &image)
 {
+    qInfo() << __FUNCTION__ << __LINE__ << "正在往图片中绘制图形...";
     QPainter painter(&image);
     handlePaint(painter);
+    qInfo() << __FUNCTION__ << __LINE__ << "图片图形已绘制";
     //    backgroundImage.save("/home/uos/Desktop/temp1.png");
 }
 
@@ -2189,6 +2204,9 @@ void ShapesWidget::handlePaint(QPainter &painter)
                 }
                 ++m;
             }
+        } else if (m_shapes[i].type == "text" && m_clearAllTextBorder) {
+            painter.setPen(pen);
+            paintText(painter, m_shapes[i].mainPoints, m_shapes[i].text, m_shapes[i].fontSize);
         }
     }
 

--- a/src/widgets/shapeswidget.h
+++ b/src/widgets/shapeswidget.h
@@ -266,7 +266,7 @@ private:
     Toolshape m_hoveredShape;
 
     QMap<int, TextEdit *> m_editMap;
-    void updateTextRect(TextEdit *edit, QRectF newRect);
+    void updateTextRect(TextEdit *edit, QRectF newRect, QString text, int fontsize);
     Toolshapes m_shapes;
     MenuController *m_menuController;
     //SideBar *m_sideBar;
@@ -283,5 +283,13 @@ private:
                     int lineWidth, bool isStraight = false);
     void paintLine(QPainter &painter, QList<QPointF> lineFPoints);
     void paintText(QPainter &painter, FourPoints rectFPoints);
+    /**
+     * @brief paintText 绘制文字工具的具体文字内容
+     * @param painter
+     * @param rectFPoints
+     * @param text
+     * @param fontsize
+     */
+    void paintText(QPainter &painter, FourPoints rectFPoints, QString text, int fontsize);
 };
 #endif // SHAPESWIDGET_H

--- a/src/widgets/textedit.cpp
+++ b/src/widgets/textedit.cpp
@@ -107,10 +107,10 @@ void TextEdit::updateContentSize(QString content)
 {
     QFontMetricsF fontMetric = QFontMetricsF(this->document()->defaultFont());
     QSizeF docSize =  fontMetric.size(0,  content);
-    this->setMinimumSize(static_cast<int>(docSize.width() + TEXT_MARGIN), static_cast<int>(docSize.height() + TEXT_MARGIN));
-    this->resize(static_cast<int>(docSize.width() + TEXT_MARGIN), static_cast<int>(docSize.height() + TEXT_MARGIN));
-    emit  repaintTextRect(this,  QRectF(this->x(), this->y(),
-                                        docSize.width() + TEXT_MARGIN, docSize.height() + TEXT_MARGIN));
+    QRectF rectf(this->x(), this->y(), docSize.width() + TEXT_MARGIN, docSize.height() + TEXT_MARGIN);
+    this->setMinimumSize(static_cast<int>(rectf.width()), static_cast<int>(rectf.height()));
+    this->resize(static_cast<int>(rectf.width()), static_cast<int>(rectf.height()));
+    emit  repaintTextRect(this, rectf, this->toPlainText(), this->document()->defaultFont().pixelSize());
 }
 
 void TextEdit::setEditing(bool edit)
@@ -188,8 +188,10 @@ void TextEdit::mouseMoveEvent(QMouseEvent *e)
         this->move(static_cast<int>(this->x() + movePos.x() - m_pressPoint.x()),
                    static_cast<int>(this->y() + movePos.y() - m_pressPoint.y()));
 
-        emit  repaintTextRect(this,  QRectF(qreal(this->x()), qreal(this->y()),
-                                            this->width(),  this->height()));
+        emit  repaintTextRect(this,
+                              QRectF(qreal(this->x()), qreal(this->y()), this->width(),  this->height()),
+                              this->toPlainText(),
+                              this->document()->defaultFont().pixelSize());
         m_pressPoint = movePos;
     }
 

--- a/src/widgets/textedit.h
+++ b/src/widgets/textedit.h
@@ -33,7 +33,7 @@ public slots:
     void setSelecting(bool select);
 
 signals:
-    void repaintTextRect(TextEdit *edit,  QRectF newPositiRect);
+    void repaintTextRect(TextEdit *edit,  QRectF newPositiRect, QString text, int fontsize);
     void backToEditing();
     void clickToEditing(int index);
     void textEditSelected(int index);


### PR DESCRIPTION
Description: 修复使用截图工具：圆形、箭头等框出重要关键字，保存图片后所画的图形，箭头等形状停留在桌面上2s后消失

Log: 修复使用截图工具：圆形、箭头等框出重要关键字，保存图片后所画的图形，箭头等形状停留在桌面上2s后消失

Bug: https://pms.uniontech.com/bug-view-170101.html