### PR TITLE
fix: 修复点击滚动截图选项菜单中的选项会触发自动滚动功能

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -562,6 +562,7 @@ void MainWindow::checkIsLockScreen()
     }
     bool isLockScreen = sessionManagerIntert.property("Locked").toBool();
 
+    qInfo() << "Current Screen is LockScreen?" << isLockScreen;
     if (isLockScreen) {
         pinScreenshotsLockScreen(isLockScreen);
         m_toolBar->setScrollShotDisabled(true);
@@ -4525,8 +4526,15 @@ void MainWindow::scrollShotMouseClickEvent(int x, int y)
         static_cast<int>(m_toolBar->width() * m_pixelRatio),
         static_cast<int>(m_toolBar->height() * m_pixelRatio)
     };
+    //选项的下拉菜单画为一个矩形
+    QRect shotOptionRect{
+        static_cast<int>(m_toolBar->getShotOptionRect().x() * m_pixelRatio),
+        static_cast<int>(m_toolBar->getShotOptionRect().y() * m_pixelRatio),
+        static_cast<int>(m_toolBar->getShotOptionRect().width() * m_pixelRatio),
+        static_cast<int>(m_toolBar->getShotOptionRect().height() * m_pixelRatio)
+    };
     //判断当前点击的点是否在工具栏或截图保存按钮上（当工具栏或截图保存按钮在捕捉区域内部时会进入）,滚动截图不响应此时的点击事件
-    if (toolBarRect.contains(mouseClickPoint)) {
+    if (toolBarRect.contains(mouseClickPoint) || shotOptionRect.contains(mouseClickPoint)) {
         return;
     }
 
@@ -4647,8 +4655,16 @@ void MainWindow::scrollShotMouseMoveEvent(int x, int y)
             static_cast<int>(m_scrollShotTip->width() * m_pixelRatio),
             static_cast<int>(m_scrollShotTip->height() * m_pixelRatio)
         };
+
+        //选项的下拉菜单
+        QRect shotOptionRect{
+            static_cast<int>(m_toolBar->getShotOptionRect().x() * m_pixelRatio),
+            static_cast<int>(m_toolBar->getShotOptionRect().y() * m_pixelRatio),
+            static_cast<int>(m_toolBar->getShotOptionRect().width() * m_pixelRatio),
+            static_cast<int>(m_toolBar->getShotOptionRect().height() * m_pixelRatio)
+        };
         //判断当前鼠标是否在工具栏或截图保存按钮或滚动截图提示上（此时工具栏或截图保存按钮或滚动截图的提示框在捕捉区域内部）
-        if (toolBarRect.contains(mouseMovePoint)) {
+        if (toolBarRect.contains(mouseMovePoint) || shotOptionRect.contains(mouseMovePoint)) {
             //滚动截图启动后，鼠标移动到工具栏或保存按钮时，需暂停自动滚动，并取消捕捉区域穿透
             if (0 != m_scrollShotStatus) {
                 m_scrollShotStatus = 4;

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -1523,6 +1523,17 @@ void SubToolWidget::setRecordAudioType(bool setMicAudio, bool setSysAudio)
         emit systemAudioActionChecked(setSysAudio);
     }
 }
+QRect SubToolWidget::getShotOptionRect(){
+    if(!m_shotOptionButton->menu()->isVisible())
+        return QRect();
+    QRect shotOptionRect {
+        static_cast<int>(m_shotOptionButton->menu()->x()),
+        static_cast<int>(m_shotOptionButton->menu()->y()),
+        static_cast<int>(m_shotOptionButton->menu()->width()),
+        static_cast<int>(m_shotOptionButton->menu()->height())
+    };
+    return shotOptionRect;
+}
 /*
 void SubToolWidget::setIsZhaoxinPlatform(bool isZhaoxin)
 {

--- a/src/widgets/subtoolwidget.h
+++ b/src/widgets/subtoolwidget.h
@@ -63,6 +63,11 @@ public:
     void setOcrScreenshotEnable(const bool &state);
 
     void setButEnableOnLockScreen(const bool &state);
+    /**
+     * @brief getShotOptionRect 获取选项菜单的位置及大小
+     * @return
+     */
+    QRect getShotOptionRect();
 signals:
     void keyBoardButtonClicked(bool checked);
     void mouseBoardButtonClicked(bool checked);

--- a/src/widgets/toolbar.cpp
+++ b/src/widgets/toolbar.cpp
@@ -237,6 +237,9 @@ void ToolBarWidget::setExpand(bool expand, QString shapeType)
     emit changeFunctionSignal(shapeType);
     update();
 }
+QRect ToolBarWidget::getShotOptionRect(){
+   return m_subTool->getShotOptionRect();
+}
 
 ToolBarWidget::~ToolBarWidget() {}
 
@@ -442,6 +445,10 @@ void ToolBar::setSystemAudioEnable(bool status)
 void ToolBar::setCameraDeviceEnable(bool status)
 {
     m_toolbarWidget->setCameraDeviceEnable(status);
+}
+
+QRect ToolBar::getShotOptionRect(){
+   return m_toolbarWidget->getShotOptionRect();
 }
 ToolBar::~ToolBar()
 {

--- a/src/widgets/toolbar.h
+++ b/src/widgets/toolbar.h
@@ -52,6 +52,11 @@ public:
     void setOcrScreenshotsEnable(const bool &state);
 
     void setButEnableOnLockScreen(const bool &state);
+    /**
+     * @brief getShotOptionRect 获取选项菜单的位置及大小
+     * @return
+     */
+    QRect getShotOptionRect();
 signals:
     void buttonChecked(QString shapeType);
     void expandChanged(bool expand,  QString shapeType);
@@ -119,6 +124,11 @@ public:
     void setOcrScreenshotsEnable(const bool &state);
 
     void setButEnableOnLockScreen(const bool &state);
+    /**
+     * @brief getShotOptionRect 获取选项菜单的位置及大小
+     * @return
+     */
+    QRect getShotOptionRect();
 signals:
     void buttonChecked(QString shape);
     void currentFunctionToMain(QString shapeType);


### PR DESCRIPTION
Description: 修复点击滚动截图选项菜单中的选项会触发自动滚动功能

Log: 修复点击滚动截图选项菜单中的选项会触发自动滚动功能

Bug: https://pms.uniontech.com/bug-view-199335.html