### PR TITLE
fix: Can not Play Recorded mp4 videos on iPhone

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -225,6 +225,8 @@ void RecordProcess::recordVideo()
         arguments << QString("44100");
         arguments << QString("-i");   // 麦克风音频id，值为固定"default"
         arguments << QString("default");
+        arguments << QString("-ac");
+        arguments << QString("2");
     }
     if (recordAudioInputType == RECORD_AUDIO_INPUT_MIC_SYSTEMAUDIO) {
         arguments << QString("-filter_complex");
@@ -289,6 +291,8 @@ void RecordProcess::recordVideo()
         arguments << QString("44100");
         arguments << QString("-i");
         arguments << QString("default");
+        arguments << QString("-ac");
+        arguments << QString("2");
     }
 
 


### PR DESCRIPTION
根据社区论坛的用户反馈,录制的视频无法在苹果手机播放
https://bbs.deepin.org/post/245693

Log: 修复录制的视频无法在苹果手机播放