### PR TITLE
fix: The quick panel plugin not show correct

### DIFF
--- a/src/dde-dock-plugins/shotstart/quickpanelwidget.cpp
+++ b/src/dde-dock-plugins/shotstart/quickpanelwidget.cpp
@@ -32,12 +32,12 @@ void QuickPanelWidget::initUI()
     DFontSizeManager::instance()->bind(m_description, DFontSizeManager::T10);
 
     auto layout = new QVBoxLayout;
-    layout->setMargin(10);
+    layout->setMargin(8);
     layout->setSpacing(0);
     layout->addStretch(1);
-    layout->addWidget(m_icon, 0, Qt::AlignHCenter);
+    layout->addWidget(m_icon, 0, Qt::AlignCenter);
     layout->addSpacing(8);
-    layout->addWidget(m_description, 0, Qt::AlignHCenter);
+    layout->addWidget(m_description, 0, Qt::AlignCenter);
     layout->addStretch(1);
 
     setLayout(layout);

--- a/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
@@ -39,12 +39,12 @@ void QuickPanelWidget::initUI()
     DFontSizeManager::instance()->bind(m_description, DFontSizeManager::T10);
 
     auto layout = new QVBoxLayout;
-    layout->setMargin(10);
+    layout->setMargin(8);
     layout->setSpacing(0);
     layout->addStretch(1);
-    layout->addWidget(m_icon, 0, Qt::AlignHCenter);
+    layout->addWidget(m_icon, 0, Qt::AlignCenter);
     layout->addSpacing(8);
-    layout->addWidget(m_description, 0, Qt::AlignHCenter);
+    layout->addWidget(m_description, 0, Qt::AlignCenter);
     layout->addStretch(1);
 
     setLayout(layout);


### PR DESCRIPTION
The font size of the system is set to the largest, and some of the text in the shortcut panel is incomplete.

Log: The quick panel plugin not show correct.
Bug: https://pms.uniontech.com/bug-view-260963.html