### PR TITLE
fix: GIF conversion and tray icon

### DIFF
--- a/src/dde-dock-plugins/shotstart/iconwidget.cpp
+++ b/src/dde-dock-plugins/shotstart/iconwidget.cpp
@@ -43,6 +43,9 @@ IconWidget::IconWidget(DWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(m_iconLabel);
 
+    // FIXME: temporarily disable m_iconLabel
+    m_iconLabel->setVisible(false);
+
     // 初始化
     m_systemVersion = DSysInfo::minorVersion().toInt();
     setMouseTracking(true);

--- a/src/dde-dock-plugins/shotstartrecord/recordiconwidget.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/recordiconwidget.cpp
@@ -44,6 +44,9 @@ RecordIconWidget::RecordIconWidget(DWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(m_iconLabel);
 
+    // FIXME: temporarily disable m_iconLabel
+    m_iconLabel->setVisible(false);
+
     // 连接 DBus 信号
     connect(m_dockInter, SIGNAL(propertyChanged(QString,QVariant)),
             this, SLOT(onPropertyChanged(QString,QVariant)));

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -153,8 +153,8 @@ void RecordProcess::onStartTranscode()
     arg << savePath;
     arg << "-r";
     arg << "12";
-    arg << "-vf";
-    arg << "split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse";
+    arg << "-filter_complex";
+    arg << "[0:v] split [a][b];[a] palettegen=stats_mode=diff [p];[b][p] paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle";
     arg << path.replace("mp4", "gif");
     transcodeProcess->start("ffmpeg", arg);
     //部分hw arm架构的机型需要这样设置


### PR DESCRIPTION
[fix: Optimize GIF conversion filter parameters](https://github.com/linuxdeepin/deepin-screen-recorder/commit/33e796cbbf3158a2812e37c938fbd77d0d341c7a) 

- Change -vf to -filter_complex to support more complex filter chains
- Update palettegen parameters to use stats_mode=diff mode
- Optimize paletteuse parameters by adding:
  - bayer dithering algorithm
  - bayer_scale=5
  - rectangle diff mode
- These changes improve GIF output quality and color fidelity

Log: Optimize GIF conversion filter parameters
Bug: https://pms.uniontech.com/bug-view-291463.html

[fix: tray icon incorrect](https://github.com/linuxdeepin/deepin-screen-recorder/commit/2373caaa18f2bb08505cdeb6b2dd4b905732b7a2) 

The tray icon updated but not fully tested,
we are temporarily disable the new icon label.
Resume later.

Log: Fix tray icon incorrect.
Bug: https://pms.uniontech.com/bug-view-295421.html