### PR TITLE
fix: (UI) 修复截图&录屏的完成按钮圆角不对

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper, pkg-config, qt5-qmake,
  libxcb-util0-dev, libqt5x11extras5-dev, qttools5-dev-tools,
- libdtkgui-dev,libdtkwidget-dev, libxtst-dev, libprocps-dev,
+ libdtkgui-dev,libdtkwidget-dev, libxtst-dev, 
  libdframeworkdbus-dev,libxcursor-dev,libxfixes-dev,libqt5multimediawidgets5,
  qtmultimedia5-dev,dde-dock-dev,qtbase5-dev-tools,
  libopencv-core-dev,libopencv-imgproc-dev,libopencv-calib3d-dev,libopencv-dev,
@@ -12,7 +12,7 @@ Build-Depends: debhelper, pkg-config, qt5-qmake,
  libxss1,qtbase5-dev,
  libkf5windowsystem-dev,libkf5wayland-dev,libkf5i18n-dev,
  libgbm-dev,libepoxy-dev,
- libavcodec-dev,libavdevice-dev,libavfilter-dev,libavformat-dev,libavutil-dev,libswscale-dev,libavresample-dev,
+ libavcodec-dev,libavdevice-dev,libavfilter-dev,libavformat-dev,libavutil-dev,libswscale-dev,
  libkf5config-dev,libxrandr-dev,libxinerama-dev,libepoxy-dev,deepin-desktop-base,
  libgstreamer1.0-dev,libgstreamer-plugins-base1.0-dev,gstreamer1.0-plugins-good,
  libusb-1.0-0-dev,libimageeditor-dev,libudev-dev,libffmpegthumbnailer-dev,portaudio19-dev,libv4l-dev

--- a/src/widgets/toolbar.cpp
+++ b/src/widgets/toolbar.cpp
@@ -323,6 +323,7 @@ void ToolBar::currentFunctionMode(QString shapeType)
         pa.setColor(DPalette::Dark, QColor(0, 129, 255, 204));
         pa.setColor(DPalette::Light, QColor(0, 129, 255, 204));
         m_confirmButton->setPalette(pa);
+        m_confirmButton->setStyleSheet("border-radius:18px;padding:2px 4px;background-color: rgba(0, 129, 255,204);");
         m_confirmButton->setIcon(QIcon(":/newUI/checked/screenshot-checked.svg"));
         Utils::setAccessibility(m_confirmButton, AC_MAINWINDOW_MAINSHOTBTN);
         m_confirmButton->setProperty("isShotState", true);
@@ -332,6 +333,7 @@ void ToolBar::currentFunctionMode(QString shapeType)
         pa.setColor(DPalette::ButtonText, QColor(28, 28, 28, 255));
         pa.setColor(DPalette::Dark, QColor(229, 70, 61, 204));
         pa.setColor(DPalette::Light, QColor(229, 70, 61, 204));
+        m_confirmButton->setStyleSheet("border-radius:18px;padding:2px 4px;background-color: rgba(229, 70, 61, 204);");
         m_confirmButton->setPalette(pa);
         m_confirmButton->setIcon(QIcon(":/newUI/checked/screencap-checked.svg"));
         Utils::setAccessibility(m_confirmButton, AC_MAINWINDOW_MAINRECORDBTN);
@@ -358,6 +360,7 @@ void ToolBar::initToolBar(MainWindow *pmainWindow)
     m_confirmButton->setFocusPolicy(Qt::NoFocus);
     m_confirmButton->setIconSize(QSize(38, 38));
     m_confirmButton->setFixedSize(76, 58);
+    m_confirmButton->setStyleSheet("border-radius:18px;padding:2px 4px;background-color: rgba(0, 129, 255,204);");
 
     DPalette pa;
     pa = m_confirmButton->palette();


### PR DESCRIPTION
Description: (UI) 修复截图&录屏的完成按钮圆角不对,去除了两个未使用的依赖

Log: (UI) 修复截图&录屏的完成按钮圆角不对

Bug: https://pms.uniontech.com/bug-view-156653.html