### PR TITLE
fix: [UI] fix shortcut evoke screen-recorder bug and…… (#475)

### DIFF
--- a/com.deepin.ScreenRecorder.service
+++ b/com.deepin.ScreenRecorder.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.ScreenRecorder
-Exec=/usr/bin/dbus-send --session --type=method_call --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.LaunchApp string:"/usr/share/applications/deepin-screen-recorder.desktop" uint32:0 array:string:"--screenRecord"
+Exec=/usr/bin/deepin-screen-recorder --screenRecord

--- a/com.deepin.Screenshot.service
+++ b/com.deepin.Screenshot.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.deepin.Screenshot
-Exec=/usr/bin/dbus-send --session --type=method_call --print-reply --dest=com.deepin.SessionManager /com/deepin/StartManager com.deepin.StartManager.LaunchApp string:"/usr/share/applications/deepin-screen-recorder.desktop" uint32:0 array:string:"--dbus"
+Exec=/usr/bin/deepin-screen-recorder --dbus

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -819,10 +819,6 @@ void RecordProcess::exitRecord(QString newSavePath)
     if (recordType == RECORD_TYPE_GIF) {
         QFile::remove(savePath);
     }
-    qInfo() << __LINE__ << __func__ << "正在保存到剪切板...";
-    //保存到剪切板
-    save2Clipboard(newSavePath);
-    qInfo() << __LINE__ << __func__ << "已保存到剪切板";
     if (Utils::isWaylandMode) {
 #ifdef KF5_WAYLAND_FLAGE_ON
         avlibInterface::unloadFunctions();
@@ -839,7 +835,10 @@ void RecordProcess::exitRecord(QString newSavePath)
         callTrayRecorderIcon(DBUS_FUNC_ON_STOP);
         qInfo() << __LINE__ << __func__ << "录屏计时图标已退出";
     }
-    qInfo() << __LINE__ << __func__ << "录屏结束!!!";
+
+    //保存到剪切板
+    save2Clipboard(newSavePath);
+    qInfo() << __LINE__ << __func__ <<"录屏已退出";
     QApplication::quit();
     if (Utils::isWaylandMode) {
         qInfo() << "wayland record exit! (_Exit(0))";


### PR DESCRIPTION
taskbar bug

The icon for repairing screenshots will be displayed on the taskbar for more than 5 seconds before disappearing from bug. Fix the failure to use shortcut keys to evoke screenshots in 6.0.1deb format.

Log: The icon for repairing screenshots will be displayed on the taskbar for more than 5 seconds before disappearing from bug. Fix the failure to use shortcut keys to evoke screenshots in 6.0.1deb format.

Bug: https://pms.uniontech.com/bug-view-251835.html https://pms.uniontech.com/bug-view-250323.html

cherry-pick from 8eb411ca3656d4dda31858d34eaa1bb789e49312 (https://github.com/linuxdeepin/deepin-screen-recorder/pull/475)