### PR TITLE
fix: 修复v23贴图工具栏在高缩放比下，工具栏模糊及选项按钮显示不全

### DIFF
--- a/src/pin_screenshots/main.cpp
+++ b/src/pin_screenshots/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
     app->setApplicationName("deepin-screen-recorder");
     app->setProductName(QObject::tr("Pin Screenshots"));
     app->setApplicationVersion("1.0");
+    app->setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     QString logFilePath = Dtk::Core::DLogManager::getlogFilePath();
     QStringList list = logFilePath.split("/");

--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -74,7 +74,8 @@ void ToolBarWidget::onThemeTypeChange(DGuiApplicationHelper::ColorType themeType
 
 void ToolBarWidget::initToolBarWidget()
 {
-    this->setFixedSize(MIN_TOOLBAR_WIDGET_SIZE);
+//    this->setFixedSize(MIN_TOOLBAR_WIDGET_SIZE);
+    this->setMinimumSize(MIN_TOOLBAR_WIDGET_SIZE);
     m_subTool = new SubToolWidget(this);
     connect(m_subTool, SIGNAL(signalOcrButtonClicked()), this, SIGNAL(sendOcrButtonClicked()));
 


### PR DESCRIPTION
Description: 修复v23贴图工具栏在高缩放比下，工具栏模糊及选项按钮显示不全

Log: 修复v23贴图工具栏在高缩放比下，工具栏模糊及选项按钮显示不全

Bug: https://pms.uniontech.com/bug-view-219447.html
	https://pms.uniontech.com/bug-view-230457.html