### PR TITLE
fix: [UI] fix shortcut evoke screen-recorder bug and displayed on the

### DIFF
--- a/com.deepin.ScreenRecorder.service
+++ b/com.deepin.ScreenRecorder.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.ScreenRecorder
-Exec=/usr/bin/dbus-send --session --type=method_call --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.LaunchApp string:"/usr/share/applications/deepin-screen-recorder.desktop" uint32:0 array:string:"--screenRecord"
+Exec=/usr/bin/deepin-screen-recorder --screenRecord

--- a/com.deepin.Screenshot.service
+++ b/com.deepin.Screenshot.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.Screenshot
-Exec=/usr/bin/dbus-send --session --type=method_call --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.LaunchApp string:"/usr/share/applications/deepin-screen-recorder.desktop" uint32:0 array:string:"--dbus"
+Exec=/usr/bin/deepin-screen-recorder --dbus

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -708,8 +708,6 @@ void RecordProcess::exitRecord(QString newSavePath)
     if (m_recordType == RECORD_TYPE_GIF) {
         QFile::remove(savePath);
     }
-    //保存到剪切板
-    save2Clipboard(newSavePath);
     if (Utils::isWaylandMode) {
 #ifdef KF5_WAYLAND_FLAGE_ON
         avlibInterface::unloadFunctions();
@@ -730,6 +728,8 @@ void RecordProcess::exitRecord(QString newSavePath)
                                                                           "onStop"));
     }
 
+    //保存到剪切板
+    save2Clipboard(newSavePath);
     qInfo() << __LINE__ << __func__ <<"录屏已退出";
     QApplication::quit();
     if (Utils::isWaylandMode) {


### PR DESCRIPTION
taskbar bug
fix: [UI] fix shortcut evoke screen-recorder bug and displayed on the taskbar bug

The icon for repairing screenshots will be displayed on the taskbar for more than 5 seconds before disappearing from bug. Fix the failure to use shortcut keys to evoke screenshots in 6.0.1deb format.

Log: The icon for repairing screenshots will be displayed on the taskbar for more than 5 seconds before disappearing from bug. Fix the failure to use shortcut keys to evoke screenshots in 6.0.1deb format.

Bug: https://pms.uniontech.com/bug-view-251835.html https://pms.uniontech.com/bug-view-250323.html