### PR TITLE
fix: the screen-capture icon in the taskbar

### DIFF
--- a/src/dde-dock-plugins/shotstart/iconwidget.cpp
+++ b/src/dde-dock-plugins/shotstart/iconwidget.cpp
@@ -36,7 +36,7 @@ IconWidget::IconWidget(QWidget *parent):
     setMinimumSize(PLUGIN_BACKGROUND_MIN_SIZE, PLUGIN_BACKGROUND_MIN_SIZE);
 
     QString iconName("screen-capture");
-    if(m_systemVersion >= 1070){
+    if(m_systemVersion >= 1070 || DSysInfo::deepinType() == DSysInfo::DeepinDesktop){
         iconName = "screenshot";
     }
     m_icon = QIcon::fromTheme(iconName, QIcon(QString(":/res/%1.svg").arg(iconName)));
@@ -143,7 +143,7 @@ void IconWidget::paintEvent(QPaintEvent *e)
 
     QPixmap pixmap;
     QString iconName = "screen-capture";
-    if(m_systemVersion >= 1070){
+    if(m_systemVersion >= 1070 || DSysInfo::deepinType() == DSysInfo::DeepinDesktop){
         iconName = "screenshot";
     }
     int iconSize = PLUGIN_ICON_MAX_SIZE;


### PR DESCRIPTION
Log: the screen-capture icon in the taskbar

Bug:https://pms.uniontech.com/bug-view-266991.html 
Issue:https://github.com/linuxdeepin/developer-center/issues/10072