### PR TITLE
fix: 修复截图保存时设置位置，在锁屏页面截图，进入系统，保存截图，会闪现锁屏页面

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1835,6 +1835,7 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
             //eventloop.exec();
             //tempTimer->stop();
             //delete tempTimer;
+            this->hide(); //wayland下隐藏主界面
             time_t endTime = time(nullptr) + 1;
             qInfo() << __FUNCTION__ << __LINE__ << "开始延时1s等待数据保存到剪切板..." << endTime;
             time_t lastTime = 0;


### PR DESCRIPTION
Description: 修复截图保存时设置位置，在锁屏页面截图，进入系统，保存截图，会闪现锁屏页面

Log: 修复截图保存时设置位置，在锁屏页面截图，进入系统，保存截图，会闪现锁屏页面

Bug: https://pms.uniontech.com/bug-view-213977.html