### PR TITLE
fix: hide record tray icon / ui issue

### DIFF
--- a/src/dde-dock-plugins/shotstart/iconwidget.cpp
+++ b/src/dde-dock-plugins/shotstart/iconwidget.cpp
@@ -223,11 +223,7 @@ void IconWidget::paintEvent(QPaintEvent *e)
     painter.setOpacity(1);
 
     m_icon = QIcon::fromTheme(iconName, QIcon(QString(":/res/%1.svg").arg(iconName)));
-    pixmap = loadSvg(iconName, QSize(iconSize, iconSize));
-
-    const QRectF &rf = QRectF(rect());
-    const QRectF &rfp = QRectF(pixmap.rect());
-    painter.drawPixmap(rf.center() - rfp.center() / pixmap.devicePixelRatioF(), pixmap);
+    m_icon.paint(&painter, rect());
 
     QWidget::paintEvent(e);
 }

--- a/src/dde-dock-plugins/shotstartrecord/recordiconwidget.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/recordiconwidget.cpp
@@ -175,6 +175,7 @@ QString RecordIconWidget::getDefaultValue(const QString &type)
 void RecordIconWidget::paintEvent(QPaintEvent *e)
 {
     QPainter painter(this);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
     QPixmap pixmap;
     QString iconName = "status-screen-record";
@@ -227,11 +228,7 @@ void RecordIconWidget::paintEvent(QPaintEvent *e)
     painter.setOpacity(1);
 
     m_icon = QIcon::fromTheme(iconName, QIcon(QString(":/res/%1.svg").arg(iconName)));
-    pixmap = loadSvg(iconName, QSize(iconSize, iconSize));
-
-    const QRectF &rf = QRectF(rect());
-    const QRectF &rfp = QRectF(pixmap.rect());
-    painter.drawPixmap(rf.center() - rfp.center() / pixmap.devicePixelRatioF(), pixmap);
+    m_icon.paint(&painter, rect());
 
     QWidget::paintEvent(e);
 }

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
@@ -94,4 +94,19 @@ private:
     bool m_bPreviousIsVisable = false; // 记录前置状态是否为禁止使能状态
 };
 
+// from dde-shell dockiteminfo.h
+struct DockItemInfo
+{
+    QString name;
+    QString displayName;
+    QString itemKey;
+    QString settingKey;
+    QString dccIcon;
+    bool visible;
+};
+Q_DECLARE_METATYPE(DockItemInfo)
+
+typedef QList<DockItemInfo> DockItemInfos;
+Q_DECLARE_METATYPE(DockItemInfos)
+
 #endif // RECORDTIME_H


### PR DESCRIPTION
[fix: not hidden record tray icon when recoding](https://github.com/linuxdeepin/deepin-screen-recorder/commit/f8c12835b06b28d9cd49382535383ab50f2dbe73) 

The DBus interface has been changed, updated.

Log: hide record tray icon when recording.
Bug: https://pms.uniontech.com/bug-view-298541.html

[fix: tray icon is blurred when the scale factor exceeds 1](https://github.com/linuxdeepin/deepin-screen-recorder/commit/2f0a301bd37318a20877326b0f11ff99f4a071a8) 

Use QIcon::paint() replace QPixmap.

Log: fix a tray icon ui issue.
Bug: https://pms.uniontech.com/bug-view-298677.html