### PR TITLE
fix: 修复截图中添加字体后，再改变字体颜色，保存出来的字体颜色未正确修改

### DIFF
--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -111,6 +111,7 @@ void ShapesWidget::updateSelectedShape(const QString &group,
         } else if (group == "text" && m_selectedShape.type == group && key == "color_index") {
             int tmpIndex = m_shapes[m_selectedOrder].index;
             if (m_editMap.contains(tmpIndex)) {
+                m_selectedShape.colorIndex = index;
                 m_editMap.value(tmpIndex)->setColor(BaseUtils::colorIndexOf(index));
                 m_editMap.value(tmpIndex)->update();
             }


### PR DESCRIPTION
Description: 修复截图中添加字体后，再改变字体颜色，保存出来的字体颜色未正确修改

Log: 修复截图中添加字体后，再改变字体颜色，保存出来的字体颜色未正确修改

Bug: https://pms.uniontech.com/bug-view-243845.html