### PR TITLE
fix: 快捷全屏录制时，不显示左上角捕捉区域大小提示、不画窗口的黑色背景

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -284,6 +284,7 @@ void MainWindow::initAttributes()
     m_sideBar->hide();
 
     m_sizeTips = new TopTips(this);
+    m_sizeTips->setFullScreenRecord(m_isFullScreenRecord);
     m_sizeTips->hide();
 
     if (m_functionType == status::record) {
@@ -1555,7 +1556,6 @@ void MainWindow::fullScreenRecord(const QString fileName)
     this->initAttributes();
     this->initResource();
     this->initLaunchMode("screenRecord");
-    recordButtonStatus = RECORD_BUTTON_RECORDING;
     this->showFullScreen();
     qApp->setOverrideCursor(BaseUtils::setCursorShape("start"));
 
@@ -3441,15 +3441,17 @@ void MainWindow::paintEvent(QPaintEvent *event)
         painter.setClipping(true);
         //使用指定的剪辑操作将剪辑区域设置为给定区域
         painter.setClipRegion(QRegion(backgroundRect).subtracted(QRegion(frameRect)));
-        //画出当前背景
-        painter.drawRect(backgroundRect);
+        //快捷全屏录制不需要画背景，非快捷全屏录制需要画背景
+        if(!m_isFullScreenRecord)
+            //画出当前背景
+            painter.drawRect(backgroundRect);
         // Reset clip. 重设剪辑区域
         painter.setClipRegion(QRegion(backgroundRect));
 
         //捕捉区域
         frameRect = QRect(recordX, recordY, recordWidth, recordHeight);
         // Draw frame. 画捕捉区域的虚线框；滚动截图模式中，已经开始滚动后，保存时不画虚线框
-        if (recordButtonStatus != RECORD_BUTTON_RECORDING && !(status::scrollshot == m_functionType && m_isSaveScrollShot)) {
+        if (!m_isFullScreenRecord && recordButtonStatus != RECORD_BUTTON_RECORDING && !(status::scrollshot == m_functionType && m_isSaveScrollShot)) {
             //qDebug() << "function: " << __func__ << " ,line: " << __LINE__;
             painter.setRenderHint(QPainter::Antialiasing, false);
             //QPen framePen(QColor("#01bdff"));

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -1044,7 +1044,8 @@ private:
     bool m_isScreenResolutionChanged = false;
 
     /**
-     * @brief m_isFullScreenRecord 全屏录制
+     * @brief m_isFullScreenRecord 快捷全屏录制
+     * 通过命令行deepin-screen-recorder --rf <filename>启动的全屏录制，未静默状态，不会显示任何相关提示
      */
     bool m_isFullScreenRecord = false;
 };

--- a/src/widgets/toptips.cpp
+++ b/src/widgets/toptips.cpp
@@ -55,6 +55,7 @@ void TopTips::setContent(const QSize &size)
 
 void TopTips::updateTips(QPoint pos, const QSize &size)
 {
+    if(m_isFullScreenRecord) return;
     if (!this->isVisible())
         this->show();
 
@@ -89,4 +90,9 @@ void TopTips::setRecorderTipsInfo(const bool showState)
     if(QSysInfo::currentCpuArchitecture().startsWith(QString("mips"))){
         m_showRecorderTips = showState;
     }
+}
+
+void TopTips::setFullScreenRecord(const bool flag)
+{
+    m_isFullScreenRecord = flag;
 }

--- a/src/widgets/toptips.h
+++ b/src/widgets/toptips.h
@@ -11,7 +11,9 @@
 #include <QLabel>
 
 DWIDGET_USE_NAMESPACE
-
+/**
+ * @brief The TopTips class 捕捉区域大小提示界面（除滚动截图外）
+ */
 class TopTips : public QLabel
 {
     Q_OBJECT
@@ -19,6 +21,7 @@ public:
     explicit TopTips(DWidget *parent = nullptr);
     ~TopTips() override;
     void setRecorderTipsInfo(const bool showState);
+    void setFullScreenRecord(const bool flag);
 public slots:
     void setContent(const QSize &rect);
     void updateTips(QPoint pos, const QSize &rect);
@@ -28,5 +31,11 @@ protected:
     bool m_showRecorderTips = false;
     int m_width = 0;
     int m_height = 0;
+
+    /**
+     * @brief m_isFullScreenRecord 快捷全屏录制的标志
+     * 快捷全屏录制时，不需要显示此界面
+     */
+    bool m_isFullScreenRecord = false;
 };
 #endif // TOPTIPS_H


### PR DESCRIPTION
Description: 快捷全屏录制时，不显示左上角捕捉区域大小提示、不画窗口的黑色背景

Log: 快捷全屏录制时，不显示左上角捕捉区域大小提示、不画窗口的黑色背景

Bug: https://pms.uniontech.com/bug-view-213709.html