### PR TITLE
fix: the window incorrect layer

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -253,7 +253,7 @@ void MainWindow::initAttributes()
             setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
         }
         if (this->windowHandle()) {
-            this->windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
+            this->windowHandle()->setProperty("_d_dwayland_window-type", "override");
             qDebug() << "设置窗口属性 _d_dwayland_window-type: " << this->windowHandle()->property("_d_dwayland_window-type");
         }
         //取消onScreenDisplay，解决wayland截长图无法滚动的问题


### PR DESCRIPTION
When the calendar is reminded, the screenshot is taken and the toolbar is not set at the top.

Log: When the calendar is reminded, the screenshot is taken and the toolbar is not set at the top.
Bug: https://pms.uniontech.com/bug-view-254705.html