### PR TITLE
fix: 修复当点击设置选项后，鼠标停留在那个选项时，该选项会被选上

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
         DGuiApplicationHelper::instance()->setPaletteType(t_type);
         Utils::themeType = t_type;
 
-        qDebug() << "截图录屏日志路径: " << Dtk::Core::DLogManager::getlogFilePath();
+        //qDebug() << "截图录屏日志路径: " << Dtk::Core::DLogManager::getlogFilePath();
         qDebug() << "截图录屏版本: " << DApplication::buildVersion(APP_VERSION);
 
         if (cmdParser.isSet(useGStreamer)) {

--- a/src/utils/configsettings.cpp
+++ b/src/utils/configsettings.cpp
@@ -32,7 +32,7 @@ ConfigSettings::ConfigSettings(QObject *parent)
     : QObject(parent)
 {
     m_settings = new QSettings("deepin/deepin-screen-recorder", "deepin-screen-recorder");
-    qDebug() << "config file path: " << m_settings->fileName();
+    //qDebug() << "config file path: " << m_settings->fileName();
 }
 
 ConfigSettings *ConfigSettings::m_configSettings = nullptr;

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -1160,10 +1160,16 @@ int SubToolWidget::getFuncSubToolX(QString &shape)
 bool SubToolWidget::eventFilter(QObject *watched, QEvent *event)
 {
     if (watched == m_recordOptionMenu || watched == m_optionMenu || watched == m_scrollOptionMenu) {
-        if (event->type() == QEvent::MouseButtonRelease) {
+        if (event->type() == QEvent::MouseButtonPress) {
             QAction *action = static_cast<DMenu *>(watched)->actionAt(static_cast<QMouseEvent *>(event)->pos());
             if (action) {
                 action->activate(QAction::Trigger);
+                return true;
+            }
+        }
+        if (event->type() == QEvent::MouseButtonRelease) {
+            QAction *action = static_cast<DMenu *>(watched)->actionAt(static_cast<QMouseEvent *>(event)->pos());
+            if (action) {
                 return true;
             }
         }


### PR DESCRIPTION
Description: 由于QAction是在鼠标释放时进行处理，外部拦截

Log: 修复当点击设置选项后，鼠标停留在那个选项时，该选项会被选上

Bug: https://pms.uniontech.com/bug-view-181447.html