### PR TITLE
fix: Screenshot tray icon remains disabled after recorder crash.

### DIFF
--- a/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
@@ -64,6 +64,8 @@ void QuickPanelWidget::setIcon(const QIcon &icon)
 void QuickPanelWidget::setDescription(const QString &description)
 {
     m_description->setText(description);
+    // 同样更新提示文案
+    m_description->setToolTip(description);
 }
 
 /**


### PR DESCRIPTION
1. 截图托盘图标在录屏崩溃后仍保持禁用状态,回退之前的修改, 保留检测录屏正在进行中的代码
2. 调整日志等级并添加日志分类,以方便后端过滤日志数据

Log: 修复界面显示问题