### PR TITLE
fix: can not quit on dbus mode / ocr image wrong

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -6229,6 +6229,14 @@ void MainWindow::stopRecord()
         }
         recordButtonStatus = RECORD_BUTTON_SAVEING;
         recordProcess.stopRecord();
+    } else {
+        qWarning() << "We might received stop request from annother process!";
+
+        QApplication::quit();
+        if (Utils::isWaylandMode) {
+            qInfo() << "wayland record exit! (_Exit(0))";
+            _Exit(0);
+        }
     }
 }
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -3218,8 +3218,6 @@ void MainWindow::changeShotToolEvent(const QString &func)
     qDebug() << "MainWindow::changeShotToolEvent >> func: " << func;
     // 调用ocr功能时先截图后，退出截图录屏，将刚截图的图片串递到ocr识别界面；
     if (func == "ocr") {
-        m_functionType = status::ocr;
-        // qDebug() << "m_saveFileName: " << m_saveFileName;
         QJsonObject obj{{"tid", EventLogUtils::StartOcr}, {"version", QCoreApplication::applicationVersion()}};
         EventLogUtils::get().writeLogs(obj);
         // 调起OCR识别界面， 传入截图路径
@@ -3232,9 +3230,15 @@ void MainWindow::changeShotToolEvent(const QString &func)
 
         // TODO: 在treeland里暂时是走handleCapture去执行保存图片，后续会和原逻辑统一
         if (Utils::isTreelandMode) {
-            QTimer::singleShot(delayTime, this, [=] { onFinishClicked(); });
+            QTimer::singleShot(delayTime, this, [=] {
+                onFinishClicked();
+                m_functionType = status::ocr;
+            });
         } else {
-            QTimer::singleShot(delayTime, this, [=] { saveScreenShot(); });
+            QTimer::singleShot(delayTime, this, [=] {
+                saveScreenShot();
+                m_functionType = status::ocr;
+            });
         }
     } else if (func == "pinScreenshots") {
         m_functionType = status::pinscreenshots;


### PR DESCRIPTION
[fix: can not quit on dbus mode](https://github.com/linuxdeepin/deepin-screen-recorder/commit/03bba7f2bee7023bbb90790aa57958e3d50640da) 

Quit when receive stop request form annother process.

Log: fix can not quit on dbus mode.
Bug: https://pms.uniontech.com/bug-view-295869.html

[fix: ocr image wrong with scroll shot](https://github.com/linuxdeepin/deepin-screen-recorder/commit/091a2e344e3eca83d63ed6dab238cf10ad4e097c) 

Save scroll shot image first, change function type later.

Log: fix ocr image wrong with scroll shot.
Bug: https://pms.uniontech.com/bug-view-281919.html
@rb-union