### PR TITLE
fix: Fix Wayland window screenshot active window acquisition.

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -580,6 +580,9 @@ void MainWindow::waylandwindowinfo(const QVector<ClientManagement::WindowState> 
                                 static_cast<int>(windowStates.at(i).geometry.height / ratio));
             }
             windowNames << windowStates.at(i).resourceName;
+            if (windowNames.contains("dde-dock")) {
+                ddeDockLayerIndex = i;
+            }
         }
     }
     if (windowStates.count() > 0) {
@@ -1847,7 +1850,7 @@ void MainWindow::topWindow()
 
 void MainWindow::saveTopWindow()
 {
-    int topWindowIndex = windowRects.size() - 2;
+    int topWindowIndex = ddeDockLayerIndex - 1;
     if (topWindowIndex < 0) {
         topWindowIndex = 0;
     }

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -580,8 +580,8 @@ void MainWindow::waylandwindowinfo(const QVector<ClientManagement::WindowState> 
                                 static_cast<int>(windowStates.at(i).geometry.height / ratio));
             }
             windowNames << windowStates.at(i).resourceName;
-            if (windowNames.contains("dde-dock")) {
-                ddeDockLayerIndex = i;
+            if (windowNames.last().contains("dde-dock")) {
+                ddeDockLayerIndex = windowNames.size() - 1;
             }
         }
     }

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -755,6 +755,7 @@ private:
      * @brief 所有窗口的名称，与windowRects一一对应
      */
     QList<QString> windowNames;
+    int ddeDockLayerIndex = -1;
     ShowButtons *m_showButtons = nullptr;
     //QTimer *flashTrayIconTimer = nullptr;
     QRect screenRect;


### PR DESCRIPTION
Fixed an issue with Wayland window screenshots capturing the active window. Previously, it rigidly used the second-to-last layer method (which could capture input methods, notifications, or remote assistance windows). Now it references dde-dock's layer level and captures the window one layer above dde-dock.

Log: Fix active window detection in Wayland screenshots
Bug: https://pms.uniontech.com/bug-view-322949.html