### PR TITLE
fix: the Alt+Print shotcut get the wrong image

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1660,7 +1660,7 @@ void MainWindow::topWindow()
         // 经DTK确认，type存在bug。用flags替换，获取窗口类型功能。bug 77300；
         if (window->flags().testFlag(Qt::Window) || window->flags().testFlag(Qt::Desktop)) {
             // 排除dde-dock作为顶层窗口
-            if (window->wmClass() == "dde-dock") {
+            if (window->wmClass() == "dde-dock" || window->wmClass() == "dde-shell") {
                 continue;
             }
             //判断窗口是否被最小化


### PR DESCRIPTION
Log: fix the Alt+Print shotcut get the wrong image
Bug: https://pms.uniontech.com/bug-view-267329.html