### PR TITLE
fix: 修复点击滚动截图后，截图录屏自动退出

### DIFF
--- a/src/camera/majorimageprocessingthread.cpp
+++ b/src/camera/majorimageprocessingthread.cpp
@@ -95,7 +95,7 @@ void MajorImageProcessingThread::run()
         if (tempImg.isNull()) {
             qWarning() << "(wayland) 未采集到摄像头画面！" ;
         } else {
-            //tempImg.save(QString("/home/wangcong/Desktop/test/test_%1.png").arg(QDateTime::currentMSecsSinceEpoch()));
+            //tempImg.save(QString("/home/uos/Desktop/test1/test_%1.png").arg(QDateTime::currentDateTime().toString(QLatin1String("hh:mm:ss.zzz "))));
             QPixmap pixmap = QPixmap::fromImage(tempImg);
             emit SendMajorImageProcessing(pixmap);
             //emit SendMajorImageProcessing(tempImg);

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1030,11 +1030,13 @@ void MainWindow::initScreenRecorder()
 //滚动截图的初始化函数
 void MainWindow::initScrollShot()
 {
+    qInfo() << "正在初始化滚动截图...";
     QJsonObject obj{
         {"tid", EventLogUtils::StartScrollShot},
         {"version", QCoreApplication::applicationVersion()}
     };
     EventLogUtils::get().writeLogs(obj);
+    m_zoomIndicator->hideMagnifier();
 
 #ifdef OCR_SCROLL_FLAGE_ON
     if (Utils::isWaylandMode) {
@@ -1132,6 +1134,7 @@ void MainWindow::initScrollShot()
     //链接滚动截图抓取当前捕捉区图片进行图片拼接
     connect(m_scrollShot, &ScrollScreenshot::getOneImg, this, [ = ] {
         //自动滚动截图模式，抓取当前捕捉区域的图片，传递给滚动截图处理类进行图片的拼接
+        qInfo() << "自动滚动截图模式，抓取当前捕捉区域的图片，传递给滚动截图处理类进行图片的拼接";
         scrollShotGrabPixmap(m_previewPostion, 5);
     });
 
@@ -1179,6 +1182,7 @@ void MainWindow::initScrollShot()
     m_tipShowtimer->setInterval(2000);
     m_initScroll = true;
 #endif
+    qInfo() << "已初始化滚动截图";
 }
 
 //根据工具栏获取滚动截图提示框的坐标
@@ -1259,6 +1263,7 @@ QPoint MainWindow::getScrollShotTipPosition()
 void MainWindow::showScrollShot()
 {
 #ifdef OCR_SCROLL_FLAGE_ON
+    qInfo() << "初始化滚动截图时，显示滚动截图中的一些公共部件、例如工具栏、提示、图片大小、第一张预览图 start";
     bool ok;
     QRect rect(recordX + 1, ((recordY == 0) ? 2 : (recordY + 1)), recordWidth - 2, recordHeight - 2);
     //滚动截图截取指定区域的第一张图片
@@ -1284,6 +1289,7 @@ void MainWindow::showScrollShot()
             //updateShotButtonPos();
         }
     });
+    qInfo() << "初始化滚动截图时，显示滚动截图中的一些公共部件、例如工具栏、提示、图片大小、第一张预览图 end";
 #endif
 }
 

--- a/src/widgets/zoomIndicator.cpp
+++ b/src/widgets/zoomIndicator.cpp
@@ -157,6 +157,7 @@ void ZoomIndicator::showMagnifier(QPoint pos)
 void ZoomIndicator::hideMagnifier()
 {
     if (Utils::isWaylandMode && !m_isOpenWM) {
+        m_zoomIndicatorGL->makeCurrent();
         m_zoomIndicatorGL->hide();
         return;
     }


### PR DESCRIPTION
Description: 由于opengl窗口的server不存在，导致程序退出

Log: 修复点击滚动截图后，截图录屏自动退出

Bug: https://pms.uniontech.com/bug-view-190933.html