### PR TITLE
Revert "fix: replace XSync with XFlush"

### DIFF
--- a/src/event_monitor.cpp
+++ b/src/event_monitor.cpp
@@ -34,9 +34,9 @@ void EventMonitor::releaseRes()
         XRecordDisableContext(m_display, m_context);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XRecordFreeContext ...";
         XRecordFreeContext(m_display, m_context);
-        qInfo() << __FUNCTION__ << __LINE__ << "执行 XFlush ...";
-        XFlush(m_display);
-        XFlush(m_display_datalink);
+        qInfo() << __FUNCTION__ << __LINE__ << "执行 XSync ...";
+        XSync(m_display, True);
+        XSync(m_display_datalink, True);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display_datalink...";
         XCloseDisplay(m_display_datalink);
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display...";


### PR DESCRIPTION
This reverts commit c0ba1f90d65e300390de66c82a7931c38fd35c7f. XCloseDisplay() also call XSync().