### PR TITLE
fix: Simplify mouse release event handling in TimeWidget

### DIFF
--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -355,13 +355,6 @@ bool TimeWidget::createCacheFile()
 void TimeWidget::mouseReleaseEvent(QMouseEvent *e)
 {
     qDebug() << "Mouse release start!";
-    if(e->button() == Qt::LeftButton && m_pressed && m_hover){
-        m_pressed = false;
-        m_hover = false;
-        update();
-        QWidget::mouseReleaseEvent(e);
-        return;
-    }
     int width = 0;
     if(m_systemVersion >= 1070){
         width = rect().width();


### PR DESCRIPTION
- Removed unnecessary checks for left button press and hover state in mouseReleaseEvent.
- Streamlined the event handling logic to improve code readability and maintainability.

This change enhances the clarity of the mouse event handling in the TimeWidget class. Log: Simplify mouse release event handling in TimeWidget Bug: https://pms.uniontech.com/bug-view-297809.html