### PR TITLE
fix: save path settings and scale factor

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2544,7 +2544,7 @@ void MainWindow::updateToolBarPos()
         checkIsLockScreen();
         qDebug() << "工具栏已初始化";
     }
-       qDebug() << "m_toolBar: " << m_toolBar->isVisible();
+
     // 有个问题需要考虑下，工具栏是否只要被拖动之后都无法回归默认位置？ //已确认不需要回归默认位置
     if (/*!isPressMouseLeftButton && */ m_isDragToolBar) {
         if (!m_toolBar->isVisible()) {

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -830,7 +830,7 @@ void SubToolWidget::initShotOption()
     t_saveGroup->addAction(saveToPictureAction);
     t_saveGroup->addAction(saveToSpecialPath);
     t_saveGroup->addAction(m_changeSaveToSpecialPath);
-  //  t_saveGroup->addAction(saveToClipAction);
+    t_saveGroup->addAction(saveToClipAction);
 
     formatTitleAction->setDisabled(true);
     pngAction->setCheckable(true);


### PR DESCRIPTION
[fix: Fix save path settings in screenshot toolbar](https://github.com/linuxdeepin/deepin-screen-recorder/commit/86706add3c1a17bf76957c4b9dd7687a26b9b07a) 

Description:
- Remove toolbar visibility debug log
- Add clipboard save option back to save options group

Log: Fix screenshot toolbar save path settings
Bug: https://pms.uniontech.com/bug-view-298655.html

[fix: Use QProcess as workaround for scale factor](https://github.com/linuxdeepin/deepin-screen-recorder/commit/6ad6cdaeccd62aa2c7f2cbaef38971cab1580837) 

Description:
- dbus-send return "No such object path" on the first call
- Replace QDBusInterface with QProcess to get display scale factor
- Add TODO comment for future toolbar position calculation refactoring

Log: Fix screen recorder launch issue when called via dbus-send
Bug: https://pms.uniontech.com/bug-view-281713.html