### PR TITLE
fix: 修复启用截图录屏，高分屏机器上任务栏图标显示异常

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: debhelper, pkg-config, qt5-qmake,
  libxss1,qtbase5-dev,
  libkf5windowsystem-dev,libkf5wayland-dev,libkf5i18n-dev,
  libgbm-dev,libepoxy-dev,
- libavcodec-dev,libavdevice-dev,libavfilter-dev,libavformat-dev,libavutil-dev,libswscale-dev,libavresample-dev,
+ libavcodec-dev,libavdevice-dev,libavfilter-dev,libavformat-dev,libavutil-dev,libswscale-dev,
  libkf5config-dev,libxrandr-dev,libxinerama-dev,libepoxy-dev,deepin-desktop-base,
  libgstreamer1.0-dev,libgstreamer-plugins-base1.0-dev,gstreamer1.0-plugins-good,
  libusb-1.0-0-dev,libimageeditor-dev,libudev-dev,libffmpegthumbnailer-dev,portaudio19-dev,libv4l-dev

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -166,17 +166,22 @@ void TimeWidget::paintEvent(QPaintEvent *e)
     //判断任务栏在屏幕上的位置,上下左右
     if (position::top == m_position || position::bottom == m_position) {
         m_pixmap = QIcon::fromTheme(QString("recordertime"), *m_currentIcon).pixmap(QSize(RECORDER_TIME_LEVEL_ICON_SIZE, RECORDER_TIME_LEVEL_ICON_SIZE));
-        //m_pixmap.setDevicePixelRatio(ratio);
+        m_pixmap.setDevicePixelRatio(ratio);
         const QRectF &rf = QRectF(rect());
         const QRectF &prf = QRectF(m_pixmap.rect());
         QPointF pf = rf.center() - prf.center();
         //绘制录像小图标
-        painter.drawPixmap(5, static_cast<int>(pf.y() + 1), m_pixmap);
+        qInfo() << "ratio: " << ratio;
+        if (ratio >= 1.5) {
+            painter.drawPixmap(5, static_cast<int>(pf.y() / ratio  + 2 * ratio), m_pixmap);
+        } else {
+            painter.drawPixmap(5, static_cast<int>(pf.y() / ratio  + 1), m_pixmap);
+        }
+        qInfo() << "录屏小图标的坐标：" << 5 << static_cast<int>(pf.y() / ratio + 5 / ratio) ;
         QFont font = RECORDER_TIME_FONT;
         painter.setFont(font);
         QFontMetrics fm(font);
-//        painter.drawText(m_pixmap.width() * static_cast<int>(ratio) + RECORDER_TEXT_TOP_BOTTOM_X + RECORDER_ICON_TOP_BOTTOM_X, rect().y(), rect().width(), rect().height(), Qt::AlignLeft | Qt::AlignVCenter, m_showTimeStr);
-        int tx = static_cast<int>(m_pixmap.width()) + RECORDER_TEXT_TOP_BOTTOM_X;
+        int tx = static_cast<int>(m_pixmap.width() / ratio) + RECORDER_TEXT_TOP_BOTTOM_X;
         int ty = rect().y();
         int twidth = rect().width();
         int theight = rect().height();
@@ -189,7 +194,7 @@ void TimeWidget::paintEvent(QPaintEvent *e)
         qDebug() << "插件区域大小: " << rect() << "图标大小: " << m_pixmap.size();
         const QRectF &rfp = QRectF(m_pixmap.rect());
         qDebug() << "rf.center() - rfp.center() / m_pixmap.devicePixelRatioF()" << rf.center() - rfp.center() / m_pixmap.devicePixelRatioF();
-        //painter.drawPixmap(rf.center() - rfp.center() / m_pixmap.devicePixelRatioF(), m_pixmap);
+//        painter.drawPixmap(rf.center() - rfp.center() / m_pixmap.devicePixelRatioF(), m_pixmap);
         painter.drawPixmap(2, 0, m_pixmap);
     }
     QWidget::paintEvent(e);

--- a/src/dde-dock-plugins/shotstart/iconwidget.cpp
+++ b/src/dde-dock-plugins/shotstart/iconwidget.cpp
@@ -128,6 +128,18 @@ QString IconWidget::getDefaultValue(const QString type)
     return retShortcut;
 }
 
+QPixmap IconWidget::iconPixMap(QIcon icon, QSize size)
+{
+    QPixmap pixmap;
+    const auto ratio = devicePixelRatioF();
+    QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps)? size:(size*ratio);
+    pixmap = icon.pixmap(pixmapSize);
+    pixmap.setDevicePixelRatio(ratio);
+    pixmap = pixmap.scaled(size * ratio);
+
+    return  pixmap;
+}
+
 
 void IconWidget::paintEvent(QPaintEvent *e)
 {

--- a/src/dde-dock-plugins/shotstart/iconwidget.h
+++ b/src/dde-dock-plugins/shotstart/iconwidget.h
@@ -31,6 +31,7 @@ public:
     QString getSysShortcuts(const QString type);
     QString getDefaultValue(const QString type);
 
+    QPixmap iconPixMap(QIcon icon, QSize size);
 protected:
     void paintEvent(QPaintEvent *e) override;
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -66,15 +66,27 @@ void ShotStartPlugin::init(PluginProxyInterface *proxyInter)
 QIcon ShotStartPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
     static QIcon icon(":/res/screen-capture-dark.svg");
+    static QIcon icon_dark(":/res/screen-capture-dark.svg");
     static QIcon shot(":/res/icon-shot.svg");
     static QIcon recorder(":/res/icon-recorder.svg");
     if (DockPart::QuickShow == dockPart) {
-        return icon;
-    } else if(DockPart::QuickPanel == dockPart) {
-        if (m_isRecording) {
-            return recorder;
+        if (themeType ==  DGuiApplicationHelper::ColorType::LightType) {
+            //return m_iconWidget->iconPixMap("screen-capture-dark", QSize(24, 24));
+            return icon_dark;
         } else {
-            return shot;
+            //return m_iconWidget->iconPixMap("screen-capture", QSize(24, 24));
+            return icon;
+        }
+    } else if (DockPart::QuickPanel == dockPart) {
+        qInfo() << "是否正在录屏。。。。。。" << m_isRecording;
+        if (m_isRecording) {
+            qInfo() << "当前正在录屏。。。";
+            return m_iconWidget->iconPixMap(recorder, QSize(24, 24));
+            //return recorder;
+        } else {
+            qInfo() << "当前正在截图。。。";
+            return m_iconWidget->iconPixMap(shot, QSize(24, 24));
+            //return shot;
         }
     }
     return icon;
@@ -150,6 +162,7 @@ void ShotStartPlugin::invokedMenuItem(const QString &itemKey, const QString &men
 bool ShotStartPlugin::onStart()
 {
     m_isRecording = true;
+    qInfo() << "开始录屏。。。。。。" << m_isRecording;
     m_baseTime = QTime::currentTime();
     m_proxyInter->updateDockInfo(this, ::DockPart::QuickPanel);
 }
@@ -157,6 +170,7 @@ bool ShotStartPlugin::onStart()
 void ShotStartPlugin::onStop()
 {
     m_isRecording = false;
+    qInfo() << "结束录屏。。。。。。" << m_isRecording;
     m_proxyInter->updateDockInfo(this, ::DockPart::QuickPanel);
 }
 


### PR DESCRIPTION
Description: 修复启用截图录屏，高分屏机器上任务栏图标显示异常

Log: 修复启用截图录屏，高分屏机器上任务栏图标显示异常

Bug: https://pms.uniontech.com/bug-view-183665.html