### PR TITLE
fix: 修复截图录屏选择区域进行截图时右下角闪屏

### DIFF
--- a/src/button_feedback.cpp
+++ b/src/button_feedback.cpp
@@ -50,7 +50,7 @@ ButtonFeedback::ButtonFeedback(DWidget *parent) : DWidget(parent)
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));
 
-    Utils::passInputEvent(static_cast<int>(this->winId()));
+    //Utils::passInputEvent(static_cast<int>(this->winId()));
     m_painter =  new QPainter();
 }
 


### PR DESCRIPTION
Description: 穿透效果已经在父窗口中实现，子窗口不用设置穿透

Log: 修复截图录屏选择区域进行截图时右下角闪屏

Bug: https://pms.uniontech.com/bug-view-231035.html
     https://pms.uniontech.com/bug-view-231041.html