### PR TITLE
fix: 适配窗管接口,修改处理buffer的流程，避免该流程耗时太长

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -584,7 +584,7 @@ void RecordProcess::startRecord()
 {
     getScreenRecordSavePath();
     //使用QtConcurrent::run受cpu核心线程数的影响，线程池默认大小为CPU核心线程数大小，由于程序中通过此方法启动的线程数超出4个，故再次设置线程池大小
-    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 8);
+    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 10);
     m_framerate = settings->value("recordConfig", "mkv_framerate").toString().toInt();
     qDebug() << "m_selectedMic: " << m_selectedMic;
     qDebug() << "m_selectedSystemAudio: " << m_selectedSystemAudio;

--- a/src/waylandrecord/avoutputstream.cpp
+++ b/src/waylandrecord/avoutputstream.cpp
@@ -1488,10 +1488,10 @@ void  CAVOutputStream::close()
             || nullptr != m_micAudioStream
             || nullptr != m_sysAudioStream
             || nullptr != audio_amix_st) {
-        //qDebug() << Q_FUNC_INFO << "开始写文件尾";
+        qDebug() << __LINE__ << __func__ << "正在写文件尾...";
         //Write file trailer
         writeTrailer(m_videoFormatContext);
-        qDebug() << Q_FUNC_INFO << "写文件尾完成";
+        qDebug() << __LINE__ << __func__ << "写文件尾完成";
     }
 
     if (m_videoStream) {

--- a/src/waylandrecord/recordadmin.cpp
+++ b/src/waylandrecord/recordadmin.cpp
@@ -187,6 +187,7 @@ void *RecordAdmin::stream(void *param)
 
 int RecordAdmin::stopStream()
 {
+    qInfo() << __LINE__ << __func__ << "正在停止视频数据写入...";
     //设置是否运行线程，用来关闭采集音频数据的线程
     m_pInputStream->setbRunThread(false);
     //设置关闭视频数据采集，将视频数据采集到队列中
@@ -201,5 +202,6 @@ int RecordAdmin::stopStream()
     //关闭输出
     m_pOutputStream->close();
     m_cacheMutex.unlock();
+    qInfo() << __LINE__ << __func__ << "已停止视频数据写入";
     return 0;
 }

--- a/src/waylandrecord/waylandintegration.cpp
+++ b/src/waylandrecord/waylandintegration.cpp
@@ -190,6 +190,7 @@ WaylandIntegration::WaylandIntegrationPrivate::WaylandIntegrationPrivate()
     m_bGetFrame = true;
     m_screenCount = 1;
     //m_recordTIme = -1;
+    initScreenFrameBuffer();
 }
 
 WaylandIntegration::WaylandIntegrationPrivate::~WaylandIntegrationPrivate()
@@ -541,15 +542,109 @@ void WaylandIntegration::WaylandIntegrationPrivate::processBuffer(const KWayland
         }
     }
     munmap(mapData, stride * height);
-    close(dma_fd);
-    qDebug() << ">>>>>> close fd!" << dma_fd;
-#ifdef KWAYLAND_REMOTE_FLAGE_ON
-    qDebug() << "rbuf->frame(): " << rbuf->frame();
-    if (rbuf->frame() == 0) {
-        qDebug() << "是否是最后一帧: " << rbuf->frame();
-        emit lastFrame();
+}
+
+void WaylandIntegration::WaylandIntegrationPrivate::processBufferHw(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect,int screenId)
+{
+    qInfo() << __FUNCTION__ << __LINE__ << "开始处理buffer...";
+    qDebug() << ">>>>>> open fd!" << rbuf->fd();
+//    QScopedPointer<const KWayland::Client::RemoteBuffer> guard(rbuf);
+    auto dma_fd = rbuf->fd();
+    quint32 width = rbuf->width();
+    quint32 height = rbuf->height();
+    quint32 stride = rbuf->stride();
+    if (m_bInitRecordAdmin) {
+        m_bInitRecordAdmin = false;
+        if (Utils::isFFmpegEnv) {
+            m_recordAdmin->init(static_cast<int>(m_screenSize.width()), static_cast<int>(m_screenSize.height()));
+            frameStartTime = avlibInterface::m_av_gettime();
+        } else {
+            frameStartTime = QDateTime::currentMSecsSinceEpoch();
+            isGstWriteVideoFrame = true;
+            if (m_gstRecordX) {
+                m_gstRecordX->waylandGstStartRecord();
+            } else {
+                qWarning() << "m_gstRecordX is nullptr!";
+            }
+            QtConcurrent::run(this, &WaylandIntegrationPrivate::gstWriteVideoFrame);
+        }
+        m_appendFrameToListFlag = true;
+        QtConcurrent::run(this, &WaylandIntegrationPrivate::appendFrameToList);
     }
-#endif
+    unsigned char *mapData = static_cast<unsigned char *>(mmap(nullptr, stride * height, PROT_READ, MAP_SHARED, dma_fd, 0));
+    if (MAP_FAILED == mapData) {
+        qCWarning(XdgDesktopPortalKdeWaylandIntegration) << "dma fd " << dma_fd << " mmap failed - ";
+    }
+    qDebug() << "mapData: " << mapData;
+    //QString pngName = "/home/uos/Desktop/test/"+QDateTime::currentDateTime().toString(QLatin1String("hh:mm:ss.zzz ") + QString("%1_").arg(rect.x()));
+    //QImage(mapData, width, height, QImage::Format_RGB32).copy().save(pngName + ".png");
+    if (m_screenCount == 1) {
+        if(!m_isExistFirstScreenData){
+            m_firstScreenData = new unsigned char[stride * height];
+            m_isExistFirstScreenData = true;
+        }
+        //单屏
+        qDebug() << ">>>>>> new unsigned char: " << stride * height;
+        memcpy(m_firstScreenData, mapData, stride * height);
+        qDebug() << ">>>>>> memcpy: " << stride * height;
+
+        QMutexLocker locker(&m_bGetScreenImageMutex);
+        m_curNewImageData._frame = m_firstScreenData;
+        m_curNewImageData._width = width;
+        m_curNewImageData._height = height;
+        m_curNewImageData._format = QImage::Format_RGBA8888;
+        m_curNewImageData._rect = QRect(0,0,0,0);
+    } else if(m_screenCount == 2){
+        //避免重复开辟内存空间,采用固定数组减小数据访问复杂度。两个屏幕的数据大小可能不同，所以需要区分开
+        if(screenId == 0){
+            if(!m_isExistFirstScreenData){
+                m_firstScreenData = new unsigned char[stride * height];
+                m_isExistFirstScreenData = true;
+            }
+            qDebug() << ">>>>>> memcpy1: " << stride * height;
+            memcpy(m_firstScreenData, mapData, stride * height);
+            qDebug() << ">>>>>> memcpy2: " << stride * height;
+            m_ScreenDateBufFrames[0]._frame = m_firstScreenData;
+            m_ScreenDateBufFrames[0]._width = width;
+            m_ScreenDateBufFrames[0]._height = height;
+            m_ScreenDateBufFrames[0]._format = getImageFormat(rbuf->format());
+            m_ScreenDateBufFrames[0]._rect = rect;
+            m_ScreenDateBufFrames[0]._flag = true;
+        }else {
+            if(!m_isExistSecondScreenData){
+                m_secondScreenData = new unsigned char[stride * height];
+                m_isExistSecondScreenData = true;
+            }
+            qDebug() << ">>>>>> memcpy1: " << stride * height;
+            memcpy(m_secondScreenData, mapData, stride * height);
+            qDebug() << ">>>>>> memcpy2: " << stride * height;
+            m_ScreenDateBufFrames[1]._frame = m_secondScreenData;
+            m_ScreenDateBufFrames[1]._width = width;
+            m_ScreenDateBufFrames[1]._height = height;
+            m_ScreenDateBufFrames[1]._format = getImageFormat(rbuf->format());
+            m_ScreenDateBufFrames[1]._rect = rect;
+            m_ScreenDateBufFrames[1]._flag = true;
+        }
+
+        qDebug() <<"m_ScreenDateBufFrames[0]._flag: " << m_ScreenDateBufFrames[0]._flag <<"m_ScreenDateBufFrames[1]._flag: " << m_ScreenDateBufFrames[1]._flag;
+        if(m_ScreenDateBufFrames[0]._flag  && m_ScreenDateBufFrames[1]._flag)
+        {
+            QMutexLocker locker(&m_bGetScreenImageMutex);
+            for (int i = 0;i < 2; i++) {
+                m_curNewImageScreenFrames[i]._frame  = m_ScreenDateBufFrames[i]._frame  ;
+                m_curNewImageScreenFrames[i]._width  = m_ScreenDateBufFrames[i]._width  ;
+                m_curNewImageScreenFrames[i]._height = m_ScreenDateBufFrames[i]._height ;
+                m_curNewImageScreenFrames[i]._format = m_ScreenDateBufFrames[i]._format ;
+                m_curNewImageScreenFrames[i]._rect   = m_ScreenDateBufFrames[i]._rect   ;
+                m_curNewImageScreenFrames[i]._flag   = m_ScreenDateBufFrames[i]._flag   ;
+                m_ScreenDateBufFrames[i]._flag = false;
+            }
+        }
+    }else{
+        qWarning() << "screen count > 2!!!";
+    }
+    munmap(mapData, stride * height);
+    qInfo() << __FUNCTION__ << __LINE__ << "已处理buffer";
 }
 
 //根据wayland客户端bufferReady给过来的像素格式，转成QImage的格式
@@ -631,15 +726,6 @@ void WaylandIntegration::WaylandIntegrationPrivate::processBufferX86(const KWayl
             m_ScreenDateBuf.clear();
         }
     }
-    close(dma_fd);
-    qDebug() << ">>>>>> close fd!" << dma_fd;
-#ifdef KWAYLAND_REMOTE_FLAGE_ON
-    qDebug() << "rbuf->frame(): " << rbuf->frame();
-    if (rbuf->frame() == 0) {
-        qDebug() << "是否是最后一帧: " << rbuf->frame();
-        emit lastFrame();
-    }
-#endif
 }
 //通过线程每30ms钟向数据池中取出一张图片添加到环形缓冲区，以便后续视频编码
 void WaylandIntegration::WaylandIntegrationPrivate::appendFrameToList()
@@ -655,7 +741,15 @@ void WaylandIntegration::WaylandIntegrationPrivate::appendFrameToList()
             QImage tempImage;
             {
                 QMutexLocker locker(&m_bGetScreenImageMutex);
-                tempImage = m_curNewImage.second.copy();
+                if (m_boardVendorType) {
+
+                    tempImage = QImage(m_curNewImageData._frame,
+                                       m_curNewImageData._width,
+                                       m_curNewImageData._height,
+                                       m_curNewImageData._format);
+                }else{
+                    tempImage = m_curNewImage.second.copy();
+                }
             }
             if (!tempImage.isNull()) {
                 //qDebug() << "用来编码的帧索引glovbalImageCount: " << globalImageCount;
@@ -697,9 +791,21 @@ void WaylandIntegration::WaylandIntegrationPrivate::appendFrameToList()
             QVector<QPair<QRect, QImage>> tempImageVec;
             {
                 QMutexLocker locker(&m_bGetScreenImageMutex);
-                if (m_curNewImageScreen.size() != m_screenCount) continue;
-                for (auto itr = m_curNewImageScreen.begin(); itr != m_curNewImageScreen.end(); ++itr) {
-                    tempImageVec.append(*itr);
+                if (m_boardVendorType) {
+                    if (!m_curNewImageScreenFrames[0]._flag || !m_curNewImageScreenFrames[1]._flag) continue;
+                    for (int i = 0 ; i < 2 ; i++) {
+                        QImage tempImage = QImage(m_curNewImageScreenFrames[i]._frame,
+                                                  static_cast<int>(m_curNewImageScreenFrames[i]._width),
+                                                  static_cast<int>(m_curNewImageScreenFrames[i]._height),
+                                                  m_curNewImageScreenFrames[i]._format).copy();
+                        tempImageVec.append(QPair<QRect, QImage>(m_curNewImageScreenFrames[i]._rect,tempImage));
+                        m_curNewImageScreenFrames[i]._flag = false;
+                    }
+                }else{
+                    if (m_curNewImageScreen.size() != m_screenCount) continue;
+                    for (auto itr = m_curNewImageScreen.begin(); itr != m_curNewImageScreen.end(); ++itr) {
+                        tempImageVec.append(*itr);
+                    }
                 }
             }
             QImage img(m_screenSize, QImage::Format_RGBA8888);
@@ -802,6 +908,7 @@ QImage WaylandIntegration::WaylandIntegrationPrivate::getImage(int32_t fd, uint3
 
     return tempImage;
 }
+static int frameCount = 0;
 void WaylandIntegration::WaylandIntegrationPrivate::setupRegistry()
 {
     qDebug() << "初始化wayland服务链接已完成";
@@ -834,18 +941,56 @@ void WaylandIntegration::WaylandIntegrationPrivate::setupRegistry()
             qDebug() << "screenGeometry: " << screenGeometry;
             //qDebug() << "rbuf->isValid(): " << rbuf->isValid();
             connect(rbuf, &KWayland::Client::RemoteBuffer::parametersObtained, this, [this, rbuf, screenGeometry] {
-                qDebug() << "正在处理buffer..." << "fd:" << rbuf->fd();
-                if (m_boardVendorType)
-                {
-                    //arm hw
-                    processBuffer(rbuf, screenGeometry);
-                } else
-                {
-                    //other
-                    processBufferX86(rbuf, screenGeometry);
+                qDebug() << "正在处理buffer..." << "fd:" << rbuf->fd() << "frameCount: " << frameCount ;
+                bool flag = false;
+                int screenId = 0;
+                if(m_screenCount == 1){
+                    //抽帧（数据过来60帧，取一半，由于memcpy一帧数据需要30ms，无法满足1s60帧的速度，所以需要抽帧）
+                    flag = (frameCount++ % 2 == 0);
+                }else{
+                    //
+                    if(frameCount == 0){
+                        qDebug() << ">>>>>>>>>>>>>>>> fisrt screenGeometry: " << screenGeometry;
+                        //第一帧画面的坐标不是从（0,0）开始，从第二帧开始取
+                        if(screenGeometry.x() != 0 || screenGeometry.y() != 0){
+                            frameCount+=1;
+                        }
+                    }
+                    //抽帧（数据过来60帧，取一半）
+                    if(frameCount % 4 == 0){
+                        screenId = 0;
+                    }else if((frameCount-1) % 4 == 0 ){
+                        screenId = 1;
+                    }
+                    flag = (frameCount % 4 == 0 ) || (((frameCount-1) != 0) && (frameCount-1) % 4 == 0 );
+                    frameCount++;
                 }
+                if(flag){
+                    qDebug() << "frameCount: " << frameCount << "screenGeometry: " << screenGeometry;
+                    if (m_boardVendorType)
+                    {
+                        //arm hw
+                        //processBuffer(rbuf, screenGeometry);
+                        processBufferHw(rbuf, screenGeometry,screenId);
+                    } else
+                    {
+                        //other
+                        processBufferX86(rbuf, screenGeometry);
+                    }
+                }
+                close(rbuf->fd());
+                qDebug() << "close(rbuf->fd())";
+#ifdef KWAYLAND_REMOTE_FLAGE_ON
+                qDebug() << "rbuf->frame(): " << rbuf->frame();
+                if (rbuf->frame() == 0) {
+                    qDebug() << "是否是最后一帧: " << rbuf->frame();
+                    emit lastFrame();
+                }
+#endif
                 qDebug() << "buffer已处理" << "fd:" << rbuf->fd();
+
                 rbuf->release();
+                qDebug() << "rbuf->release()";
             });
             qDebug() << "buffer已接收";
         });
@@ -959,6 +1104,34 @@ void WaylandIntegration::WaylandIntegrationPrivate::appendBuffer(unsigned char *
         }
     }
     //qDebug() << "存视频帧 m_waylandList.size(): " << m_waylandList.size() << " , m_freeList.size(): " << m_freeList.size();
+}
+
+void WaylandIntegration::WaylandIntegrationPrivate::initScreenFrameBuffer()
+{
+    m_ScreenDateBufFrames[0]._frame = nullptr;
+    m_ScreenDateBufFrames[0]._width = 0;
+    m_ScreenDateBufFrames[0]._height = 0;
+    m_ScreenDateBufFrames[0]._format =  QImage::Format_RGBA8888;
+    m_ScreenDateBufFrames[0]._rect = QRect(0,0,0,0);
+    m_ScreenDateBufFrames[0]._flag = false;
+    m_ScreenDateBufFrames[1]._frame = nullptr;
+    m_ScreenDateBufFrames[1]._width = 0;
+    m_ScreenDateBufFrames[1]._height = 0;
+    m_ScreenDateBufFrames[1]._format =  QImage::Format_RGBA8888;
+    m_ScreenDateBufFrames[1]._rect = QRect(0,0,0,0);
+    m_ScreenDateBufFrames[1]._flag = false;
+    m_curNewImageScreenFrames[0]._frame = nullptr;
+    m_curNewImageScreenFrames[0]._width = 0;
+    m_curNewImageScreenFrames[0]._height = 0;
+    m_curNewImageScreenFrames[0]._format =  QImage::Format_RGBA8888;
+    m_curNewImageScreenFrames[0]._rect = QRect(0,0,0,0);
+    m_curNewImageScreenFrames[0]._flag = false;
+    m_curNewImageScreenFrames[1]._frame = nullptr;
+    m_curNewImageScreenFrames[1]._width = 0;
+    m_curNewImageScreenFrames[1]._height = 0;
+    m_curNewImageScreenFrames[1]._format =  QImage::Format_RGBA8888;
+    m_curNewImageScreenFrames[1]._rect = QRect(0,0,0,0);
+    m_curNewImageScreenFrames[1]._flag = false;
 }
 
 int WaylandIntegration::WaylandIntegrationPrivate::frameIndex = 0;

--- a/src/waylandrecord/waylandintegration_p.h
+++ b/src/waylandrecord/waylandintegration_p.h
@@ -72,6 +72,15 @@ public:
         unsigned char *_frame;
     };
 
+    struct FrameData {
+        quint32 _width;
+        quint32 _height;
+        unsigned char *_frame;
+        QImage::Format _format;
+        QRect _rect ;
+        bool _flag;
+    };
+
     typedef struct {
         uint nodeId;
         QVariantMap map;
@@ -137,6 +146,7 @@ protected Q_SLOTS:
      * @param rbuf
      */
     void processBuffer(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect);
+    void processBufferHw(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect,int screenId = 0);
 
     /**
      * @brief getImageFormat 根据wayland客户端bufferReady给过来的像素格式，转成QImage的格式
@@ -189,6 +199,10 @@ private:
      * @param time:时间戳
      */
     void appendBuffer(unsigned char *frame, int width, int height, int stride, int64_t time);
+    /**
+     * @brief initScreenFrameBuffer 初始化屏幕数据数组
+     */
+    void initScreenFrameBuffer();
 public:
     /**
      * @ 内存由getFrame函数内部申请
@@ -228,6 +242,7 @@ private:
     QList<unsigned char *> m_freeList;
 
     QPair<qint64, QImage> m_curNewImage;
+    FrameData m_curNewImageData;
 
 
 
@@ -268,8 +283,19 @@ private:
     struct EglStruct m_eglstruct;
     QMutex m_bGetScreenImageMutex;
     QMap<QString, QRect> m_screenId2Point;
+    //双屏情况
     QVector<QPair<QRect, QImage>> m_ScreenDateBuf;
     QVector<QPair<QRect, QImage>> m_curNewImageScreen;
+    //hw双屏
+    unsigned char *m_firstScreenData = nullptr;
+    unsigned char *m_secondScreenData = nullptr;
+
+    //第一次拷贝数据的时候需要开辟内存空间
+    bool m_isExistFirstScreenData = false;
+    bool m_isExistSecondScreenData = false;
+    FrameData m_ScreenDateBufFrames[2];
+    FrameData m_curNewImageScreenFrames[2];
+
     QSize m_screenSize;
     int m_screenCount;
 


### PR DESCRIPTION
Description: 由于双屏扩展模式下，使用buffer之后窗管没有去释放，现在交由应用主动去释放，需要减少处理buffer的时间，以免冗余

Log: 适配窗管接口,修改处理buffer的流程，避免该流程耗时太长

Bug: https://pms.uniontech.com/bug-view-191041.html