### PR TITLE
fix: 修复截图指定保存位置，hover到历史保存位置后，移动到“保存时更新位置”选项时，hover未消失

### DIFF
--- a/src/pin_screenshots/ui/subtoolwidget.cpp
+++ b/src/pin_screenshots/ui/subtoolwidget.cpp
@@ -9,6 +9,8 @@
 
 #include <QActionGroup>
 #include <QFileInfo>
+#include <QHelpEvent>
+#include <QToolTip>
 #include <DFontSizeManager>
 
 #define THEMETYPE 1 // 主题颜色为浅色
@@ -69,6 +71,7 @@ void SubToolWidget::initShotLable()
     m_saveToSpecialPathMenu->setTitle(tr("Folder"));
     m_saveToSpecialPathMenu->setToolTipsVisible(true);
     m_saveToSpecialPathMenu->menuAction()->setCheckable(true);
+    m_saveToSpecialPathMenu->installEventFilter(this);
     DFontSizeManager::instance()->bind(m_saveToSpecialPathMenu, DFontSizeManager::T8);
     QString specialPath = Settings::instance()->getSavePath();
     //设置或更新指定路径的菜单按键
@@ -274,4 +277,23 @@ void SubToolWidget::updateOptionChecked()
 
     m_SavePathActions.value(m_SaveInfo.first)->setChecked(true);
     m_SaveFormatActions.value(m_SaveInfo.second)->setChecked(true);
+}
+
+bool SubToolWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_saveToSpecialPathMenu) {
+        if(event->type() == QEvent::ToolTip){
+            QHelpEvent* he = dynamic_cast<QHelpEvent*>(event);
+            QAction *action = static_cast<QMenu *>(watched)->actionAt(he->pos());
+            if (action != nullptr) {
+                if (action == m_saveToSpecialPathAction) {
+                    QToolTip::showText(he->globalPos(), action->toolTip(), this);
+                }
+                if (action == m_changeSaveToSpecialPath) {
+                    QToolTip::hideText();
+                }
+            }
+        }
+    }
+    return false;
 }

--- a/src/pin_screenshots/ui/subtoolwidget.h
+++ b/src/pin_screenshots/ui/subtoolwidget.h
@@ -45,6 +45,7 @@ signals:
 protected:
     void initShotLable();
     void initChangeSaveToSpecialAction(const QString specialPath);
+    bool eventFilter(QObject *watched, QEvent *event) override;
 private:
     /**
      * @brief 贴图功能工具栏

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -31,6 +31,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QThread>
+#include <QToolTip>
 
 #include <unistd.h>
 
@@ -854,6 +855,7 @@ void SubToolWidget::initShotLabel()
     m_saveToSpecialPathMenu = new DMenu(m_optionMenu);
     m_saveToSpecialPathMenu->setTitle(tr("Folder"));
     m_saveToSpecialPathMenu->setToolTipsVisible(true);
+    m_saveToSpecialPathMenu->installEventFilter(this);
     m_saveToSpecialPathMenu->menuAction()->setCheckable(true);
     DFontSizeManager::instance()->bind(m_saveToSpecialPathMenu, DFontSizeManager::T8);
     QString specialPath = ConfigSettings::instance()->value("save", "specifiedSavepath").value<QString>();
@@ -1534,6 +1536,26 @@ QRect SubToolWidget::getShotOptionRect(){
     };
     return shotOptionRect;
 }
+
+bool SubToolWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == m_saveToSpecialPathMenu) {
+        if(event->type() == QEvent::ToolTip){
+            QHelpEvent* he = dynamic_cast<QHelpEvent*>(event);
+            QAction *action = static_cast<QMenu *>(watched)->actionAt(he->pos());
+            if (action != nullptr) {
+                if (action == m_saveToSpecialPathAction) {
+                    QToolTip::showText(he->globalPos(), action->toolTip(), this);
+                }
+                if (action == m_changeSaveToSpecialPath) {
+                    QToolTip::hideText();
+                }
+            }
+        }
+    }
+    return false;
+}
+
 /*
 void SubToolWidget::setIsZhaoxinPlatform(bool isZhaoxin)
 {

--- a/src/widgets/subtoolwidget.h
+++ b/src/widgets/subtoolwidget.h
@@ -118,6 +118,8 @@ protected:
      * @brief 用来设置 当前录制制视频所采集的音频信息
      */
     void setRecordAudioType(bool setMicAudio, bool setSysAudio);
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
 private:
     /**
      * @brief 录屏功能工具栏


### PR DESCRIPTION
Description: 修复截图指定保存位置，hover到历史保存位置后，移动到“保存时更新位置”选项时，hover未消失

Log: 修复截图指定保存位置，hover到历史保存位置后，移动到“保存时更新位置”选项时，hover未消失

Bug: https://pms.uniontech.com/bug-view-189167.html