### PR TITLE
fix: 修复双屏跨屏全屏截图，无法保存到剪切板,增加系统限定范围

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include <DWindowManagerHelper>
 #include <DForeignWindow>
 #include <DHiDPIHelper>
+#include <DSysInfo>
 
 #include <QApplication>
 #include <QTimer>
@@ -1897,7 +1898,8 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
             cb->setMimeData(t_imageData, QClipboard::Clipboard);
             qDebug() << "Whether the data passed to the clipboard is empty? " << t_imageData->imageData().isNull();
             //临时方案对于多屏跨屏截图保存到剪切板需要进行一个延时
-            if(m_screenCount > 1){
+            if((DSysInfo::minorVersion().contains("1070") || DSysInfo::minorVersion().toInt() >= 1070) && m_screenCount > 1){
+                this->hide();
                 //捕捉区域的四个点（左上，左下，右上，右下）
                 QPoint recordPoints[4];
                 //左上


### PR DESCRIPTION
Description: 此方案是规避方案，在将数据传递到剪切板时，延时3s钟，确保数据完全传递到剪切板之后，截图录屏应用才退出。增加系统限定范 围及数据传递到剪切板时隐藏主界面。

Log: 修复双屏跨屏全屏截图，无法保存到剪切板,增加系统限定范围

Bug: https://pms.uniontech.com/bug-view-237073.html