### PR TITLE
fix: Wrong translation and icon in control-center

### DIFF
--- a/src/dde-dock-plugins/shotstartrecord/res.qrc
+++ b/src/dde-dock-plugins/shotstartrecord/res.qrc
@@ -8,5 +8,7 @@
         <file>res/screen-recording.svg</file>
         <file>res/status-screen-record.svg</file>
         <file>res/status-screen-record-dark.svg</file>
+        <file>res/shot-start-record-plugin.svg</file>
+        <file>res/shot-start-record-plugin-dark.svg</file>
     </qresource>
 </RCC>

--- a/src/dde-dock-plugins/shotstartrecord/res/shot-start-record-plugin-dark.svg
+++ b/src/dde-dock-plugins/shotstartrecord/res/shot-start-record-plugin-dark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>status-screen-recording</title>
+    <g id="status-screen-recording" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M8,1 C11.8659932,1 15,4.13400677 15,8 C15,11.8659932 11.8659932,15 8,15 C4.13400677,15 1,11.8659932 1,8 C1,4.13400675 4.13400675,1 8,1 Z M8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.68629152,14 8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.68629152 11.3137085,2 8,2 Z M8,4.5 C9.93299662,4.5 11.5,6.06700338 11.5,8 C11.5,9.93299662 9.93299662,11.5 8,11.5 C6.06700338,11.5 4.5,9.93299662 4.5,8 C4.5,6.06700338 6.06700338,4.5 8,4.5 Z" id="形状" fill="#FFFFFF" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/src/dde-dock-plugins/shotstartrecord/res/shot-start-record-plugin.svg
+++ b/src/dde-dock-plugins/shotstartrecord/res/shot-start-record-plugin.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>status-screen-recording-dark</title>
+    <g id="status-screen-recording-dark" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M8,1 C11.8659932,1 15,4.13400677 15,8 C15,11.8659932 11.8659932,15 8,15 C4.13400677,15 1,11.8659932 1,8 C1,4.13400675 4.13400675,1 8,1 Z M8,2 C4.6862915,2 2,4.6862915 2,8 C2,11.3137085 4.68629152,14 8,14 C11.3137085,14 14,11.3137085 14,8 C14,4.68629152 11.3137085,2 8,2 Z M8,4.5 C9.93299662,4.5 11.5,6.06700338 11.5,8 C11.5,9.93299662 9.93299662,11.5 8,11.5 C6.06700338,11.5 4.5,9.93299662 4.5,8 C4.5,6.06700338 6.06700338,4.5 8,4.5 Z" id="形状" fill="#000000" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecord.pro
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecord.pro
@@ -27,6 +27,9 @@ SOURCES += \
 target.path = /usr/lib/dde-dock/plugins/
 file.files += $$PWD/com.deepin.dde.dock.module.shot-start-record-plugin.gschema.xml
 file.path += /usr/share/glib-2.0/schemas/
+recordicon.files += $$PWD/res/shot-start-record-plugin.svg \
+                    $$PWD/res/shot-start-record-plugin-dark.svg
+recordicon.path += /usr/share/icons/hicolor/scalable/status
 
-INSTALLS += target file
+INSTALLS += target file recordicon
 RESOURCES += res.qrc

--- a/translations/deepin-screen-recorder_bo.ts
+++ b/translations/deepin-screen-recorder_bo.ts
@@ -141,11 +141,22 @@ or press the shortcut again to stop recording</source>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">བརྙན་བཤུས།</translation>
+        <translation>བརྙན་བཤུས།</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">བརྙན་ཕབ།</translation>
+        <translation>བརྙན་ཕབ།</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>བརྙན་བཤུས།</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>བརྙན་ཕབ།</translation>
     </message>
 </context>
 <context>
@@ -394,7 +405,7 @@ or press the shortcut again to stop recording</source>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished">བརྙན་ཕབ།</translation>
+        <translation>བརྙན་ཕབ།</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-screen-recorder_ug.ts
+++ b/translations/deepin-screen-recorder_ug.ts
@@ -140,11 +140,22 @@ or press the shortcut again to stop recording</source>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">رەسىم تۇتۇش</translation>
+        <translation>رەسىم تۇتۇش</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">سىنغا ئېلىش</translation>
+        <translation>سىنغا ئېلىش</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>رەسىم تۇتۇش</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>ئېكراننى سىنغا ئېلىش</translation>
     </message>
 </context>
 <context>
@@ -393,7 +404,7 @@ or press the shortcut again to stop recording</source>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished">سىنغا ئېلىش</translation>
+        <translation>سىنغا ئېلىش</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-screen-recorder_zh_CN.ts
+++ b/translations/deepin-screen-recorder_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -139,11 +141,22 @@ or press the shortcut again to stop recording</source>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation/>截图</translation>
+        <translation>截图</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation/>录屏</translation>
+        <translation>录屏</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>截图</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>录屏</translation>
     </message>
 </context>
 <context>
@@ -392,7 +405,7 @@ or press the shortcut again to stop recording</source>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation/></translation>
+        <translation>录屏</translation>
     </message>
 </context>
 <context>
@@ -404,14 +417,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Mosaic</source>
         <translation>马赛克</translation>
-    </message>
-</context>
-<context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -617,13 +622,6 @@ select the area to record</source>
     <message>
         <source>Exit</source>
         <translation>退出</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>新录音</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_zh_HK.ts
+++ b/translations/deepin-screen-recorder_zh_HK.ts
@@ -141,11 +141,22 @@ or press the shortcut again to stop recording</source>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">截圖</translation>
+        <translation>截圖</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">錄屏</translation>
+        <translation>錄屏</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>截圖</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>錄屏</translation>
     </message>
 </context>
 <context>
@@ -394,7 +405,7 @@ or press the shortcut again to stop recording</source>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished">錄屏</translation>
+        <translation>錄屏</translation>
     </message>
 </context>
 <context>

--- a/translations/deepin-screen-recorder_zh_TW.ts
+++ b/translations/deepin-screen-recorder_zh_TW.ts
@@ -141,11 +141,22 @@ or press the shortcut again to stop recording</source>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">截圖</translation>
+        <translation>截圖</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">錄屏</translation>
+        <translation>錄屏</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>截圖</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>錄屏</translation>
     </message>
 </context>
 <context>
@@ -394,7 +405,7 @@ or press the shortcut again to stop recording</source>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished">錄屏</translation>
+        <translation>錄屏</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
1. 修复翻译问题
2. 更新在控制中心显示的图标,截图的默认图标在dcc-dock-plugin 插件中已有，录屏图标需单独安装

Log: 修复翻译和显示问题