### PR TITLE
fix: 修复录屏选择可见点击效果，录屏中点击鼠标，显示黑色背景

### DIFF
--- a/src/button_feedback.cpp
+++ b/src/button_feedback.cpp
@@ -7,6 +7,7 @@
 #include "utils.h"
 
 #include <DHiDPIHelper>
+#include <DWindowManagerHelper>
 
 #include <QPainter>
 #include <QTimer>
@@ -18,6 +19,7 @@
 const int ButtonFeedback::FRAME_RATE = 40; // ms
 
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 ButtonFeedback::ButtonFeedback(DWidget *parent) : DWidget(parent)
 {
@@ -114,6 +116,9 @@ void ButtonFeedback::paintEvent(QPaintEvent *event)
     m_painter->drawPixmap(QPoint(0, 0), pixmap);
     m_painter->end();
     //setMask(pixmap.mask());
+    if (!DWindowManagerHelper::instance()->hasComposite()) {
+        setMask(pixmap.mask());
+    }
     event->accept();
 }
 


### PR DESCRIPTION
Description: 由于2d模式（无窗口特效）不支持透明，因此会将背景框显示出来

Log: 修复录屏选择可见点击效果，录屏中点击鼠标，显示黑色背景

Bug: https://pms.uniontech.com/bug-view-199945.html