### PR TITLE
Fix  record error and bump verison

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+deepin-screen-recorder (6.5.0) unstable; urgency=medium
+
+  * feat: [translation]add transifex config(Task: 361363)
+  * fix: the config button status(Bug: 270437)
+  * fix: the mouse click control lose in workspace(Bug: 268293)
+  * fix: Optimize command line acquisition parameters(Task: 362613)
+  * fix: the pinscreenshot tips(Bug: 275657)
+  * fix: the pinscreenshot save format error(Bug: 276833)
+  * fix: the offset problem when dual-screen non-alignment(Bug: 275805)
+  * fix: the dual screen expandsion position when scaled(Bug: 273083)
+  * refactor: merge code and fix bugs
+  * fix: dde-shell not show screen shot icon.
+  * fix: camera not display image
+  * fix: save to clipboard slow
+  * fix: audio record pts error on wayland
+
+ -- renbin <renbin@uniontech.com>  Fri, 18 Oct 2024 14:29:23 +0800
+
 deepin-screen-recorder (6.0.9) unstable; urgency=medium
 
   * changelog 6.0.9.

--- a/src/event_monitor.cpp
+++ b/src/event_monitor.cpp
@@ -33,7 +33,8 @@ void EventMonitor::releaseRes()
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XRecordFreeContext ...";
         XRecordFreeContext(m_display, m_context);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XSync ...";
-        XSync(m_display, False);
+        XSync(m_display, True);
+        XSync(m_display_datalink, True);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display_datalink...";
         XCloseDisplay(m_display_datalink);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display...";

--- a/src/record_process.h
+++ b/src/record_process.h
@@ -30,19 +30,10 @@ class RecordProcess  : public QObject
     Q_OBJECT
 
 public:
-    static const int RECORD_TYPE_GIF;
-    static const int RECORD_TYPE_MP4;
-    static const int RECORD_TYPE_MKV;
-
     static const int RECORD_MOUSE_NULL;
     static const int RECORD_MOUSE_CURSE;
     static const int RECORD_MOUSE_CHECK;
     static const int RECORD_MOUSE_CURSE_CHECK;
-
-    static const int RECORD_AUDIO_NULL;
-    static const int RECORD_AUDIO_MIC;
-    static const int RECORD_AUDIO_SYSTEMAUDIO;
-    static const int RECORD_AUDIO_MIC_SYSTEMAUDIO;
 
     static const int RECORD_FRAMERATE_5;
     static const int RECORD_FRAMERATE_10;

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,7 +5,7 @@
 
 #ifndef UTILS_H
 #define UTILS_H
-//#include <dwindowmanager.h>
+// #include <dwindowmanager.h>
 #include <DPushButton>
 #include <DImageButton>
 
@@ -22,7 +22,23 @@ DCORE_USE_NAMESPACE
 class Utils : public QObject
 {
     Q_OBJECT
+
 public:
+    // the file format of the recorded video
+    enum RecordVideoType {
+        kGIF = 0,
+        kMP4 = 1,
+        kMKV = 2,
+    };
+
+    // the audio input source at recording
+    enum AudioRecordType {
+        kNoAudio = 0,
+        kMic = 1,          // microphone
+        kSystemAudio = 2,  // system audio
+        kMicAndSystemAudio = 3,
+    };
+
     struct ScreenInfo
     {
         int x;

--- a/src/utils/audioutils.cpp
+++ b/src/utils/audioutils.cpp
@@ -24,7 +24,9 @@
 AudioUtils::AudioUtils(QObject *parent)
 {
     Q_UNUSED(parent);
-    initAudioDBusInterface();
+    if (Utils::isSysGreatEqualV23()) {
+        initAudioDBusInterface();
+    }
 }
 
 // 初始化音频dbus服务的接口

--- a/src/utils/configsettings.cpp
+++ b/src/utils/configsettings.cpp
@@ -13,21 +13,6 @@
 #include <QTemporaryFile>
 #include <QDebug>
 
-/*
-RECORD_TYPE_GIF = 0;
-RECORD_TYPE_MP4 = 1;
-RECORD_TYPE_MKV = 2;
-
-RECORD_MOUSE_NULL = 0;
-RECORD_MOUSE_CURSE = 1;
-RECORD_MOUSE_CHECK = 2;
-RECORD_MOUSE_CURSE_CHECK = 3;
-
-RECORD_AUDIO_NULL = 0;
-RECORD_AUDIO_MIC = 1;
-RECORD_AUDIO_SYSTEMAUDIO = 2;
-RECORD_AUDIO_MIC_SYSTEMAUDIO = 3;
-*/
 ConfigSettings::ConfigSettings(QObject *parent)
     : QObject(parent)
 {

--- a/src/waylandrecord/avoutputstream.cpp
+++ b/src/waylandrecord/avoutputstream.cpp
@@ -23,6 +23,8 @@ DTS是AVPacket里的一个成员，表示这个压缩包应该什么时候被解
 #include <QDebug>
 #include <QThread>
 
+#include "utils.h"
+
 CAVOutputStream::CAVOutputStream(WaylandIntegration::WaylandIntegrationPrivate *context):
     m_context(context),
     m_pSysAudioSwrContext(nullptr),
@@ -74,7 +76,7 @@ CAVOutputStream::CAVOutputStream(WaylandIntegration::WaylandIntegrationPrivate *
     m_nLastAudioCardPresentationTime = 0;
     m_nLastAudioMixPresentationTime = 0;
     m_mixCount = 0;
-    m_videoType = videoType::MP4;
+    m_videoType = Utils::kMP4;
     m_left = 0;
     m_top = 0;
     m_right = 0;
@@ -913,7 +915,7 @@ int CAVOutputStream::writeMicAudioFrame(AVStream *stream, AVFrame *inputFrame, i
             outputPacket.stream_index = m_micAudioStream->index;
             printf("output_packet.stream_index1  audio_st =%d\n", outputPacket.stream_index);
             //outputPacket.pts = avlibInterface::m_av_rescale_q(m_nLastAudioPresentationTime, rational, m_micAudioStream->time_base);
-            if (m_videoType == videoType::MKV) {
+            if (m_videoType == Utils::kMKV) {
                 //显示时间戳，应大于或等于解码时间戳
                 outputPacket.pts = m_singleCount * m_pMicCodecContext->frame_size * 1000 / m_pMicCodecContext->sample_rate;
             } else {
@@ -1169,7 +1171,7 @@ void CAVOutputStream::writeMixAudio()
                 if (got_packet_ptr) {
                     packet_out.stream_index = audio_amix_st->index;
 
-                    if (m_videoType == videoType::MKV) {
+                    if (m_videoType == Utils::kMKV) {
                         //显示时间戳，应大于或等于解码时间戳
                         packet_out.pts = m_mixCount * pCodecCtx_amix->frame_size * 1000 / pFrame_out->sample_rate;
                     } else {
@@ -1235,7 +1237,7 @@ int  CAVOutputStream::writeSysAudioFrame(AVStream *stream, AVFrame *inputFrame, 
         assert(m_pSysCodecContext->sample_rate == stream->codec->sample_rate);
         avlibInterface::m_swr_init(m_pSysAudioSwrContext);
         if (nullptr == m_sysAudioFifo) {
-            if (m_videoType == videoType::MKV) {
+            if (m_videoType == Utils::kMKV) {
                 m_sysAudioFifo = audioFifoAlloc(m_pSysCodecContext->sample_fmt, m_pSysCodecContext->channels,  inputFrame->nb_samples);
                 m_initFifoSpace = audioFifoSpace(m_sysAudioFifo);
             } else {
@@ -1277,7 +1279,7 @@ int  CAVOutputStream::writeSysAudioFrame(AVStream *stream, AVFrame *inputFrame, 
     * the old and the new samples.使FIFO尽可能大，因为它需要容纳旧的和新的样品。
     */
     //qDebug() << "m_videoType: " << m_videoType;
-    if (m_videoType == videoType::MKV) {
+    if (m_videoType == Utils::kMKV) {
         //对比某个时间段缓冲区大小是否比初始化缓冲区大小大，大：需要减小当前的缓冲区，小不做操作
         if (m_initFifoSpace < audioFifoSpace(m_sysAudioFifo)) {
             if ((ret = audioFifoRealloc(m_sysAudioFifo, m_initFifoSpace + inputFrame->nb_samples)) < 0) {
@@ -1373,7 +1375,7 @@ int  CAVOutputStream::writeSysAudioFrame(AVStream *stream, AVFrame *inputFrame, 
         if (enc_got_frame_a) {
             outputPacket.stream_index = m_sysAudioStream->index;
             //            outputPacket.pts = m_singleCount * m_pSysCodecContext->frame_size * 1000 / m_pSysCodecContext->sample_rate;
-            if (m_videoType == videoType::MKV) {
+            if (m_videoType == Utils::kMKV) {
                 //显示时间戳，应大于或等于解码时间戳
                 outputPacket.pts = m_singleCount * m_pSysCodecContext->frame_size * 1000 / m_pSysCodecContext->sample_rate;
             } else {

--- a/src/waylandrecord/recordadmin.cpp
+++ b/src/waylandrecord/recordadmin.cpp
@@ -14,6 +14,8 @@
 #include <qtimer.h>
 #include <QDebug>
 
+#include "utils.h"
+
 RecordAdmin::RecordAdmin(QStringList list, WaylandIntegration::WaylandIntegrationPrivate *context, QObject *parent): QObject(parent),
     m_pInputStream(nullptr),
     m_pOutputStream(nullptr),
@@ -35,9 +37,9 @@ RecordAdmin::RecordAdmin(QStringList list, WaylandIntegration::WaylandIntegratio
         m_inputDeviceName = list[8];
         m_outputDeviceName = list[9];
     }
-    if (videoType::GIF == m_videoType) {
+    if (Utils::kGIF == m_videoType) {
         m_fps = 24;
-        m_audioType = audioType::NOS;
+        m_audioType = Utils::kNoAudio;
         m_filePath = m_filePath.replace("gif", "mp4");
     }
     m_pInputStream  = new CAVInputStream(context);
@@ -68,19 +70,19 @@ RecordAdmin::~RecordAdmin()
 void RecordAdmin::setRecordAudioType(int audioType)
 {
     switch (audioType) {
-    case audioType::MIC:
+    case Utils::kMic:
         setMicAudioRecord(true);
         setSysAudioRecord(false);
         break;
-    case audioType::SYS:
+    case Utils::kSystemAudio:
         setMicAudioRecord(false);
         setSysAudioRecord(true);
         break;
-    case audioType::MIC_SYS:
+    case Utils::kMicAndSystemAudio:
         setMicAudioRecord(true);
         setSysAudioRecord(true);
         break;
-    case audioType::NOS:
+    case Utils::kNoAudio:
         setMicAudioRecord(false);
         setSysAudioRecord(false);
         break;

--- a/src/waylandrecord/waylandintegration_p.h
+++ b/src/waylandrecord/waylandintegration_p.h
@@ -17,23 +17,6 @@
 #include <QMutex>
 #include <EGL/egl.h>
 
-enum audioType {
-    //麦克风
-    MIC = 2,
-    //系统音频
-    SYS,
-    //麦克风+系统音频
-    MIC_SYS,
-    //不录音
-    NOS
-};
-
-enum videoType {
-    GIF = 1,
-    MP4,
-    MKV
-};
-
 class RecordAdmin;
 class ScreenCastStream;
 


### PR DESCRIPTION
[fix: audio record pts error on wayland](https://github.com/linuxdeepin/deepin-screen-recorder/commit/734f5279a0727966fed0bf7fa2b6c731ec5d02d7) 

The recorded audio enumeration type is inconsistent.
The backend processing has incorrect set values,
Causes audio recording errors.

Log: Fix audio record error.

[chore: Bump version to 6.5.0](https://github.com/linuxdeepin/deepin-screen-recorder/commit/c976db349e1d5ed5bf20feceac329aa121955a0e) 

Bump version to 6.5.0

Log: Bump version to 6.5.0