### PR TITLE
fix: 修复当从截图录屏按钮切换至截图按钮时，默认选中了直线按钮

### DIFF
--- a/src/accessibility/acTextDefine.h
+++ b/src/accessibility/acTextDefine.h
@@ -30,6 +30,7 @@
 #define AC_SUBTOOLWIDGET_KEYBOARD_BUTTON "keyboard_button"// 录屏 显示按键按钮
 #define AC_SUBTOOLWIDGET_CAMERA_BUTTON "camera_button"//录屏 摄像头按钮
 #define AC_SUBTOOLWIDGET_MOUSE_BUTTON "mouse_button"//录屏 显示鼠标按钮
+#define AC_SUBTOOLWIDGET_SHOT_BUTTON "shot_button"//录屏 截图按钮
 #define AC_SUBTOOLWIDGET_RECORD_OPTION_BUT "record_option_but" //录屏选项按钮
 
 #define AC_SUBTOOLWIDGET_PINSCREENSHOTS_BUTTON "pinscreenshots_button"// 截图 贴图工具按钮
@@ -39,7 +40,10 @@
 #define AC_SUBTOOLWIDGET_CIRCL_BUTTON "circl_button"//截图 椭圆工具按钮
 #define AC_SUBTOOLWIDGET_LINE_BUTTON "line_button"// 截图 直线按钮
 #define AC_SUBTOOLWIDGET_PEN_BUTTON "pen_button"// 截图 画笔按钮
+#define AC_SUBTOOLWIDGET_MOSAIC_BUTTON "mosaic_button"// 截图 模糊按钮
 #define AC_SUBTOOLWIDGET_TEXT_BUTTON "text_button"// 截图文本按钮
+#define AC_SUBTOOLWIDGET_UNDO_BUTTON "undo_button"// 截图撤销按钮
+#define AC_SUBTOOLWIDGET_RECORDER_BUTTON "recorder_button"// 截图 录屏按钮
 #define AC_SUBTOOLWIDGET_SHOT_OPTION_BUT "shot_option_but" // 截图 选项按钮
 
 

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -108,7 +108,13 @@ QIcon ShotStartPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Col
 
 PluginFlags ShotStartPlugin::flags() const
 {
-    return  Type_Common | Quick_Single | Attribute_CanSetting | Attribute_CanDrag | Attribute_CanInsert;
+    if(m_isRecording){
+        qInfo() << ">>>>>>>>>>>>>>>> flags() 正在录屏" ;
+        return  Type_Common | Quick_Single | Attribute_CanSetting | Attribute_CanDrag | Attribute_CanInsert | Attribute_ForceDock;
+    }else{
+        qInfo() << ">>>>>>>>>>>>>>>> flags() 没有录屏" ;
+        return  Type_Common | Quick_Single | Attribute_CanSetting | Attribute_CanDrag | Attribute_CanInsert;
+    }
 }
 
 QWidget *ShotStartPlugin::itemWidget(const QString &itemKey)

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2316,7 +2316,7 @@ void MainWindow::getToolBarPoint()
 //切换截图功能或者录屏功能
 void MainWindow::changeFunctionButton(QString type)
 {
-    qDebug() << "切换截图功能或者录屏功能";
+    qInfo() << "切换截图功能或者录屏功能" << type;
     if (type == "record") {
         if (status::record == m_functionType) {
             return;
@@ -2327,6 +2327,7 @@ void MainWindow::changeFunctionButton(QString type)
         //updateRecordButtonPos();
         //m_recordButton->show();
         m_functionType = status::record;
+        m_toolBar->hide();
         //切换录屏或截屏时保证工具栏右对齐
         m_toolBar->move(m_toolBarPoint.x() - m_toolBar->width(), m_toolBarPoint.y());
         updateToolBarPos();
@@ -2351,6 +2352,7 @@ void MainWindow::changeFunctionButton(QString type)
         //updateShotButtonPos();
         //m_shotButton->show();
         m_functionType = status::shot;
+        m_toolBar->hide();
         if (m_toolBarPoint.x() - m_toolBar->width() < 0) {
             //由于截图的工具栏比录屏的工具栏更长，因此在屏幕左侧，采用右对齐的方式可能出现切换后截图工具栏出现在屏幕外
             //此处做了规避处理

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -110,7 +110,7 @@ void SubToolWidget::initRecordLabel()
 
     m_shotButton = new ToolButton();
     m_shotButton->setCheckable(false);
-    Utils::setAccessibility(m_shotButton, AC_SUBTOOLWIDGET_CAMERA_BUTTON);
+    Utils::setAccessibility(m_shotButton, AC_SUBTOOLWIDGET_SHOT_BUTTON);
     m_shotButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_shotButton, tr("Screenshot"));
     m_shotButton->setIcon(QIcon::fromTheme("shot"));
@@ -118,7 +118,9 @@ void SubToolWidget::initRecordLabel()
     btnList.append(m_shotButton);
     connect(m_shotButton, &DPushButton::clicked, this, [ = ] {
         m_pMainWindow->getToolBarPoint();
+        qInfo() << "shotbutton is clicked";
         switchContent("shot");
+        qInfo() << "emit changeShotToolFunc(shot)";
         emit changeShotToolFunc("shot");
     });
 
@@ -546,7 +548,7 @@ void SubToolWidget::initShotLabel()
     m_mosaicButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_mosaicButton, tr("Blur (B)"));
     m_mosaicButton->setIcon(QIcon::fromTheme("Mosaic_normal"));
-    Utils::setAccessibility(m_mosaicButton, AC_SUBTOOLWIDGET_PEN_BUTTON);
+    Utils::setAccessibility(m_mosaicButton, AC_SUBTOOLWIDGET_MOSAIC_BUTTON);
     m_shotBtnGroup->addButton(m_mosaicButton);
     m_mosaicButton->setFixedSize(TOOL_BUTTON_SIZE);
     btnList.append(m_mosaicButton);
@@ -604,7 +606,7 @@ void SubToolWidget::initShotLabel()
     m_cancelButton->setCheckable(false);
     m_cancelButton->setIconSize(TOOL_ICON_SIZE);
     m_cancelButton->setIcon(QIcon::fromTheme("cancel"));
-    Utils::setAccessibility(m_cancelButton, AC_SUBTOOLWIDGET_PINSCREENSHOTS_BUTTON);
+    Utils::setAccessibility(m_cancelButton, AC_SUBTOOLWIDGET_UNDO_BUTTON);
     m_cancelButton->setFixedSize(TOOL_BUTTON_SIZE);
     installTipHint(m_cancelButton, tr("Undo (Ctrl+Z)"));
     btnList.append(m_cancelButton);
@@ -620,7 +622,7 @@ void SubToolWidget::initShotLabel()
     m_recorderButton->setCheckable(false);
     m_recorderButton->setIconSize(TOOL_ICON_SIZE);
     m_recorderButton->setIcon(QIcon::fromTheme("recorder"));
-    Utils::setAccessibility(m_recorderButton, AC_SUBTOOLWIDGET_PINSCREENSHOTS_BUTTON);
+    Utils::setAccessibility(m_recorderButton, AC_SUBTOOLWIDGET_RECORDER_BUTTON);
     m_recorderButton->setFixedSize(TOOL_BUTTON_SIZE);
     installTipHint(m_recorderButton, tr("Record"));
     btnList.append(m_recorderButton);
@@ -1293,7 +1295,7 @@ bool SubToolWidget::eventFilter(QObject *watched, QEvent *event)
 
 void SubToolWidget::switchContent(QString shapeType)
 {
-    qDebug() << __FUNCTION__ << __LINE__ << "切换截图或者录屏工具栏" ;
+    qDebug() << __FUNCTION__ << __LINE__ << "切换截图或者录屏工具栏" << shapeType << QCursor().pos() << this->count();
     if (shapeType == "record") {
         this->addWidget(m_recordSubTool);
         this->removeWidget(m_shotSubTool);
@@ -1312,6 +1314,7 @@ void SubToolWidget::switchContent(QString shapeType)
         setCurrentWidget(m_scrollSubTool);
         m_currentType = shapeType;
     }
+    qDebug() << __FUNCTION__ << __LINE__ << "已切换工具栏" << shapeType << this->count();
 }
 void SubToolWidget::setRecordButtonDisable()
 {


### PR DESCRIPTION
Description: 由于切换后工具栏的位置没有及时刷新,及部分关键日志

Log: 修复当从截图录屏按钮切换至截图按钮时，默认选中了直线按钮

Bug: https://pms.uniontech.com/bug-view-181299.html