### PR TITLE
fix: 修复截图后数据未保存到剪切板

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1780,6 +1780,7 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
                 //QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
             }
             qInfo() << __FUNCTION__ << __LINE__ << "3s延时完成" << time(nullptr);
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
         }
     }
     qInfo() << __FUNCTION__ << __LINE__ << "已保存到剪贴板！";


### PR DESCRIPTION
Description: 添加事件循环等待保存到剪切板

Log: 修复截图后数据未保存到剪切板

Bug: https://pms.uniontech.com/bug-view-184637.html