### PR TITLE
fix: 修改截图编辑多行文字保存对齐问题

### DIFF
--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -1869,7 +1869,7 @@ void ShapesWidget::paintText(QPainter &painter, FourPoints rectFPoints, QString 
                static_cast<int>(rectFPoints[0].y()),
                static_cast<int>(rectFPoints[3].x() - rectFPoints[0].x()),
                static_cast<int>(rectFPoints[3].y() - rectFPoints[0].y()));
-    painter.drawText(rect, Qt::AlignCenter, text);
+    painter.drawText(rect, Qt::AlignLeft, text);
 }
 void ShapesWidget::paintEvent(QPaintEvent *)
 {


### PR DESCRIPTION
截图时，编辑多行文字，完成截图后，插入的文字为居中显示问题
保存和显示不一致问题

Log: 修改截图编辑多行文字保存对齐问题
Bug: https://pms.uniontech.com/bug-view-256283.html