### PR TITLE
fix: 修复滚动截屏时,自动调整捕捉区域图片预览右侧多出虚线

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -4964,7 +4964,9 @@ void MainWindow::onAdjustCaptureArea()
     QTimer::singleShot(delayTime, this, [ = ] {
         //更新预览图的位置及大小
         bool ok;
-        QRect previewRecordRect(recordX + 1, recordY + 1, recordWidth - 2, recordHeight - 2);
+        int scalingOffset =qRound(2 * m_pixelRatio);
+        qDebug() << "scalingOffset: " << scalingOffset;
+        QRect previewRecordRect(recordX + 1, recordY + 1, recordWidth - scalingOffset, recordHeight - scalingOffset);
         m_previewWidget->updatePreviewSize(previewRecordRect);
         m_firstScrollShotImg = m_screenGrabber.grabEntireDesktop(ok, previewRecordRect, m_pixelRatio);
         m_previewWidget->updateImage(m_firstScrollShotImg.toImage());


### PR DESCRIPTION
Description: 截图的区域没有将缩放比例带入计算

Log: 修复滚动截屏时,自动调整捕捉区域图片预览右侧多出虚线

Bug: https://pms.uniontech.com/bug-view-231759.html