### PR TITLE
fix: the 'alt print' shotcut not quit

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1814,6 +1814,10 @@ void MainWindow::topWindow()
     const auto r = saveAction(screenShotPix);
     save2Clipboard(screenShotPix);
     sendNotify(m_saveIndex, m_saveFileName, r);
+
+    QTimer::singleShot(10, [ = ] {
+        exitApp();
+    });
 }
 
 void MainWindow::saveTopWindow()


### PR DESCRIPTION
fix the 'alt print' shotcut not quit

Log: fix the 'alt print' shotcut not quit
Bug: https://pms.uniontech.com/bug-view-279221.html