### PR TITLE
fix: 修复双屏时，边缘截图无菜单显示

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2373,8 +2373,8 @@ void MainWindow::updateToolBarPos()
             }
         }
         if (!toolIsInScreen) {
-            if (!tempScreen.isNull() || tempScreen.isEmpty()) {
-                qDebug() << "当前屏幕：" <<  tempScreen;
+            if (!tempScreen.isNull() /*|| tempScreen.isEmpty()*/) {
+                //qDebug() << "当前屏幕：" <<  tempScreen;
                 if (recordY - tempScreen.y() >  m_toolBar->height() + 28) {
                     //qDebug() << "工具栏位置未在任一屏幕内，需要矫正 >>> 放捕捉区域上边 toolbarPoint: " << toolbarPoint;
                     toolbarPoint.setY(recordY - m_toolBar->height() - TOOLBAR_Y_SPACING);
@@ -2382,13 +2382,20 @@ void MainWindow::updateToolBarPos()
                     //qDebug() << "工具栏位置未在任一屏幕内，需要矫正 >>> 放捕捉区域里面 toolbarPoint: " << toolbarPoint;
                     toolbarPoint.setY(recordY + TOOLBAR_Y_SPACING);
                 }
+                if(recordX + recordWidth - m_toolBar->width() < tempScreen.x()){
+                    toolbarPoint.setX(recordX);
+                }
                 //qDebug() << "工具栏位置未在任一屏幕内，已矫正 >>> toolbarPoint: " << toolbarPoint;
+            }else{
+                toolbarPoint.setX(m_toolbarLastPoint.x());
+                toolbarPoint.setY(m_toolbarLastPoint.y());
             }
         }
     }
     //qDebug() << "工具栏最新坐标 >>> toolbarPoint: " << toolbarPoint;
     //快捷全屏录制不需要显示工具栏
     if(m_isFullScreenRecord) return;
+    m_toolbarLastPoint = toolbarPoint;
     m_toolBar->showAt(toolbarPoint);
     //qDebug() << "==================2=================";
 }

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -1083,6 +1083,10 @@ private:
      */
     bool m_isSaveClipboard = false;
 
+    /**
+     * @brief m_toolbarLastPoint 工具栏位置改变后，上一次工具栏的位置
+     */
+    QPoint m_toolbarLastPoint;
 };
 
 #endif //MAINWINDOW_H


### PR DESCRIPTION
Description: 由于工具栏的定位点参考捕捉区域的左上角，因此会出现工具栏显示在屏幕外部。注意：双屏扩展两个屏幕大小不一致或者错位排布 时，此时捕捉区域是允许移动到屏幕外部。因为工具栏的定位点参考捕捉区域的左上角，此时就需要考虑两个方面。1.当捕捉区域左上角移动到屏幕边缘，工具栏左对齐捕捉区域。2. 当捕捉区域左上角移动到屏幕外，工具栏采用上次的位置进行显示。

Log: 修复双屏时，边缘截图无菜单显示

Bug: https://pms.uniontech.com/bug-view-242535.html