### PR TITLE
fix: the grid block shadow in recorded gif

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -153,6 +153,8 @@ void RecordProcess::onStartTranscode()
     arg << savePath;
     arg << "-r";
     arg << "12";
+    arg << "-vf";
+    arg << "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse";
     arg << path.replace("mp4", "gif");
     transcodeProcess->start("ffmpeg", arg);
     //部分hw arm架构的机型需要这样设置


### PR DESCRIPTION
After discussion, we still use the color palette to ensure the effect.

Log: fix the grid block shadow in recorded gif.
Bug: https://pms.uniontech.com/bug-view-264145.html
     https://pms.uniontech.com/bug-view-262443.html