### PR TITLE
fix: 适配窗管新接口，保证每次使用buffer之后，都可以被释放

### DIFF
--- a/src/waylandrecord/waylandintegration.cpp
+++ b/src/waylandrecord/waylandintegration.cpp
@@ -464,9 +464,9 @@ void WaylandIntegration::WaylandIntegrationPrivate::onDeviceChanged(quint32 name
 
 void WaylandIntegration::WaylandIntegrationPrivate::processBuffer(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect)
 {
-    //qDebug() << Q_FUNC_INFO;
+    qInfo() << __FUNCTION__ << __LINE__ << "开始处理buffer...";
     qDebug() << ">>>>>> open fd!" << rbuf->fd();
-    QScopedPointer<const KWayland::Client::RemoteBuffer> guard(rbuf);
+//    QScopedPointer<const KWayland::Client::RemoteBuffer> guard(rbuf);
     auto dma_fd = rbuf->fd();
     quint32 width = rbuf->width();
     quint32 height = rbuf->height();
@@ -564,8 +564,9 @@ QImage::Format WaylandIntegration::WaylandIntegrationPrivate::getImageFormat(qui
 
 void WaylandIntegration::WaylandIntegrationPrivate::processBufferX86(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect)
 {
+    qInfo() << __FUNCTION__ << __LINE__ << "开始处理buffer...";
     qDebug() << ">>>>>> open fd!" << rbuf->fd();
-    QScopedPointer<const KWayland::Client::RemoteBuffer> guard(rbuf);
+    //QScopedPointer<const KWayland::Client::RemoteBuffer> guard(rbuf);
     auto dma_fd = rbuf->fd();
     quint32 width = rbuf->width();
     quint32 height = rbuf->height();
@@ -803,11 +804,11 @@ void WaylandIntegration::WaylandIntegrationPrivate::setupRegistry()
         qDebug() << "正在创建wayland远程管理...";
         m_remoteAccessManager = m_registry->createRemoteAccessManager(m_registry->interface(KWayland::Client::Registry::Interface::RemoteAccessManager).name, m_registry->interface(KWayland::Client::Registry::Interface::RemoteAccessManager).version);
         qDebug() << "wayland远程管理已创建";
-        connect(m_remoteAccessManager, &KWayland::Client::RemoteAccessManager::bufferReady, this, [this](const void *output, const KWayland::Client::RemoteBuffer * rbuf) {
+        connect(m_remoteAccessManager, &KWayland::Client::RemoteAccessManager::bufferReady, this, [this](const void *output,KWayland::Client::RemoteBuffer * rbuf) {
             qDebug() << "正在接收buffer...";
             QRect screenGeometry = (KWayland::Client::Output::get(reinterpret_cast<wl_output *>(const_cast<void *>(output))))->geometry();
             qDebug() << "screenGeometry: " << screenGeometry;
-            qDebug() << "rbuf->isValid(): " << rbuf->isValid();
+            //qDebug() << "rbuf->isValid(): " << rbuf->isValid();
             connect(rbuf, &KWayland::Client::RemoteBuffer::parametersObtained, this, [this, rbuf, screenGeometry] {
                 qDebug() << "正在处理buffer..." << "fd:" << rbuf->fd();
                 if (m_boardVendorType)
@@ -820,6 +821,7 @@ void WaylandIntegration::WaylandIntegrationPrivate::setupRegistry()
                     processBufferX86(rbuf, screenGeometry);
                 }
                 qDebug() << "buffer已处理" << "fd:" << rbuf->fd();
+                rbuf->release();
             });
             qDebug() << "buffer已接收";
         });


### PR DESCRIPTION
Description: 由于双屏扩展模式下，使用buffer之后窗管没有去释放，现在交由应用主动去释放

Log: 适配窗管新接口，保证每次使用buffer之后，都可以被释放

Bug: https://pms.uniontech.com/bug-view-191041.html