### PR TITLE
fix: 屏蔽录屏开始之后的焦点获取

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -5574,6 +5574,10 @@ void MainWindow::startCountdown()
     if (!Utils::isWaylandMode) {
         hide();
         show();
+    } else {
+        qDebug() << "wayland开始录屏之后不获取焦点";
+        setWindowFlag(Qt::WindowDoesNotAcceptFocus);
+        this->show();
     }
     Utils::passInputEvent(static_cast<int>(this->winId()));
 


### PR DESCRIPTION
Description: wayland下录屏开始之后浏览器中无法获取键盘输入，由于onscreendisplay属性导致。

Log: 屏蔽录屏开始之后的焦点获取