### PR TITLE
fix: the taskbar display incorrectly

### DIFF
--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
@@ -66,6 +66,7 @@ QWidget *RecordTimePlugin::itemWidget(const QString &itemKey)
 void RecordTimePlugin::clear()
 {
     m_timeWidget->setting()->setValue(RECORDER_TIME_STARTCONFIG, QTime(0,0,0));
+    m_timeWidget->setting()->setValue(RECORDER_TIME_STARTCOUNTCONFIG, 0);
     if (nullptr != m_timer)
     {
         m_timer->stop();

--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -38,6 +38,7 @@ TimeWidget::TimeWidget(DWidget *parent):
     m_hover(false),
     m_pressed(false),
     m_systemVersion(0),
+    m_timerCount(0),
     m_setting(nullptr)
 {
     m_systemVersion = DSysInfo::minorVersion().toInt() ;
@@ -137,6 +138,7 @@ QSize TimeWidget::sizeHint() const
 
 void TimeWidget::onTimeout()
 {
+    m_timerCount++;
     if (m_bRefresh) {
         if (m_currentIcon == m_lightIcon)
             m_currentIcon = m_shadeIcon;
@@ -145,7 +147,8 @@ void TimeWidget::onTimeout()
     }
     m_bRefresh = !m_bRefresh;
     QTime showTime(0, 0, 0);
-    showTime = showTime.addSecs(m_baseTime.secsTo(QTime::currentTime()));
+    showTime = showTime.addMSecs(m_timerCount * 400);
+    m_setting->setValue(RECORDER_TIME_STARTCOUNTCONFIG, m_timerCount);
     m_showTimeStr = showTime.toString("hh:mm:ss");
     update();
 }
@@ -421,6 +424,13 @@ void TimeWidget::start()
         m_baseTime = QTime::currentTime();
     } else {
         m_baseTime = m_setting->value(RECORDER_TIME_STARTCONFIG).toTime();
+    }
+
+    if (m_setting->value(RECORDER_TIME_STARTCOUNTCONFIG).toInt() == 0) {
+        m_setting->setValue(RECORDER_TIME_STARTCOUNTCONFIG, 0);
+        m_timerCount = 0;
+    } else {
+        m_timerCount = m_setting->value(RECORDER_TIME_STARTCOUNTCONFIG).toInt();
     }
     m_showTimeStr = QString("00:00:00");
     connect(m_timer, SIGNAL(timeout()), this, SLOT(onTimeout()));

--- a/src/dde-dock-plugins/recordtime/timewidget.h
+++ b/src/dde-dock-plugins/recordtime/timewidget.h
@@ -26,6 +26,7 @@
 #define RECORDER_TIME_WIDGET_MAXHEIGHT 40
 #define RECORDER_TIME_WIDGET_MAXWIDTH 120
 #define RECORDER_TIME_STARTCONFIG "CurrentStartTime"
+#define RECORDER_TIME_STARTCOUNTCONFIG "CurrentStartCount"
 DWIDGET_USE_NAMESPACE
 using DBusDock = com::deepin::dde::daemon::Dock;
 
@@ -111,6 +112,7 @@ private:
     bool m_hover;
     bool m_pressed;
     int m_systemVersion;
+    int m_timerCount;
     QSettings *m_setting;
     /**
      * @brief m_lightIcon1070 1070下录屏计时图标icon


### PR DESCRIPTION
During screen recording, the system time was modified, and the screen recorthe taskbar was displayed incorrectly. This modify clash with the bug-262791

Log: fix the taskbar display incorrectly
Bug: https://pms.uniontech.com/bug-view-258049.html 
https://pms.uniontech.com/bug-view-262791.html