### PR TITLE
fix: using the OpenGL indicator.

### DIFF
--- a/src/main_window.h
+++ b/src/main_window.h
@@ -957,7 +957,7 @@ private:
     /**
      * @brief 功能类型
      */
-    unsigned int m_functionType = status::record;  //0: record, 1: shot , 2: scrollshot
+    unsigned int m_functionType = status::shot;  //0: record, 1: shot , 2: scrollshot
     /**
      * @brief 键盘开关状态
      */


### PR DESCRIPTION
The screenshot defaults to launching in 'shot' mode, changing from the
previous default 'record' mode. The 'shot' mode utilizes OpenGL
rendering, which offers higher performance compared to image rendering.

Log: reduce stuttering during corner marker movement.
Bug: https://pms.uniontech.com//bug-view-323453.html