### PR TITLE
fix: Fix dependency libprocps dev to libproc2 dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper, pkg-config, qt5-qmake,
  libxcb-util0-dev, libqt5x11extras5-dev, qttools5-dev-tools,
- libdtkgui-dev,libdtkwidget-dev, libxtst-dev, libprocps-dev,
+ libdtkgui-dev,libdtkwidget-dev, libxtst-dev, libprocps-dev | libproc2-dev,
  libdframeworkdbus-dev,libxcursor-dev,libxfixes-dev,libqt5multimediawidgets5,
  qtmultimedia5-dev,dde-dock-dev,qtbase5-dev-tools,
  libopencv-core-dev,libopencv-imgproc-dev,libopencv-calib3d-dev,libopencv-dev,


### PR DESCRIPTION
procps 源码升级后，构建出的软件包名改动，https://github.com/deepin-community/procps/commit/56f2908bc078821a3c4968f8900bd95bfa3e119e#diff-2a13f1344504379e877324d3a0375adcbcb4cb27d7e575ad8f4618a52d6a00e0

Log: fix dependency