### PR TITLE
fix: 修复录屏结束时，同时按下Esc导致应用不能正常退出

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2436,7 +2436,6 @@ void MainWindow::changeFunctionButton(QString type)
 void MainWindow::showKeyBoardButtons(const QString &key)
 {
     //键盘按钮启用状态下创建按键控件
-    qDebug() << this->geometry();
     if (m_keyBoardStatus) {
         if (m_hasComposite == false && RECORD_BUTTON_RECORDING == recordButtonStatus) {
             // 2D 录屏下将按键发送至m_pRecorderRegion区域。
@@ -4362,7 +4361,8 @@ void MainWindow::onKeyboardPress(unsigned char keyCode)
     if (status::record == m_functionType) {
         m_showButtons->showContentButtons(keyCode);
         recordKeyPressEvent(keyCode);
-        if (RECORD_BUTTON_RECORDING != recordButtonStatus && keyCode == KEY_ESCAPE) {
+        if (RECORD_BUTTON_RECORDING != recordButtonStatus && RECORD_BUTTON_SAVEING != recordButtonStatus && keyCode == KEY_ESCAPE) {
+            qDebug() << "录屏模式退出应用" << recordButtonStatus;
             exitApp();
         }
     } else if (status::shot == m_functionType || status::scrollshot == m_functionType) {


### PR DESCRIPTION
Description: 修复录屏结束时，同时按下Esc导致应用不能正常退出

Log: 修复录屏结束时，同时按下Esc导致应用不能正常退出

Bug: https://pms.uniontech.com/bug-view-176727.html