### PR TITLE
fix: 修复录屏时点击计时图标没有退出录屏

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -258,7 +258,10 @@ void TimeWidget::mousePressEvent(QMouseEvent *e)
 #if  defined (__mips__) || defined (__sw_64__) || defined (__loongarch_64__) || defined (__aarch64__) || defined (__loongarch__)
         if (isWaylandProtocol()) {
             flag = false;
-            createCacheFile();
+            if (!createCacheFile()) {
+                qInfo() << "Create cache file fail!";
+                flag = true;
+            };
         }
 #endif
         if (flag) {
@@ -276,7 +279,7 @@ void TimeWidget::mousePressEvent(QMouseEvent *e)
     qDebug() << "Click the taskbar plugin! The end!";
 }
 //创建缓存文件，只有wayland模式下的mips或部分arm架构适用
-void TimeWidget::createCacheFile()
+bool TimeWidget::createCacheFile()
 {
     qDebug() << "createCacheFile start!";
     QString userName = QDir::homePath().section("/", -1, -1);
@@ -296,13 +299,13 @@ void TimeWidget::createCacheFile()
     int fd = open(path.c_str(), O_RDWR | O_CREAT, 0644);
     if (fd == -1) {
         qDebug() << "open file fail!" << strerror(errno);
-        return;
+        return false;
     }
     //文件加锁
     int flock = lockf(fd, F_TLOCK, 0);
     if (flock == -1) {
         qDebug() << "lock file fail!" << strerror(errno);
-        return;
+        return false;
     }
     ssize_t ret = -1;
     //文件内容为1，读取文件时会停止录屏
@@ -311,12 +314,16 @@ void TimeWidget::createCacheFile()
     ret = write(fd, wBuffer, 2);
     if (ret < 0) {
         qDebug() << "write file fail!";
-        return ;
+        return false;
     }
     flock = lockf(fd, F_ULOCK, 0);
+    if (flock == -1) {
+        qDebug() << "unlock file fail!" << strerror(errno);
+        return false;
+     }
     ::close(fd);
     qDebug() << "createCacheFile end!";
-
+    return true;
 }
 
 void TimeWidget::mouseReleaseEvent(QMouseEvent *e)

--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -74,7 +74,7 @@ protected:
     /**
      * @brief 创建缓存文件，只有wayland模式下的mips或部分arm架构适用
      */
-    void createCacheFile();
+    bool createCacheFile();
 private slots:
     /**
      * @brief onTimeout:更新数据

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -4345,7 +4345,7 @@ bool MainWindow::eventFilter(QObject *, QEvent *event)
     // to avoid repaint many times in one event function.
 
     if (needRepaint) {
-#if defined __mips__
+#if defined (__mips__) || defined (__aarch64__)
         //在1052U2 mips上碰到问题使用repaint()会导致界面卡死，换成update()才可保证程序正常，为保证其他架构不受影响故做了区分处理。
         //该问题目前只出现在1052U2上，1051的系统使用相同应用程序包无此问题。
         update();


### PR DESCRIPTION
Log: 当前用户在.cache目录下无权限时，不采用文件共享的方式来停止录屏，而是直接发送停止的dbus信号

Bug: https://pms.uniontech.com/bug-view-231153.html