### PR TITLE
fix: 修复电源界面进行截图->工具菜单里的“选项”功能未禁用

### DIFF
--- a/src/main_window.h
+++ b/src/main_window.h
@@ -523,6 +523,12 @@ public slots:
     void onLockScreenEvent(QDBusMessage msg);
 
     /**
+     * @brief onPowersource 监听电源管理界面，进入电源管理界面时会触发此信号槽
+     * @param flag
+     */
+    void onPowersource(bool flag);
+
+    /**
      * @brief 打开截图录屏帮助文档并定位到滚动截图
      */
     void onOpenScrollShotHelp();


### PR DESCRIPTION
Description: 由于DDE更新了电源管理界面的dbus信号，需要应用重新适配

Log: 修复电源界面进行截图->工具菜单里的“选项”功能未禁用

Bug: https://pms.uniontech.com/bug-view-222335.html