### PR TITLE
fix: fix a crash

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -22,6 +22,7 @@
 #include "keydefine.h"
 #include "utils/eventlogutils.h"
 #include "widgets/imagemenu.h"
+#include <signal.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -4251,7 +4252,7 @@ void MainWindow::onKeyboardPress(unsigned char keyCode)
     if (status::record == m_functionType) {
         m_showButtons->showContentButtons(keyCode);
         recordKeyPressEvent(keyCode);
-        if (RECORD_BUTTON_RECORDING != recordButtonStatus && keyCode == KEY_ESCAPE) {
+        if (RECORD_BUTTON_RECORDING != recordButtonStatus && RECORD_BUTTON_SAVEING != recordButtonStatus && keyCode == KEY_ESCAPE) {
             exitApp();
         }
     } else if (status::shot == m_functionType || status::scrollshot == m_functionType) {


### PR DESCRIPTION
在保存时，不响应 ECS 事件。
防止 exitApp 导致 QProcess 被提前释放

Issues: linuxdeepin/developer-center#10385