### PR TITLE
fix: can not save pin screenshots settings / can not start record via tray icon

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ include /usr/share/dpkg/default.mk
 export DH_OPTIONS := --buildsystem=qmake
 
 %:
-	dh $@ --buildsystem=qmake
+	dh $@ --parallel --buildsystem=qmake
 
 override_dh_auto_configure:
 	$(QMAKE) \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,8 @@ int main(int argc, char *argv[])
                                     QDBusConnection::sessionBus());
 
         QList<QVariant> arg;
-        notification.callWithArgumentList(QDBus::AutoDetect, "stopRecord", arg);
+        // Use stopApp() instead of stopRecord(), actually stop previous process.
+        notification.callWithArgumentList(QDBus::AutoDetect, "stopApp", arg);
     }
 
     return 0;

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -6233,6 +6233,13 @@ void MainWindow::stopRecord()
         }
         recordButtonStatus = RECORD_BUTTON_SAVEING;
         recordProcess.stopRecord();
+    }
+}
+
+void MainWindow::stopApp()
+{
+    if (recordButtonStatus == RECORD_BUTTON_RECORDING) {
+        stopRecord();
     } else {
         qWarning() << "We might received stop request from annother process!";
 

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -430,6 +430,8 @@ public slots:
     void updateCaptureRegion();
 
     Q_SCRIPTABLE void stopRecord();
+    Q_SCRIPTABLE void stopApp();
+
     /**
      * @brief 启动录屏倒计时
      */

--- a/src/pin_screenshots/ui/subtoolwidget.cpp
+++ b/src/pin_screenshots/ui/subtoolwidget.cpp
@@ -254,7 +254,7 @@ void SubToolWidget::updateOptionChecked()
         saveInfo.second = PNG; // 默认保存格式
     }
     //没有配置文件时，给定一个默认值
-    if (saveInfo.first == 0 || saveInfo.second == 0) {
+    if (saveInfo.first == 0 && saveInfo.second == 0) {
         m_SaveInfo.first = CLIPBOARD; // 默认保存路径
         m_SaveInfo.second = PNG; // 默认保存格式
     } else {

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -153,6 +153,11 @@ void Screenshot::stopRecord()
     m_window.stopRecord();
 }
 
+void Screenshot::stopApp()
+{
+    m_window.stopApp();
+}
+
 QString Screenshot::getRecorderNormalIcon()
 {
     return RecorderTablet::getRecorderNormalIcon();

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -37,6 +37,7 @@ public slots:
     void fullScreenRecord(QString fileName = "");
 
     Q_SCRIPTABLE void stopRecord();
+    Q_SCRIPTABLE void stopApp();
     Q_SCRIPTABLE QString getRecorderNormalIcon();
 signals:
     Q_SCRIPTABLE void RecorderState(const bool isStart); // true begin recorder; false stop recorder;


### PR DESCRIPTION
[fix: can not save pin screenshots settings](https://github.com/linuxdeepin/deepin-screen-recorder/commit/0e28ed6302d7bdc2cd3d39f73bbcb8e6c1da6002) 

As title.

Log: fix a config issue.
Bug: https://pms.uniontech.com/bug-view-298631.htm

[fix: can not start record via tray icon](https://github.com/linuxdeepin/deepin-screen-recorder/commit/9c72e143dd75267f39066395fbbd1b8949295a1f) 

- Fix zombie processes caused by stopRecord() misuse
- Restore original stopRecord() behavior to enable recording start
- Add stopApp() for proper process termination
- Prevent lingering processes when not recording

Log: fix can not start recrod via tray icon.

[chore: support parallel build](https://github.com/linuxdeepin/deepin-screen-recorder/commit/78935882c2f37537cc7b4b417b77de2cef95a66d) 

As title.

Log: support parallel build.