### PR TITLE
fix: 修复录屏选择可见点击效果，录屏中点击鼠标，显示黑色背景

### DIFF
--- a/src/button_feedback.cpp
+++ b/src/button_feedback.cpp
@@ -17,6 +17,7 @@
 
 const int ButtonFeedback::FRAME_RATE = 40; // ms
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 ButtonFeedback::ButtonFeedback(DWidget *parent) : DWidget(parent)
@@ -113,7 +114,9 @@ void ButtonFeedback::paintEvent(QPaintEvent *event)
     m_painter->begin(this);
     m_painter->drawPixmap(QPoint(0, 0), pixmap);
     m_painter->end();
-    //setMask(pixmap.mask());
+    if (!DWindowManagerHelper::instance()->hasComposite()) {
+        setMask(pixmap.mask());
+    }
     event->accept();
 }
 

--- a/src/button_feedback.h
+++ b/src/button_feedback.h
@@ -5,6 +5,7 @@
 
 #ifndef BUTTONFEEDBACK_H
 #define BUTTONFEEDBACK_H
+#include <DWindowManagerHelper>
 
 #include <DWidget>
 #include <QTimer>
@@ -36,7 +37,7 @@ private:
     QTimer *timer;
 
     int frameIndex;
-    QPainter* m_painter = nullptr;
+    QPainter *m_painter = nullptr;
 };
 
 #endif


### PR DESCRIPTION
Description: 由于2d模式（无窗口特效）不支持透明，因此会将背景框显示出来

Log: 修复录屏选择可见点击效果，录屏中点击鼠标，显示黑色背景

Bug: https://pms.uniontech.com/bug-view-200881.html