### PR TITLE
fix: 适配窗管接口,修改处理buffer的流程，避免该流程耗时太长

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -584,7 +584,7 @@ void RecordProcess::startRecord()
 {
     getScreenRecordSavePath();
     //使用QtConcurrent::run受cpu核心线程数的影响，线程池默认大小为CPU核心线程数大小，由于程序中通过此方法启动的线程数超出4个，故再次设置线程池大小
-    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 8);
+    QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 10);
     m_framerate = settings->value("recordConfig", "mkv_framerate").toString().toInt();
     qDebug() << "m_selectedMic: " << m_selectedMic;
     qDebug() << "m_selectedSystemAudio: " << m_selectedSystemAudio;

--- a/src/waylandrecord/avoutputstream.cpp
+++ b/src/waylandrecord/avoutputstream.cpp
@@ -1488,10 +1488,10 @@ void  CAVOutputStream::close()
             || nullptr != m_micAudioStream
             || nullptr != m_sysAudioStream
             || nullptr != audio_amix_st) {
-        //qDebug() << Q_FUNC_INFO << "开始写文件尾";
+        qDebug() << __LINE__ << __func__ << "正在写文件尾...";
         //Write file trailer
         writeTrailer(m_videoFormatContext);
-        qDebug() << Q_FUNC_INFO << "写文件尾完成";
+        qDebug() << __LINE__ << __func__ << "写文件尾完成";
     }
 
     if (m_videoStream) {

--- a/src/waylandrecord/recordadmin.cpp
+++ b/src/waylandrecord/recordadmin.cpp
@@ -187,6 +187,7 @@ void *RecordAdmin::stream(void *param)
 
 int RecordAdmin::stopStream()
 {
+    qInfo() << __LINE__ << __func__ << "正在停止视频数据写入...";
     //设置是否运行线程，用来关闭采集音频数据的线程
     m_pInputStream->setbRunThread(false);
     //设置关闭视频数据采集，将视频数据采集到队列中
@@ -201,5 +202,6 @@ int RecordAdmin::stopStream()
     //关闭输出
     m_pOutputStream->close();
     m_cacheMutex.unlock();
+    qInfo() << __LINE__ << __func__ << "已停止视频数据写入";
     return 0;
 }

--- a/src/waylandrecord/waylandintegration_p.h
+++ b/src/waylandrecord/waylandintegration_p.h
@@ -72,6 +72,15 @@ public:
         unsigned char *_frame;
     };
 
+    struct FrameData {
+        quint32 _width;
+        quint32 _height;
+        unsigned char *_frame;
+        QImage::Format _format;
+        QRect _rect ;
+        bool _flag;
+    };
+
     typedef struct {
         uint nodeId;
         QVariantMap map;
@@ -137,6 +146,7 @@ protected Q_SLOTS:
      * @param rbuf
      */
     void processBuffer(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect);
+    void processBufferHw(const KWayland::Client::RemoteBuffer *rbuf, const QRect rect,int screenId = 0);
 
     /**
      * @brief getImageFormat 根据wayland客户端bufferReady给过来的像素格式，转成QImage的格式
@@ -189,6 +199,10 @@ private:
      * @param time:时间戳
      */
     void appendBuffer(unsigned char *frame, int width, int height, int stride, int64_t time);
+    /**
+     * @brief initScreenFrameBuffer 初始化屏幕数据数组
+     */
+    void initScreenFrameBuffer();
 public:
     /**
      * @ 内存由getFrame函数内部申请
@@ -228,6 +242,7 @@ private:
     QList<unsigned char *> m_freeList;
 
     QPair<qint64, QImage> m_curNewImage;
+    FrameData m_curNewImageData;
 
 
 
@@ -268,8 +283,19 @@ private:
     struct EglStruct m_eglstruct;
     QMutex m_bGetScreenImageMutex;
     QMap<QString, QRect> m_screenId2Point;
+    //双屏情况
     QVector<QPair<QRect, QImage>> m_ScreenDateBuf;
     QVector<QPair<QRect, QImage>> m_curNewImageScreen;
+    //hw双屏
+    unsigned char *m_firstScreenData = nullptr;
+    unsigned char *m_secondScreenData = nullptr;
+
+    //第一次拷贝数据的时候需要开辟内存空间
+    bool m_isExistFirstScreenData = false;
+    bool m_isExistSecondScreenData = false;
+    FrameData m_ScreenDateBufFrames[2];
+    FrameData m_curNewImageScreenFrames[2];
+
     QSize m_screenSize;
     int m_screenCount;
 


### PR DESCRIPTION
Description: 由于双屏扩展模式下，使用buffer之后窗管没有去释放，现在交由应用主动去释放，需要减少处理buffer的时间，以免冗余

Log: 适配窗管接口,修改处理buffer的流程，避免该流程耗时太长

Bug: https://pms.uniontech.com/bug-view-191041.html