### PR TITLE
fix: adapt new quick pannel plugin interface

### DIFF
--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -126,6 +126,18 @@ void ShotStartPlugin::pluginStateSwitched()
     }
 }
 
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+
+/**
+ * @return The Tray plugin supports the quick panel type
+ */
+Dock::PluginFlags ShotStartPlugin::flags() const
+{
+    return Dock::Type_Quick | Dock::Quick_Panel_Single | Dock::Attribute_Normal;
+}
+
+#endif
+
 QWidget *ShotStartPlugin::itemWidget(const QString &itemKey)
 {
     if (itemKey == QUICK_ITEM_KEY) {

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.h
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
+// Copyright (C) 2020 ~ 2024 Uniontech Software Technology Co.,Ltd.
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -10,9 +10,19 @@
 #include "quickpanelwidget.h"
 #include "tipswidget.h"
 #include <QtDBus/QtDBus>
-#include <dde-dock/pluginsiteminterface.h>
 
+#include <dde-dock/constants.h>
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+#include <dde-dock/pluginsiteminterface_v2.h>
+#else
+#include <dde-dock/pluginsiteminterface.h>
+#endif
+
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+class ShotStartPlugin : public QObject, PluginsItemInterfaceV2
+#else
 class ShotStartPlugin : public QObject, PluginsItemInterface
+#endif
 {
     Q_OBJECT
     Q_INTERFACES(PluginsItemInterface)
@@ -45,6 +55,10 @@ public:
     bool pluginIsAllowDisable() override { return true; }
     bool pluginIsDisable() override;
     void pluginStateSwitched() override;
+
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+    Dock::PluginFlags flags() const override;
+#endif
 
     /**
      * Dock::Type_Quick=0x02           插件类型-快捷插件区;

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp
@@ -141,6 +141,18 @@ void ShotStartRecordPlugin::pluginStateSwitched()
     }
 }
 
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+
+/**
+ * @return The Tray plugin supports the quick panel type
+ */
+Dock::PluginFlags ShotStartRecordPlugin::flags() const
+{
+    return Dock::Type_Quick | Dock::Quick_Panel_Single | Dock::Attribute_Normal;
+}
+
+#endif
+
 /**
  * @brief itemWidget:返回插件主控件，用于dde-dock面板上显示
  * @param itemKey:控件名称

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
@@ -8,10 +8,21 @@
 #include "recordiconwidget.h"
 #include "quickpanelwidget.h"
 #include "tipswidget.h"
-#include <QtDBus/QtDBus>
-#include <dde-dock/pluginsiteminterface.h>
 
+#include <QtDBus/QtDBus>
+
+#include <dde-dock/constants.h>
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+#include <dde-dock/pluginsiteminterface_v2.h>
+#else
+#include <dde-dock/pluginsiteminterface.h>
+#endif
+
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+class ShotStartRecordPlugin : public QObject, PluginsItemInterfaceV2
+#else
 class ShotStartRecordPlugin : public QObject, PluginsItemInterface
+#endif
 {
     Q_OBJECT
     Q_INTERFACES(PluginsItemInterface)
@@ -30,6 +41,10 @@ public:
     bool pluginIsAllowDisable() override { return true; }
     bool pluginIsDisable() override;
     void pluginStateSwitched() override;
+
+#if defined(DOCK_API_VERSION) && (DOCK_API_VERSION >= DOCK_API_VERSION_CHECK(2, 0, 0))
+    Dock::PluginFlags flags() const override;
+#endif
 
     /**
      * Dock::Type_Quick=0x02           插件类型-快捷插件区;
@@ -66,15 +81,15 @@ private:
     bool getTrayIconVisible();
 
 private:
-    QScopedPointer<RecordIconWidget> m_iconWidget;        // 任务栏图标
-    QScopedPointer<QuickPanelWidget> m_quickPanelWidget;  // 快捷面板
+    QScopedPointer<RecordIconWidget> m_iconWidget;       // 任务栏图标
+    QScopedPointer<QuickPanelWidget> m_quickPanelWidget; // 快捷面板
     QScopedPointer<TipsWidget> m_tipsWidget;
-    bool m_isRecording;    // true:正在录屏 false:未启动录屏
-    QTimer *m_checkTimer;  // 此定时器的作用为每隔1秒检查下截图录屏是否还在运行中。避免截图录屏崩溃后导致本插件还在执行
-    int m_nextCount = 0;   // 用来判断录屏是否正在进行中
-    int m_count = 0;       // 用来判断录屏是否正在进行中
-    bool m_bDockQuickPanel;              // 兼容性适配，老版的dock不支持快捷面板
-    bool m_bPreviousIsVisable = false;  // 记录前置状态是否为禁止使能状态
+    bool m_isRecording;                // true:正在录屏 false:未启动录屏
+    QTimer *m_checkTimer;              // 此定时器的作用为每隔1秒检查下截图录屏是否还在运行中。避免截图录屏崩溃后导致本插件还在执行
+    int m_nextCount = 0;               // 用来判断录屏是否正在进行中
+    int m_count = 0;                   // 用来判断录屏是否正在进行中
+    bool m_bDockQuickPanel;            // 兼容性适配，老版的dock不支持快捷面板
+    bool m_bPreviousIsVisable = false; // 记录前置状态是否为禁止使能状态
 };
 
-#endif  // RECORDTIME_H
+#endif // RECORDTIME_H


### PR DESCRIPTION
As title.
Tray icon manager updated from dde-dock to dde-tray-loader, no longer compatible with previous settings.
This commit updates the interface to PluginsItemInterfaceV2.

Log: Adapt new quick pannel plugin interface.
Bug: https://pms.uniontech.com/bug-view-266839.html