### PR TITLE
fix: not reset time after reboot / improve the speed of convrting to GIF

### DIFF
--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
@@ -30,7 +30,8 @@ void RecordTimePlugin::init(PluginProxyInterface *proxyInter)
 {
     m_proxyInter = proxyInter;
     m_dBusService = new DBusService(this);
-    connect(m_dBusService, SIGNAL(start()), this, SLOT(onStart()));
+    // Reset record time (save in file) when restart recording.
+    connect(m_dBusService, &DBusService::start, this, [this](){ onStart(true); });
     connect(m_dBusService, SIGNAL(stop()), this, SLOT(onStop()));
     connect(m_dBusService, SIGNAL(recording()), this, SLOT(onRecording()));
     connect(m_dBusService, SIGNAL(pause()), this, SLOT(onPause()));
@@ -87,11 +88,14 @@ void RecordTimePlugin::clear()
     }
 }
 
-void RecordTimePlugin::onStart()
+void RecordTimePlugin::onStart(bool resetTime)
 {
     qInfo() << "start record time";
     m_timer = new QTimer(this);
     m_timeWidget = new TimeWidget();
+    if (resetTime) {
+        m_timeWidget->clearSetting();
+    }
     m_checkTimer = nullptr;
     m_timer->start(600);
     connect(m_timer, &QTimer::timeout, this, &RecordTimePlugin::refresh);

--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.h
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.h
@@ -61,7 +61,7 @@ public slots:
     /**
      * @brief onStart:启动计时服务
      */
-    void onStart();
+    void onStart(bool resetTime = false);
 
     /**
      * @brief onStop:停止计时服务

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -200,7 +200,7 @@ void RecordProcess::onTranscodePaletteFinished(const QString &palettePng)
         arg << "-i";
         arg << palettePng;
         arg << "-filter_complex";
-        arg << "paletteuse=dither=none:diff_mode=rectangle";
+        arg << "fps=12,paletteuse=dither=none:diff_mode=rectangle";
     }
 
     arg << "-r";


### PR DESCRIPTION
We log the record time to a file to avoid plugin crashes, but time is restored after reboot.
Reset the time every time when start a new screen recording.

Log: fix a ui issue.
Bug: https://pms.uniontech.com/zentao/bug-view-308411.html

[fix: improve the speed of convrting to GIF](https://github.com/linuxdeepin/deepin-screen-recorder/pull/638/commits/fa6c4144833deff48eb89374b532d5f9d6502fe2)
Fileter frames in `avfilter`.

Log: improve the speed of convrting to GIF.
Bug: https://pms.uniontech.com/zentao/bug-view-295949.html