### PR TITLE
fix: restructure event monitor cleanup

### DIFF
--- a/src/event_monitor.cpp
+++ b/src/event_monitor.cpp
@@ -32,17 +32,8 @@ void EventMonitor::releaseRes()
     if (m_display_datalink && m_display) {
         qInfo() << __FUNCTION__ << __LINE__ << "执行 XRecordDisableContext ...";
         XRecordDisableContext(m_display, m_context);
-        qInfo() << __FUNCTION__ << __LINE__ << "执行 XRecordFreeContext ...";
-        XRecordFreeContext(m_display, m_context);
-        qInfo() << __FUNCTION__ << __LINE__ << "执行 XSync ...";
-        XSync(m_display, True);
-        XSync(m_display_datalink, True);
-        qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display_datalink...";
-        XCloseDisplay(m_display_datalink);
-        qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display...";
-        XCloseDisplay(m_display);
-        m_display_datalink = nullptr;
-        m_display = nullptr;
+
+        XFlush(m_display);
     }
 }
 
@@ -87,6 +78,19 @@ void EventMonitor::run()
         fprintf(stderr, "XRecordEnableContext() failed\n");
         return;
     }
+    qInfo() << "XRecordEnableContext() finished.";
+
+    qInfo() << __FUNCTION__ << __LINE__ << "执行 XRecordFreeContext ...";
+    XRecordFreeContext(m_display, m_context);
+    qInfo() << __FUNCTION__ << __LINE__ << "执行 XSync ...";
+    XSync(m_display, true);
+    XSync(m_display_datalink, true);
+    qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display_datalink...";
+    XCloseDisplay(m_display_datalink);
+    qInfo() << __FUNCTION__ << __LINE__ << "执行 XCloseDisplay m_display...";
+    XCloseDisplay(m_display);
+    m_display_datalink = nullptr;
+    m_display = nullptr;
 }
 
 void EventMonitor::callback(XPointer ptr, XRecordInterceptData *data)

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -179,8 +179,11 @@ public:
         qInfo() << __FUNCTION__ << __LINE__ << "正在释放截图录屏全局事件监听线程...";
         if (m_pScreenCaptureEvent) {
             m_pScreenCaptureEvent->releaseRes();
-            //m_pScreenCaptureEvent->terminate();
-            m_pScreenCaptureEvent->wait();
+            m_pScreenCaptureEvent->wait(30 * 1000);
+            if (m_pScreenCaptureEvent->isRunning()) {
+                qCritical() << "Detect X release hangs.";
+                m_pScreenCaptureEvent->terminate();
+            }
             delete m_pScreenCaptureEvent;
             m_pScreenCaptureEvent = nullptr;
         }


### PR DESCRIPTION
- Adjust cleanup timing to avoid race with record thread
- Move cleanup logic to end of run method
- Add 30s timeout to prevent deadlock

Log: restructure event monitor cleanup.
Bug: https://pms.uniontech.com/bug-view-306357.html