### PR TITLE
fix: blur effect error and revert previous commit

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Build-Depends: debhelper,
  libdtk6widget-dev,
  libdframeworkdbus-dev,
  dde-tray-loader-dev | dde-dock-dev,
- libimageeditor-dev,
  libffmpegthumbnailer-dev,
  deepin-desktop-base,
 # opencv

--- a/src/camera/majorimageprocessingthread.cpp
+++ b/src/camera/majorimageprocessingthread.cpp
@@ -6,10 +6,6 @@
 #include "majorimageprocessingthread.h"
 #include "../utils.h"
 
-extern "C" {
-#include <libimagevisualresult/visualresult.h>
-}
-
 #include <QFile>
 #include <QDate>
 #include <QDir>

--- a/src/countdown_tooltip.cpp
+++ b/src/countdown_tooltip.cpp
@@ -128,23 +128,29 @@ QPixmap CountdownTooltip::getTooltipBackground()
 {
     TempFile *tempFile = TempFile::instance();
     const int radius = 50;
-    //qDebug() << "rect().x(),rect().y()" << rect().x() << "," << rect().y();
-    //qDebug() << "rect().width(),rect().height()" << rect().width() << "," << rect().height();
-    //qDebug() << "this->x(),this->y()" << this->x() << "," << this->y();
-    //qDebug() << "this->width(),this->height()" << this->width() << "," << this->height();
+
     //用当前提示窗口的位置和提示框的大小构建一个矩形框
-    QRect target( static_cast<int>(this->x()),
-                      static_cast<int>(this->y()),
-                      static_cast<int>(this->width() ),
-                      static_cast<int>(this->height()));
+    auto ratio = qApp->devicePixelRatio();
+    QRect target( static_cast<int>(this->x() * ratio),
+                      static_cast<int>(this->y() * ratio),
+                      static_cast<int>(this->width() * ratio),
+                      static_cast<int>(this->height() * ratio));
+
     QPixmap tmpImg = tempFile->getFullscreenPixmap().copy(target);
     if (!tmpImg.isNull()) {
         int imgWidth = tmpImg.width();
         int imgHeight = tmpImg.height();
         tmpImg = tmpImg.scaled(imgWidth / radius, imgHeight / radius, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
         tmpImg = tmpImg.scaled(imgWidth, imgHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-        //qDebug() << "tmpImg.width(),tmpImg.height()" << tmpImg.width() << "," << tmpImg.height();
     }
+
+#ifdef QT_DEBUG
+    qDebug() << "rect().x(),rect().y()" << rect().x() << "," << rect().y();
+    qDebug() << "rect().width(),rect().height()" << rect().width() << "," << rect().height();
+    qDebug() << "this->x(),this->y()" << this->x() << "," << this->y();
+    qDebug() << "this->width(),this->height()" << this->width() << "," << this->height();
+    qDebug() << "tmpImg.width(),tmpImg.height()" << tmpImg.width() << "," << tmpImg.height();
+#endif
     return  tmpImg;
 }
 

--- a/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp
@@ -39,7 +39,7 @@ void QuickPanelWidget::initUI()
     DFontSizeManager::instance()->bind(m_description, DFontSizeManager::T10);
 
     auto layout = new QVBoxLayout;
-    setContentsMargins(0, 0, 0, 0);
+    setContentsMargins(8, 8, 8, 8);
     layout->setSpacing(0);
     layout->addStretch(1);
     layout->addWidget(m_icon, 0, Qt::AlignCenter);

--- a/src/src.pro
+++ b/src/src.pro
@@ -318,7 +318,7 @@ RESOURCES = ../assets/image/deepin-screen-recorder.qrc \
     ../resources.qrc
 
 # Libraries
-LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -ldl -limagevisualresult -lXinerama
+LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -ldl -lXinerama
 
 contains(DEFINES, OCR_SCROLL_FLAGE_ON) {
     LIBS += -lopencv_small


### PR DESCRIPTION
As title, grab image rectangle erorr.
Previous commit incorrect.

Log: fix blur effect.
Bug: https://pms.uniontech.com/zentao/bug-view-309211.html