### PR TITLE
fix: use system theme / reset scale in special multi screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2011 ~ 2018 Deepin, Inc.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 ~ 2025 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +16,7 @@
 #include <DWidgetUtil>
 #include <DGuiApplicationHelper>
 #include <DApplication>
+#include <DPlatformTheme>
 
 #include <QCoreApplication>
 #include <QDBusConnection>
@@ -40,26 +40,27 @@ static bool isWaylandProtocol()
 
     QString XDG_SESSION_TYPE = e.value(QStringLiteral("XDG_SESSION_TYPE"));
     QString WAYLAND_DISPLAY = e.value(QStringLiteral("WAYLAND_DISPLAY"));
-    return XDG_SESSION_TYPE == QLatin1String("wayland") ||  WAYLAND_DISPLAY.contains(QLatin1String("wayland"), Qt::CaseInsensitive) ;
+    return XDG_SESSION_TYPE == QLatin1String("wayland") ||
+           WAYLAND_DISPLAY.contains(QLatin1String("wayland"), Qt::CaseInsensitive);
 }
 
 static bool CheckFFmpegEnv()
 {
     bool flag = false;
     QDir dir;
-    QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
+    QString path = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
     qDebug() << "QLibraryInfo::LibrariesPath: " << path;
     dir.setPath(path);
-    qDebug() <<  "where is libs? where is " << dir ;
+    qDebug() << "where is libs? where is " << dir;
     QStringList list = dir.entryList(QStringList() << (QString("libavcodec") + "*"), QDir::NoDotAndDotDot | QDir::Files);
-    qDebug()  << "Is libavcodec in there?  there is :" << list ;
+    qDebug() << "Is libavcodec in there?  there is :" << list;
 
     if (list.contains("libavcodec.so.58")) {
-        qInfo()  << "list contains libavcodec.so.58" ;
+        qInfo() << "list contains libavcodec.so.58";
         flag = true;
     }
 
-    //x11下需要检测ffmpeg应用是否存在
+    // x11下需要检测ffmpeg应用是否存在
     if (!isWaylandProtocol()) {
         flag = !QStandardPaths::findExecutable("ffmpeg").isEmpty();
         qInfo() << "Is exists ffmpeg in PATH(" << qgetenv("PATH") << "):" << flag;
@@ -70,8 +71,8 @@ static bool CheckFFmpegEnv()
 
 int main(int argc, char *argv[])
 {
-    //wayland调试输出
-    //qputenv("WAYLAND_DEBUG", "1");
+    // wayland调试输出
+    // qputenv("WAYLAND_DEBUG", "1");
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);
     }
@@ -83,10 +84,14 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     // Support V23 or later.
-    // FIXME: Reconstruct the toolbar position calculation based on scaleFactor, 
+    // FIXME: Reconstruct the toolbar position calculation based on scaleFactor,
     // or fix the issue of the dbus-send call
     QProcess proc;
-    proc.start("dbus-send", {"--print-reply=literal", "--dest=org.deepin.dde.Display1", "/org/deepin/dde/XSettings1",  "org.deepin.dde.XSettings1.GetScaleFactor"});
+    proc.start("dbus-send",
+               {"--print-reply=literal",
+                "--dest=org.deepin.dde.Display1",
+                "/org/deepin/dde/XSettings1",
+                "org.deepin.dde.XSettings1.GetScaleFactor"});
     proc.waitForFinished();
     QByteArray data = proc.readAllStandardOutput().simplified();
     if (!data.isEmpty()) {
@@ -98,14 +103,10 @@ int main(int argc, char *argv[])
     }
 
     // 平板模式
-    Utils::isTabletEnvironment = false; // DGuiApplicationHelper::isTabletEnvironment();
-    //qInfo() << "Is Table:" << Utils::isTabletEnvironment;
-
+    // Utils::isTabletEnvironment = DGuiApplicationHelper::isTabletEnvironment();
     // wayland 协议
     Utils::isWaylandMode = isWaylandProtocol();
-
     Utils::isRootUser = (getuid() == 0);
-    //qInfo() << "Is Root User:" << Utils::isRootUser;
 
     if (Utils::isWaylandMode) {
         qputenv("QT_WAYLAND_SHELL_INTEGRATION", "kwayland-shell");
@@ -119,18 +120,16 @@ int main(int argc, char *argv[])
     qDebug() << "Is FFmpeg Environment:" << Utils::isFFmpegEnv;
 
     // 适配deepin-turbo 启动加速
-#if(DTK_VERSION < DTK_VERSION_CHECK(5,4,0,0))
+#if (DTK_VERSION < DTK_VERSION_CHECK(5, 4, 0, 0))
     DApplication::loadDXcbPlugin();
     QScopedPointer<DApplication> app(new DApplication(argc, argv));
 #else
     QScopedPointer<DApplication> app(DApplication::globalApplication(argc, argv));
 #endif
 
-
-    //treeland环境开启，方便可以用命令行参数启动treeland——demo调试
+    // treeland环境开启，方便可以用命令行参数启动treeland——demo调试
     if (Utils::isWaylandMode || QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive))
         Utils::isTreelandMode = true;
-
 
     if (Utils::isWaylandMode) {
 #ifdef __mips__
@@ -140,21 +139,17 @@ int main(int argc, char *argv[])
     // 集成测试标签
 #ifdef ENABLE_ACCESSIBILITY
     QAccessible::installFactory(accessibleFactory);
-#endif    
+#endif
 
     QDBusConnection dbus = QDBusConnection::sessionBus();
-    //    dbus.registerService("com.deepin.ScreenRecorder");
     if (dbus.registerService("com.deepin.ScreenRecorder")) {
         app->setOrganizationName("deepin");
         app->setApplicationName("deepin-screen-recorder");
         app->setApplicationVersion("1.0");
 
 #if (QT_VERSION_MAJOR == 5)
-    app->setAttribute(Qt::AA_UseHighDpiPixmaps);
+        app->setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
-        //        static const QDate buildDate = QLocale(QLocale::English).
-        //                                       toDate(QString(__DATE__).replace("  ", " 0"), "MMM dd yyyy");
-        //        QString t_date = buildDate.toString("MMdd");
 
         // Version Time
         app->setApplicationVersion(DApplication::buildVersion(APP_VERSION));
@@ -163,20 +158,20 @@ int main(int argc, char *argv[])
         Dtk::Core::DLogManager::registerConsoleAppender();
         Dtk::Core::DLogManager::registerFileAppender();
 
-        QCommandLineOption  delayOption(QStringList() << "d" << "delay", "Take a screenshot after NUM seconds.", "NUM");
+        QCommandLineOption delayOption(QStringList() << "d" << "delay", "Take a screenshot after NUM seconds.", "NUM");
         QCommandLineOption fullscreenOption(QStringList() << "f" << "fullscreen", "Take a screenshot the whole screen.");
         QCommandLineOption topWindowOption(QStringList() << "w" << "top-window", "Take a screenshot of the most top window.");
         QCommandLineOption savePathOption(QStringList() << "s" << "save-path", "Specify a path to save the screenshot.", "PATH");
         QCommandLineOption prohibitNotifyOption(QStringList() << "n" << "no-notification", "Don't send notifications.");
         QCommandLineOption useGStreamer(QStringList() << "g" << "gstreamer", "Use GStreamer.");
         QCommandLineOption dbusOption(QStringList() << "u" << "dbus", "Start  from dbus.");
-        QCommandLineOption screenRecordFullScreenOption(QStringList() << "rf" << "recordFullScreen","Record full screen","FileNAME","");
+        QCommandLineOption screenRecordFullScreenOption(
+            QStringList() << "rf" << "recordFullScreen", "Record full screen", "FileNAME", "");
         screenRecordFullScreenOption.setFlags(QCommandLineOption::Flag::HiddenFromHelp);
         QCommandLineOption screenRecordOption(QStringList() << "record" << "screenRecord" << "start screen record");
         QCommandLineOption screenShotOption(QStringList() << "shot" << "screenShot" << "start screen shot");
         QCommandLineOption screenOcrOption(QStringList() << "ocr" << "screenOcr" << "start screen ocr");
         QCommandLineOption screenScrollOption(QStringList() << "scroll" << "screenScroll" << "start screen scroll");
-
 
         QCommandLineParser cmdParser;
         cmdParser.setApplicationDescription("deepin-screen-recorder");
@@ -199,20 +194,25 @@ int main(int argc, char *argv[])
         // Load translator.
         app->loadTranslator();
         Utils::appName = MainWindow::tr("deepin-screen-recorder");
-        qInfo() << "Original Application Name is: " << QCoreApplication::applicationName() << ". International Application Name is: " << Utils::appName;
+        qInfo() << "Original Application Name is: " << QCoreApplication::applicationName()
+                << ". International Application Name is: " << Utils::appName;
 
-        // 主题设置
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        // Use system theme type instead of app cached theme type
+        if (auto systemTheme = DGuiApplicationHelper::instance()->systemTheme()) {
+            DPalette sysPalette = DGuiApplicationHelper::fetchPalette(systemTheme);
+            DGuiApplicationHelper::instance()->setApplicationPalette(sysPalette);
+            Utils::themeType = DGuiApplicationHelper::toColorType(sysPalette);
+        }
+#else
         DGuiApplicationHelper::ColorType t_type = DGuiApplicationHelper::instance()->themeType();
         DGuiApplicationHelper::instance()->setPaletteType(t_type);
         Utils::themeType = t_type;
+#endif
 
-        //qDebug() << "截图录屏日志路径: " << Dtk::Core::DLogManager::getlogFilePath();
-        qDebug() << "截图录屏版本: " << DApplication::buildVersion(APP_VERSION);
-
-        //显示系统信息
+        // 显示系统信息
         Utils::showCurrentSys();
 
-        //qInfo() << "截图录屏日志路径: " << Dtk::Core::DLogManager::getlogFilePath().right(Dtk::Core::DLogManager::getlogFilePath().length() - Dtk::Core::DLogManager::getlogFilePath().indexOf(".cache"));
         qInfo() << "截图录屏版本: " << DApplication::buildVersion(APP_VERSION);
 #ifdef KF5_WAYLAND_FLAGE_ON
         qInfo() << "KF5_WAYLAND_FLAGE_ON is open!!";
@@ -238,7 +238,9 @@ int main(int argc, char *argv[])
         window.initLaunchMode(t_launchMode);
         DBusScreenshotService dbusService(&window);
         // Register debus service.
-        dbus.registerObject("/com/deepin/ScreenRecorder", &window, QDBusConnection::ExportScriptableSignals | QDBusConnection::ExportScriptableSlots);
+        dbus.registerObject("/com/deepin/ScreenRecorder",
+                            &window,
+                            QDBusConnection::ExportScriptableSignals | QDBusConnection::ExportScriptableSlots);
         QDBusConnection conn = QDBusConnection::sessionBus();
 
         if (!conn.registerService("com.deepin.Screenshot") || !conn.registerObject("/com/deepin/Screenshot", &window)) {
@@ -255,12 +257,10 @@ int main(int argc, char *argv[])
             return app->exec();
 
         } else {
-            QJsonObject obj{
-                {"tid", EventLogUtils::Start},
-                {"version", QCoreApplication::applicationVersion()},
-                {"mode", 1},
-                {"startup_mode", "A"}
-            };
+            QJsonObject obj{{"tid", EventLogUtils::Start},
+                            {"version", QCoreApplication::applicationVersion()},
+                            {"mode", 1},
+                            {"startup_mode", "A"}};
             if (!cmdParser.isSet(screenRecordOption))
                 EventLogUtils::get().writeLogs(obj);
             dbusService.setSingleInstance(true);
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
                 qDebug() << "screenshot no notify!";
                 window.noNotifyScreenshot();
             } else if (cmdParser.isSet(screenRecordFullScreenOption)) {
-                qDebug() << "screenRecordFullScreenOption!!!!"<< cmdParser.value(screenRecordFullScreenOption);
+                qDebug() << "screenRecordFullScreenOption!!!!" << cmdParser.value(screenRecordFullScreenOption);
                 window.fullScreenRecord(cmdParser.value(screenRecordFullScreenOption));
             } else {
                 window.startScreenshot();
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
 
         return app->exec();
     } else {
-        //      Send DBus message to stop screen - recorder if found other screen - recorder DBus service has started.
+        // Send DBus message to stop screen-recorder if found other screen-recorder DBus service has started.
         QDBusInterface notification("com.deepin.ScreenRecorder",
                                     "/com/deepin/ScreenRecorder",
                                     "com.deepin.ScreenRecorder",

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -188,7 +188,13 @@ void MainWindow::initMainWindow()
         m_cursorBound = 5;
     }
     setDragCursor();
-    m_pixelRatio = qApp->primaryScreen()->devicePixelRatio();
+    // FIXME(205567 / 307017): temporarily fix, we manually reset scale factor to 1
+    if (Utils::forceResetScale) {
+        m_pixelRatio = 1.0;
+    } else {
+        m_pixelRatio = qApp->primaryScreen()->devicePixelRatio();
+    }
+
     Utils::pixelRatio = m_pixelRatio;
     // 监控录屏过程中， 特效窗口的变化。
     connect(m_wmHelper, &DWindowManagerHelper::hasCompositeChanged, this, &MainWindow::compositeChanged);

--- a/src/src.pro
+++ b/src/src.pro
@@ -172,6 +172,7 @@ HEADERS += main_window.h \
     menucontroller/menucontroller.h \
     utils/proxyaudioport.h \
     utils/voicevolumewatcher_interface.h \
+    utils/x_multi_screen_info.h \
     utils_interface.h \
     voicevolumewatcherext.h \
     utils/baseutils.h \
@@ -239,6 +240,7 @@ SOURCES += main.cpp \
     utils/configsettings.cpp \
     utils/baseutils.cpp \
     utils/voicevolumewatcher_interface.cpp \
+    utils/x_multi_screen_info.cpp \
     utils_interface.cpp \
     wayland-treeland-capture-unstable-v1-protocol.c \
     widgets/toptips.cpp \
@@ -316,7 +318,7 @@ RESOURCES = ../assets/image/deepin-screen-recorder.qrc \
     ../resources.qrc
 
 # Libraries
-LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -ldl -limagevisualresult
+LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -ldl -limagevisualresult -lXinerama
 
 contains(DEFINES, OCR_SCROLL_FLAGE_ON) {
     LIBS += -lopencv_small

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -57,6 +57,8 @@ bool Utils::isTabletEnvironment = false;
 bool Utils::isWaylandMode = false;
 bool Utils::isTreelandMode = false;
 
+bool Utils::forceResetScale = false;
+
 bool Utils::isRootUser = false;
 qreal Utils::pixelRatio = 0.0;
 bool Utils::isFFmpegEnv = true;

--- a/src/utils.h
+++ b/src/utils.h
@@ -79,6 +79,9 @@ public:
     static bool isWaylandMode;
     static bool isTreelandMode;
 
+    // temporary flag, remove it if fix scale factor bugs.
+    static bool forceResetScale;
+
     static QString appName;
     /**
      * @brief 本机是否存在ffmpeg相关库 true:存在 false:不存在

--- a/src/utils/x_multi_screen_info.cpp
+++ b/src/utils/x_multi_screen_info.cpp
@@ -1,0 +1,55 @@
+#include "x_multi_screen_info.h"
+
+
+#include <X11/Xlib.h>
+#include <X11/extensions/Xinerama.h>
+
+#include <stdio.h>
+
+XMultiScreenInfo::XMultiScreenInfo() {}
+
+/*
+ * FIXME(205567): If multi-screen, the coordinates of the screen
+ *      need to be flush on the horizontal or vertical axis.
+ */
+bool XMultiScreenInfo::screenNeedResetScale()
+{
+    Display *display = XOpenDisplay(nullptr);
+    if (!display) {
+        return false;
+    }
+
+    bool needResetScale = false;
+    do {
+        int event_base, error_base;
+        if (!XineramaQueryExtension(display, &event_base, &error_base)) {
+            break;
+        }
+
+        if (!XineramaIsActive(display)) {
+            break;
+        }
+
+        int num_screens;
+        XineramaScreenInfo *screens = XineramaQueryScreens(display, &num_screens);
+        if (!screens || num_screens <= 1) {
+            break;
+        }
+
+        int xOffset = 0;
+        int yOffset = 0;
+        for (int i = 0; i < num_screens; i++) {
+            printf("screen %d: x = %d, y = %d, width = %d, height = %d\n",
+                   i, screens[i].x_org, screens[i].y_org, screens[i].width, screens[i].height);
+
+            xOffset += screens[i].x_org;
+            yOffset += screens[i].y_org;
+        }
+        needResetScale = (0 != xOffset) && (0 != yOffset);
+
+        XFree(screens);
+    } while (false);
+
+    XCloseDisplay(display);
+    return needResetScale;
+}

--- a/src/utils/x_multi_screen_info.h
+++ b/src/utils/x_multi_screen_info.h
@@ -1,0 +1,12 @@
+#ifndef X_MULTI_SCREEN_INFO_H
+#define X_MULTI_SCREEN_INFO_H
+
+class XMultiScreenInfo
+{
+public:
+    XMultiScreenInfo();
+
+    static bool screenNeedResetScale();
+};
+
+#endif // X_MULTI_SCREEN_INFO_H


### PR DESCRIPTION
screen-recorder's theme type is the same as the current system settings.

Log: fix theme type error.
Bug: https://pms.uniontech.com/zentao/bug-view-300679.html
     https://pms.uniontech.com/zentao/bug-view-287991.html

[fix: paint full screen rectangle error.](https://github.com/linuxdeepin/deepin-screen-recorder/pull/639/commits/6e64658a6d8d3bdaa20c82d1fd7a7d106f3b238e)
There is an error in the scale factor from the screen,
Force reset the scale factor before fix bug 205567.

Those changes for multi-screen, the coordinates of the screen
need to be flush on the horizontal or vertical axis.

Log: fix a ui issue.
Bug: https://pms.uniontech.com/zentao/bug-view-307017.html