### PR TITLE
fix: 规范桌面入口文件的Desktop Action

### DIFF
--- a/deepin-screen-recorder.desktop
+++ b/deepin-screen-recorder.desktop
@@ -13,6 +13,7 @@ X-Deepin-ManualID=deepin-screen-recorder
 X-Deepin-Vendor=deepin
 X-Deepin-TurboType=dtkwidget
 NotShowIn=DeepinTablet
+Actions=delay-screenshot;fullscreen-screenshot;
 
 # Translations:
 # Do not manually modify!
@@ -125,7 +126,7 @@ Name[zh_CN]=截图录屏
 Name[zh_HK]=Deepin 螢幕錄影
 Name[zh_TW]=Deepin 螢幕錄影
 
-[X-Full Shortcut Group]
+[Desktop Action fullscreen-screenshot]
 Exec=dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.FullscreenScreenshot
 Name=Full Screenshot
 
@@ -161,7 +162,7 @@ Name[zh_CN]=全屏截图
 Name[zh_HK]=全屏截圖
 Name[zh_TW]=全屏截圖
 
-[X-Delay Shortcut Group]
+[Desktop Action delay-screenshot]
 Exec=dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.DelayScreenshot int64:5
 Name=Delay Screenshot
 


### PR DESCRIPTION
参考freedesktop桌面入口文件规范：
1、在[Desktop Entry]中增加应用动作描述：Actions=delay-screenshot;fullscreen-screenshot; 
2、修改组名[X-Delay Shortcut Group] -> [Desktop Action delay-screenshot] 
3、修改组名[X-Full Shortcut Group] -> [Desktop Action fullscreen-screenshot]