### PR TITLE
fix: 修复录屏时点击计时图标没有退出录屏

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -74,7 +74,7 @@ protected:
     /**
      * @brief 创建缓存文件，只有wayland模式下的mips或部分arm架构适用
      */
-    void createCacheFile();
+    bool createCacheFile();
 private slots:
     /**
      * @brief onTimeout:更新数据

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -35,7 +35,7 @@ void ShotStartPlugin::init(PluginProxyInterface *proxyInter)
 {
 #ifndef UNIT_TEST
     bool ret;
-    qInfo() << "当前dock版本：" << qApp->property("dock_api_version").toInt(&ret);
+    qInfo() << "当前dock版本：" << qApp->property("dock_api_version").toInt(&ret) << ret;
     if(ret && qApp->property("dock_api_version") >= ((2<<16) | (0<<8) | (0))){
         m_bDockQuickPanel = true;
         qWarning() << "The current dock version does not support quick panels!!";


### PR DESCRIPTION
Description: 当前用户在.cache目录下无权限时，不采用文件共享的方式来停止录屏，而是直接发送停止的dbus信号

Log: 修复录屏时点击计时图标没有退出录屏

Bug: https://pms.uniontech.com/bug-view-231153.html