### PR TITLE
fix: when two screen not aligned recorder may not record

### DIFF
--- a/src/waylandrecord/waylandintegration.cpp
+++ b/src/waylandrecord/waylandintegration.cpp
@@ -1098,7 +1098,7 @@ void WaylandIntegration::WaylandIntegrationPrivate::setupRegistry()
                         QtConcurrent::run(this, &WaylandIntegrationPrivate::appendRemoteBuffer);
                     }
                 }else if(m_screenCount == 2 && m_isScreenExtension){
-                    if(screenGeometry.x() == 0 && screenGeometry.y() == 0)
+                    if(screenGeometry.x() == 0 /* && screenGeometry.y() == 0*/) // when two screen not aligned recorder may not record
                     {
                         if(m_currentScreenBufs[0] == nullptr)
                         {


### PR DESCRIPTION
when two screen not aligned recorder may not record

Log: fix when two screen not aligned recorder may not record
Bug: https://pms.uniontech.com/bug-view-298177.html