### PR TITLE
fix: 修复录屏时同时存在显示按键和摄像头时，按键盘会使摄像头闪烁

### DIFF
--- a/src/camera/majorimageprocessingthread.cpp
+++ b/src/camera/majorimageprocessingthread.cpp
@@ -77,8 +77,8 @@ void MajorImageProcessingThread::run()
         uint yuvsize = 0;
         unsigned int nVdWidth = static_cast<unsigned int>(m_frame->width);
         unsigned int nVdHeight = static_cast<unsigned int>(m_frame->height);
-        uint8_t  * rgbPtr = nullptr;
-        uint8_t  * yuvPtr = nullptr;
+        uint8_t   *rgbPtr = nullptr;
+        uint8_t   *yuvPtr = nullptr;
         QImage tempImg;
 
         // wayland环境下，解码后的帧数据为yu12格式
@@ -89,14 +89,16 @@ void MajorImageProcessingThread::run()
         rgbsize = nVdWidth * nVdHeight * 3;
         rgbPtr = static_cast<uint8_t *>(calloc(rgbsize, sizeof(uint8_t)));
         // yu12到rgb数据高性能转换
-        yu12_to_rgb24_higheffic(rgbPtr,yuvPtr, m_frame->width, m_frame->height);
+        yu12_to_rgb24_higheffic(rgbPtr, yuvPtr, m_frame->width, m_frame->height);
 
         tempImg = QImage(rgbPtr, m_frame->width, m_frame->height, QImage::Format_RGB888);
         if (tempImg.isNull()) {
             qWarning() << "(wayland) 未采集到摄像头画面！" ;
         } else {
-            //tempImg.save(QString("/home/uos/Desktop/test/test_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
-            emit SendMajorImageProcessing(tempImg);
+            //tempImg.save(QString("/home/wangcong/Desktop/test/test_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
+            QPixmap pixmap = QPixmap::fromImage(tempImg);
+            emit SendMajorImageProcessing(pixmap);
+            //emit SendMajorImageProcessing(tempImg);
             //qInfo() << "(wayland) 已采集摄像头画面，正在传递摄像头画面";
         }
         if (yuvPtr != nullptr) {

--- a/src/camera/majorimageprocessingthread.h
+++ b/src/camera/majorimageprocessingthread.h
@@ -75,11 +75,15 @@ protected:
 
 signals:
     /**
-     * @brief SendMajorImageProcessing 向预览界面发送帧数据  mips平台、wayland下使用该接口
+     * @brief SendMajorImageProcessing 向预览界面发送帧数据
      * @param image 图像
-     * @param result 结果
      */
     void SendMajorImageProcessing(QImage image);
+    /**
+     * @brief SendMajorImageProcessing
+     * @param pixmap
+     */
+    void SendMajorImageProcessing(QPixmap pixmap);
 
     void isEnd();
 

--- a/src/widgets/camerawidget.cpp
+++ b/src/widgets/camerawidget.cpp
@@ -98,8 +98,10 @@ void CameraWidget::cameraStart()
             m_imgPrcThread = new MajorImageProcessingThread;
             m_imgPrcThread->setParent(this);
             m_imgPrcThread->setObjectName("MajorThread");
-            connect(m_imgPrcThread, SIGNAL(SendMajorImageProcessing(QImage)),
-                    this, SLOT(onReceiveMajorImage(QImage)));
+//            connect(m_imgPrcThread, SIGNAL(SendMajorImageProcessing(QImage)),
+//                    this, SLOT(onReceiveMajorImage(QImage)));
+            connect(m_imgPrcThread, SIGNAL(SendMajorImageProcessing(QPixmap)),
+                    this, SLOT(onReceiveMajorImage(QPixmap)));
         }
         m_isInitCamera = true;
         startCameraV4l2(m_deviceName.toLatin1());
@@ -188,13 +190,21 @@ void CameraWidget::cameraStop()
 void CameraWidget::onReceiveMajorImage(QImage image)
 {
     QImage t_image = image.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio, Qt::FastTransformation);
-    QPixmap pixmap = QPixmap::fromImage(t_image);
-//    pixmap.save(QString("/home/wangcong/Desktop/test/test_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
+    //t_image.save(QString("/home/wangcong/Desktop/test/t_image_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
+    QPixmap pixmap = QPixmap::fromImage(image);
+    //pixmap.save(QString("/home/wangcong/Desktop/test/pixmap_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
     if (m_cameraUI)
         m_cameraUI->setPixmap(pixmap);
     //qInfo() << "接收当前摄像头画面！";
 }
 
+void CameraWidget::onReceiveMajorImage(QPixmap pixmap)
+{
+    pixmap =  pixmap.scaled(this->width(), this->height());
+    if (m_cameraUI)
+        m_cameraUI->setPixmap(pixmap);
+    //qInfo() << "接收当前摄像头画面！";
+}
 void CameraWidget::enterEvent(QEvent *e)
 {
     Q_UNUSED(e);

--- a/src/widgets/camerawidget.h
+++ b/src/widgets/camerawidget.h
@@ -99,6 +99,7 @@ protected:
 
 public slots:
     void onReceiveMajorImage(QImage image);
+    void onReceiveMajorImage(QPixmap pixmap);
 
 private:
     int recordX = 0;


### PR DESCRIPTION
Description: 修复录屏时同时存在显示按键和摄像头时，按键盘会使摄像头闪烁

Log: 修复录屏时同时存在显示按键和摄像头时，按键盘会使摄像头闪烁

Bug: https://pms.uniontech.com/bug-view-172567.html