### PR TITLE
fix: oom when convert large video to gif

### DIFF
--- a/src/record_process.h
+++ b/src/record_process.h
@@ -126,6 +126,9 @@ private slots:
      */
     void onStartTranscode();
 
+    // convert mp4 to gif with palette
+    void onTranscodePaletteFinished(const QString &palettePng);
+
     /**
      * @brief onTranscodeFinish:转码完成
      */


### PR DESCRIPTION
The `split` with `palettegen` using full frames,
Split into two steps, compress the number of frames used by the palette.

Log: fix a oom issue.
Bug: https://pms.uniontech.com/bug-view-308389.html