### PR TITLE
fix: 修复正常录屏中时，录屏插件图标在任务栏的插件区默认还有底色区域，与新插件图标风格不一致

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -102,6 +102,7 @@ private:
     QBoxLayout *centralLayout;
     bool m_hover;
     bool m_pressed;
+    int m_systemVersion;
 };
 
 #endif // TIMEWIDGET_H


### PR DESCRIPTION
Description: 由于1070上dock的风格改变，不再需要黑色背景，因此录屏插件需要适配

Log: 修复正常录屏中时，录屏插件图标在任务栏的插件区默认还有底色区域，与新插件图标风格不一致

Bug: https://pms.uniontech.com/bug-view-232619.html