### PR TITLE
fix: 修复通知中心中截图录屏提示信息未国际化

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,6 +169,8 @@ int main(int argc, char *argv[])
 
         // Load translator.
         app->loadTranslator();
+        Utils::appName = MainWindow::tr("deepin-screen-recorder");
+        qInfo() << "Original Application Name is: " << QCoreApplication::applicationName() << ". International Application Name is: " << Utils::appName;
         Screenshot window;
 
         // 主题设置

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -593,7 +593,7 @@ void MainWindow::sendSavingNotify()
     unsigned int id = 0;
 
     QList<QVariant> arg;
-    arg << (QCoreApplication::applicationName())                 // appname
+    arg << Utils::appName //(QCoreApplication::applicationName())                 // appname
         << id                                                   // id
         << QString("deepin-screen-recorder")                     // icon
         << QString(tr("Screen Capture"))                         // summary
@@ -620,7 +620,7 @@ void MainWindow::forciblySavingNotify()
     unsigned int id = 0;
 
     QList<QVariant> arg;
-    arg << (QCoreApplication::applicationName())                 // appname
+    arg << Utils::appName  //(QCoreApplication::applicationName())                 // appname
         << id                                                   // id
         << QString("deepin-screen-recorder")                     // icon
         << QString(tr("Screen Capture"))                         // summary
@@ -1794,7 +1794,7 @@ void MainWindow::initBackground()
     if (m_backgroundPixmap.isNull()) {
         DBusNotify shotFailedNotify;
         QString tips = QString(tr("Screenshot failed."));
-        shotFailedNotify.Notify(QCoreApplication::applicationName(), 0, "deepin-screen-recorder", QString(), tips, QStringList(), QVariantMap(), 5000);
+        shotFailedNotify.Notify(Utils::appName /*QCoreApplication::applicationName()*/, 0, "deepin-screen-recorder", QString(), tips, QStringList(), QVariantMap(), 5000);
         // if(Utils::isWaylandMode) {
         qWarning() << "截图失败(防截图) 无法获取截图背景，应用退出！";
         _exit(0);
@@ -2649,7 +2649,7 @@ void MainWindow::sendNotify(SaveAction saveAction, QString saveFilePath, const b
         DBusNotify saveFailedNotify;
         QString tips = QString(tr("Save failed. Please save it in your home directory."));
         ConfigSettings::instance()->setValue("shot", "save_dir", "");
-        saveFailedNotify.Notify(QCoreApplication::applicationName(), 0, "deepin-screen-recorder", QString(), tips, QStringList(), QVariantMap(), 5000);
+        saveFailedNotify.Notify(Utils::appName /*QCoreApplication::applicationName()*/, 0, "deepin-screen-recorder", QString(), tips, QStringList(), QVariantMap(), 5000);
         exitApp();
         return;
     }
@@ -2690,7 +2690,7 @@ void MainWindow::sendNotify(SaveAction saveAction, QString saveFilePath, const b
     QList<QVariant> arg;
     int timeout = 5000;
     unsigned int id = 0;
-    arg << (QCoreApplication::applicationName())                 // appname
+    arg << Utils::appName //(QCoreApplication::applicationName())                 // appname
         << id                                                    // id
         << QString("deepin-screen-recorder")                     // icon
         << tr("Screenshot finished")                             // summary

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -692,7 +692,7 @@ void RecordProcess::exitRecord(QString newSavePath)
         unsigned int id = 0;
 
         QList<QVariant> arg;
-        arg << (QCoreApplication::applicationName())                 // appname
+        arg << Utils::appName  //(QCoreApplication::applicationName())                 // appname
             << id                                                    // id
             << QString("deepin-screen-recorder")                     // icon
             << tr("Recording finished")                              // summary

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -47,7 +47,7 @@ void Screenshot::delayScreenshot(double num)
     QVariantMap hints;
     DBusNotify *notifyDBus = new DBusNotify(this);
     if (num >= 2) {
-        notifyDBus->Notify(QCoreApplication::applicationName(), 0,  "deepin-screen-recorder", "",
+        notifyDBus->Notify(Utils::appName /*QCoreApplication::applicationName()*/, 0,  "deepin-screen-recorder", "",
                            summary, actions, hints, 3000);
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,6 +42,7 @@ bool Utils::isRootUser = false;
 qreal Utils::pixelRatio = 0.0;
 bool Utils::isFFmpegEnv = true;
 int Utils::themeType = 0;
+QString Utils::appName = "";
 
 QString Utils::getQrcPath(QString imageName)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -54,6 +54,7 @@ public:
     static bool is3rdInterfaceStart;
     static bool isTabletEnvironment;
     static bool isWaylandMode;
+    static QString appName;
     /**
      * @brief 本机是否存在ffmpeg相关库 true:存在 false:不存在
      */

--- a/translations/deepin-screen-recorder_ar.ts
+++ b/translations/deepin-screen-recorder_ar.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_bo.ts
+++ b/translations/deepin-screen-recorder_bo.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished">སྦྱར་རིས།</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_br.ts
+++ b/translations/deepin-screen-recorder_br.ts
@@ -107,6 +107,10 @@ pe bouezit adarre war ar verradenn evit paouez an enrolladenn</translation>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_ca.ts
+++ b/translations/deepin-screen-recorder_ca.ts
@@ -107,6 +107,10 @@ o premeu la drecera de nou per aturar la gravació.</translation>
         <source>Pin Screenshots</source>
         <translation>Fixa les captures</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_cs.ts
+++ b/translations/deepin-screen-recorder_cs.ts
@@ -107,6 +107,10 @@ v oznamovací oblasti panelu nebo stiskněte klávesovou zkratku</translation>
         <source>Pin Screenshots</source>
         <translation>Připnout snímky obrazovky</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_da.ts
+++ b/translations/deepin-screen-recorder_da.ts
@@ -107,6 +107,10 @@ eller tryk på genvejen igen, for at stoppe optagelse</translation>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_de.ts
+++ b/translations/deepin-screen-recorder_de.ts
@@ -107,6 +107,10 @@ oder drücken Sie die Tastenkombination erneut, um die Aufnahme zu stoppen</tran
         <source>Pin Screenshots</source>
         <translation>Bildschirmfotos anheften</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_en_US.ts
+++ b/translations/deepin-screen-recorder_en_US.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</translation>
         <source>Pin Screenshots</source>
         <translation>Pin Screenshots</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_es.ts
+++ b/translations/deepin-screen-recorder_es.ts
@@ -107,6 +107,10 @@ o haga clic en el icono de la bandeja</translation>
         <source>Pin Screenshots</source>
         <translation>Anclar captura de pantalla</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_fi.ts
+++ b/translations/deepin-screen-recorder_fi.ts
@@ -107,6 +107,10 @@ tai lopeta tallennus painamalla pikakuvaketta uudelleen</translation>
         <source>Pin Screenshots</source>
         <translation>Kiinnitä kaappaukset</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_fr.ts
+++ b/translations/deepin-screen-recorder_fr.ts
@@ -107,6 +107,10 @@ ou appuyer à nouveau sur le raccourci pour arrêter l&apos;enregistrement</tran
         <source>Pin Screenshots</source>
         <translation>Captures d&apos;écran de l&apos;épingle</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_gl_ES.ts
+++ b/translations/deepin-screen-recorder_gl_ES.ts
@@ -107,6 +107,10 @@ ou prema de novo o atallo para deixar de gravar</translation>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_hu.ts
+++ b/translations/deepin-screen-recorder_hu.ts
@@ -107,6 +107,10 @@ vagy nyomja le a gyorsbillentyűt ismét a felvétel megállításához</transla
         <source>Pin Screenshots</source>
         <translation>Képernyőképek kitűzése</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_it.ts
+++ b/translations/deepin-screen-recorder_it.ts
@@ -107,6 +107,10 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
         <source>Pin Screenshots</source>
         <translation>Blocca screenshot</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_ko.ts
+++ b/translations/deepin-screen-recorder_ko.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_ms.ts
+++ b/translations/deepin-screen-recorder_ms.ts
@@ -107,6 +107,10 @@ atau klik pintasan sekali lagi untuk hentikan rakaman</translation>
         <source>Pin Screenshots</source>
         <translation>Cemat Tangkap Layar</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_nl.ts
+++ b/translations/deepin-screen-recorder_nl.ts
@@ -107,6 +107,10 @@ of druk nogmaals op de sneltoets om te stoppen</translation>
         <source>Pin Screenshots</source>
         <translation>Schermfoto&apos;s vastmaken</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_pl.ts
+++ b/translations/deepin-screen-recorder_pl.ts
@@ -107,6 +107,10 @@ lub naciśnij ponownie skrót, aby zatrzymać nagrywanie</translation>
         <source>Pin Screenshots</source>
         <translation>Przypnij zrzuty ekranu</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_pt.ts
+++ b/translations/deepin-screen-recorder_pt.ts
@@ -107,6 +107,10 @@ ou pressione novamente o atalho para parar de gravar</translation>
         <source>Pin Screenshots</source>
         <translation>Afixar capturas de ecrã</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_pt_BR.ts
+++ b/translations/deepin-screen-recorder_pt_BR.ts
@@ -107,6 +107,10 @@ clique no ícone da bandeja ou use o atalho</translation>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_ru.ts
+++ b/translations/deepin-screen-recorder_ru.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_sq.ts
+++ b/translations/deepin-screen-recorder_sq.ts
@@ -107,6 +107,10 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
         <source>Pin Screenshots</source>
         <translation>Fiksoni Foto Ekrani</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_sr.ts
+++ b/translations/deepin-screen-recorder_sr.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_tr.ts
+++ b/translations/deepin-screen-recorder_tr.ts
@@ -107,6 +107,10 @@ tepsi simgesine tıklayın ya da kısayola yeniden basın</translation>
         <source>Pin Screenshots</source>
         <translation>Ekran Görüntülerini Sabitle</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_ug.ts
+++ b/translations/deepin-screen-recorder_ug.ts
@@ -106,6 +106,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation type="unfinished">چاپلاق</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_uk.ts
+++ b/translations/deepin-screen-recorder_uk.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation>Пришпилити знімки</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_zh_CN.ts
+++ b/translations/deepin-screen-recorder_zh_CN.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation>贴图</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation>截图录屏</translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_zh_HK.ts
+++ b/translations/deepin-screen-recorder_zh_HK.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation>貼圖</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>

--- a/translations/deepin-screen-recorder_zh_TW.ts
+++ b/translations/deepin-screen-recorder_zh_TW.ts
@@ -107,6 +107,10 @@ or press the shortcut again to stop recording</source>
         <source>Pin Screenshots</source>
         <translation>貼圖</translation>
     </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MenuController</name>


### PR DESCRIPTION
Description: 应用名称没有tr

Log: 修复通知中心中截图录屏提示信息未国际化

Bug: https://pms.uniontech.com/bug-view-200517.html