### PR TITLE
fix: 调整相机初始化和修复剪贴板无数据问题

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2010,13 +2010,19 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
             }
             qInfo() << __FUNCTION__ << __LINE__ << "1s延时完成" << time(nullptr);
         } else {
-            t_imageData->setImageData(pix);
+            // 图片数据过大时，可能影响后端剪贴板处理，调整为保存 PNG 图片
+            QByteArray bytes;
+            QBuffer buffer(&bytes);
+            buffer.open(QIODevice::WriteOnly);
+            pix.save(&buffer, "PNG");
+            t_imageData->setData("image/png", bytes);
+
             QClipboard *cb = qApp->clipboard();
             qInfo() << __FUNCTION__ << __LINE__ << "将数据传递到剪贴板！";
             cb->setMimeData(t_imageData, QClipboard::Clipboard);
             qDebug() << "Whether the data passed to the clipboard is empty? " << t_imageData->imageData().isNull();
-
         }
+
         if(DSysInfo::minorVersion().toInt() >= 1070){
             if (!Utils::isWaylandMode) {
                 this->hide(); //隐藏主界面

--- a/src/pin_screenshots/mainwindow.cpp
+++ b/src/pin_screenshots/mainwindow.cpp
@@ -220,7 +220,12 @@ void MainWindow::saveImg()
 
     // 保存到剪贴板
     QMimeData *t_imageData = new QMimeData;
-    t_imageData->setImageData(m_image);
+    // 图片数据过大时，可能影响后端剪贴板处理，调整为保存 PNG 图片
+    QByteArray bytes;
+    QBuffer buffer(&bytes);
+    buffer.open(QIODevice::WriteOnly);
+    m_image.save(&buffer, "PNG");
+    t_imageData->setData("image/png", bytes);
     QClipboard *cb = qApp->clipboard();
     cb->setMimeData(t_imageData, QClipboard::Clipboard);
 


### PR DESCRIPTION
相机调整为在录屏时初始化,截图时无需调用

Log: 调整应用初始化处理

旧版保存了图片的原始数据，在数据较大时对后端
剪贴板有影响。调整为使用转换PNG格式数据，降低
后端转换影响。

Log: 修改剪贴板无记录问题
Bug: https://pms.uniontech.com/bug-view-251565.html