### PR TITLE
fix: 录屏时不允许改变屏幕分辨率

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -137,6 +137,9 @@ void MainWindow::initMainWindow()
     }
 
     m_screenCount = QApplication::desktop()->screenCount();
+    QDesktopWidget *desktopwidget = QApplication::desktop();
+    connect(desktopwidget, SIGNAL(resized(int)), this, SLOT(onScreenResolutionChanged()));
+
     QList<QScreen *> screenList = qApp->screens();
     int hTotal = 0;
     for (auto it = screenList.constBegin(); it != screenList.constEnd(); ++it) {
@@ -657,6 +660,7 @@ void MainWindow::forciblySavingNotify()
 
 void MainWindow::onExit()
 {
+    qInfo() << "exit screenshot app";
     if (RECORD_BUTTON_RECORDING == recordButtonStatus) {
         stopRecord();
     } else {
@@ -1449,6 +1453,15 @@ void MainWindow::onExitScreenCapture()
 {
     qInfo() << __FUNCTION__ << __LINE__ << "已超时(3s) 强制退出截图录屏...";
     _Exit(0);
+}
+
+void MainWindow::onScreenResolutionChanged()
+{
+    qInfo() << "Screen Resolution has Changed!";
+    if (!m_isScreenResolutionChanged) {
+        m_isScreenResolutionChanged = true;
+        onExit();
+    }
 }
 
 void MainWindow::initLaunchMode(const QString &launchMode)

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -552,6 +552,11 @@ public slots:
      * @brief 有些时候退出全局事件监听线程会卡住，此时强退截图录屏
      */
     void onExitScreenCapture();
+
+    /**
+     * @brief 任意屏幕分辨率被改变
+     */
+    void onScreenResolutionChanged();
 protected:
     bool eventFilter(QObject *object, QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
@@ -1030,6 +1035,7 @@ private:
     bool m_isFullScreenShot = false;
     bool m_isScreenVertical = false; // 判断多屏是否纵向布局
     bool m_isLockedState = false;
+    bool m_isScreenResolutionChanged = false;
 };
 
 #endif //MAINWINDOW_H


### PR DESCRIPTION
Description: 由于开始录屏之前，就会将需要录制的屏幕大小给进去，录制过程中，不允许修改分辨率

Log: 录屏时不允许改变屏幕分辨率