### PR TITLE
fix: 修复截图设置保存时设置位置，在锁屏页面截图，进入系统，关闭截图保存操作框，会闪现锁屏页面

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -3122,6 +3122,7 @@ bool MainWindow::saveAction(const QPixmap &pix)
             // 保存到指定位置, 用户在选择保存目录时，点击取消。保存失败，且不显示通知信息
             m_noNotify = true;
             qInfo() << __FUNCTION__ << __LINE__ << "取消保存到指定位置！";
+            this->hide();
             return false;
         }
 


### PR DESCRIPTION
Description: 修复截图设置保存时设置位置，在锁屏页面截图，进入系统，关闭截图保存操作框，会闪现锁屏页面

Log: 修复截图设置保存时设置位置，在锁屏页面截图，进入系统，关闭截图保存操作框，会闪现锁屏页面

Bug: https://pms.uniontech.com/bug-view-213977.html