### PR TITLE
fix: Optimize GIF conversion filter parameters

### DIFF
--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -149,8 +149,8 @@ void RecordProcess::onStartTranscode()
     arg << savePath;
     arg << "-r";
     arg << "12";
-    arg << "-vf";
-    arg << "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse";
+    arg << "-filter_complex";
+    arg << "[0:v] split [a][b];[a] palettegen=stats_mode=diff [p];[b][p] paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle";
     arg << path.replace("mp4", "gif");
     transcodeProcess->start("ffmpeg", arg);
     //部分hw arm架构的机型需要这样设置


### PR DESCRIPTION
- Change -vf to -filter_complex to support more complex filter chains
- Update palettegen parameters to use stats_mode=diff mode
- Optimize paletteuse parameters by adding:
  - bayer dithering algorithm
  - bayer_scale=5
  - rectangle diff mode
- These changes improve GIF output quality and color fidelity

Log: Optimize GIF conversion filter parameters
Bug: https://pms.uniontech.com/bug-view-291463.html
Influence: save-gif