### PR TITLE
fix: Task trayicon widget error

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -61,8 +61,6 @@ TimeWidget::TimeWidget(DWidget *parent):
    }
 
     m_currentIcon = m_lightIcon;
-    // 避免任务栏在左/右时出现挤压图标情况，调整最小大小
-    setMinimumSize(PLUGIN_BACKGROUND_MIN_SIZE, PLUGIN_BACKGROUND_MIN_SIZE);
     setMaximumSize(RECORDER_TIME_WIDGET_MAXWIDTH,RECORDER_TIME_WIDGET_MAXHEIGHT);
     if (position::left == m_position || position::right == m_position) {
         setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Maximum);
@@ -118,11 +116,11 @@ QSize TimeWidget::sizeHint() const
             height = width;
         }else{
             width = this->width();
-            height =width;
+            height = width;
         }
         if(m_systemVersion >= 1070){
-            width = RECORDER_TIME_VERTICAL_ICON_SIZE;
-            height =width;
+            width = RECORDER_TIME_VERTICAL_ICON_SIZE_1070;
+            height = width;
         }
         qInfo() << "left or right itemWidget width: " << width << " ,itemWidget height: " << height;
     }
@@ -153,7 +151,9 @@ void TimeWidget::onPositionChanged(int value)
     qInfo() << "====================== onPositionChanged ====start=================";
     m_position = value;
     if (position::left == m_position || position::right == m_position) {
-        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Maximum);
+        setGeometry(this->geometry().x(), this->geometry().y(), this->geometry().width(), RECORDER_TIME_VERTICAL_ICON_SIZE);
+        updateGeometry();
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
      }else {
         setGeometry(this->geometry().x(),this->geometry().y(),this->geometry().width(),RECORDER_TIME_WIDGET_MAXHEIGHT);
         updateGeometry();
@@ -424,4 +424,11 @@ bool TimeWidget::isWaylandProtocol()
     QString XDG_SESSION_TYPE = e.value(QStringLiteral("XDG_SESSION_TYPE"));
     QString WAYLAND_DISPLAY = e.value(QStringLiteral("WAYLAND_DISPLAY"));
     return XDG_SESSION_TYPE == QLatin1String("wayland") ||  WAYLAND_DISPLAY.contains(QLatin1String("wayland"), Qt::CaseInsensitive);
+}
+
+void TimeWidget::showEvent(QShowEvent *e)
+{
+    // 强制重新刷新 sizePolicy 和 size
+    onPositionChanged(m_position);
+    DWidget::showEvent(e);
 }

--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -66,7 +66,9 @@ public:
      * @return
      */
     bool isWaylandProtocol();
+    
 protected:
+    void showEvent(QShowEvent *) override;
     void paintEvent(QPaintEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;

--- a/src/dde-dock-plugins/shotstartrecord/com.deepin.dde.dock.module.shot-start-record-plugin.gschema.xml
+++ b/src/dde-dock-plugins/shotstartrecord/com.deepin.dde.dock.module.shot-start-record-plugin.gschema.xml
@@ -24,10 +24,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
       </description>
     </key>
     <key type="b" name="menu-enable">
-      <default>false</default>
-      <summary>Menu Disable</summary>
+      <default>true</default>
+      <summary>Menu Enable</summary>
       <description>
-          Control Menu Disable
+          Control Menu Enable
       </description>
     </key>
     <key type="b" name="visible">


### PR DESCRIPTION
之前的提交将 gschema 配置文件设置为false, 不会显示
任何菜单，调整文件配置。

Log: 修复托盘图标菜单问题
Bug: https://pms.uniontech.com/bug-view-250811.html

调整宽度计算值为1070的推荐值，同时回退之前设置
最小宽度的修改，修复图标显示过程中变更宽度的问题

Log: 修复图标显示问题
Bug: https://pms.uniontech.com/bug-view-250749.html