### PR TITLE
fix: the taskbar display incorrectly

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -37,7 +37,8 @@ TimeWidget::TimeWidget(DWidget *parent):
     m_position(-1),
     m_hover(false),
     m_pressed(false),
-    m_systemVersion(0)
+    m_systemVersion(0),
+    m_timerCount(0)
 {
     m_systemVersion = DSysInfo::minorVersion().toInt() ;
     qInfo() <<  "Current system version: " << m_systemVersion;
@@ -132,6 +133,7 @@ QSize TimeWidget::sizeHint() const
 
 void TimeWidget::onTimeout()
 {
+    m_timerCount++;
     if (m_bRefresh) {
         if (m_currentIcon == m_lightIcon)
             m_currentIcon = m_shadeIcon;
@@ -140,8 +142,7 @@ void TimeWidget::onTimeout()
     }
     m_bRefresh = !m_bRefresh;
     QTime showTime(0, 0, 0);
-    int time = m_baseTime.secsTo(QTime::currentTime());
-    showTime = showTime.addSecs(time);
+    showTime = showTime.addMSecs(m_timerCount * 400);
     m_showTimeStr = showTime.toString("hh:mm:ss");
     update();
 }
@@ -411,6 +412,7 @@ void TimeWidget::start()
     connect(m_timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
     m_baseTime = QTime::currentTime();
     m_timer->start(400);
+    m_timerCount = 0;
 }
 
 void TimeWidget::stop()

--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -106,7 +106,7 @@ private:
     bool m_hover;
     bool m_pressed;
     int m_systemVersion;
-
+    int m_timerCount;
     /**
      * @brief m_lightIcon1070 1070下录屏计时图标icon
      */


### PR DESCRIPTION
During screen recording, the system time was modified, 
and the screen recorthe taskbar was displayed incorrectly

Log: the temporal performance of recording gif
Bug: https://pms.uniontech.com/bug-view-258049.html
     https://pms.uniontech.com/bug-view-258049.html