### PR TITLE
fix: show application icon in other desktop environments

### DIFF
--- a/deepin-screen-recorder.desktop
+++ b/deepin-screen-recorder.desktop
@@ -12,8 +12,7 @@ Type=Application
 X-Deepin-ManualID=deepin-screen-recorder
 X-Deepin-Vendor=deepin
 X-Deepin-TurboType=dtkwidget
-#OnlyShowIn=DeepinTablet
-OnlyShowIn=Deepin
+NotShowIn=DeepinTablet
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
In 8559f78d85775fca0d7ee38da646f095864377e3 the `OnlyShowIn` entry was added to forbid it from being shown in DeepinTablet. This unfortunately has the side effect that disables the icon from other desktop environments either.

Let's use `NotShowIn` instead to better align with the original goal and fixes the problem.

Fixes https://github.com/orgs/linuxdeepin/discussions/3560

Log: Show application icon in other desktop environments