### PR TITLE
fix: 录制视频时选择显示点击，录屏过程中点击多任务视图，结束录屏后，键盘无法正常使用

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -940,7 +940,7 @@ void MainWindow::initResource()
     m_showButtons = new ShowButtons(this);
     connect(m_showButtons, SIGNAL(keyShowSignal(const QString &)), this, SLOT(showKeyBoardButtons(const QString &)));
     resizeHandleBigImg = DHiDPIHelper::loadNxPixmap(":/newUI/normal/node.svg");
-    buttonFeedback = new ButtonFeedback();
+    buttonFeedback = new ButtonFeedback(this);
 
     m_initResource = true;
 }


### PR DESCRIPTION
Description: 录制视频时选择显示点击，录屏过程中点击多任务视图，结束录屏后，键盘无法正常使用

Log: 录制视频时选择显示点击，录屏过程中点击多任务视图，结束录屏后，键盘无法正常使用

Bug: https://pms.uniontech.com/bug-view-227399.html
     https://pms.uniontech.com/bug-view-227375.html