### PR TITLE
fix: Correct fullscreen behavior in screenshot functionality

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1970,7 +1970,6 @@ void MainWindow::fullScreenshot()
     // DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
     this->initAttributes();
     this->initLaunchMode("screenShot");
-    this->showFullScreen();
     this->initResource();
     qCDebug(dsrApp) << "fullScreenshot repaint";
     repaint();
@@ -1994,6 +1993,7 @@ void MainWindow::fullScreenshot()
     //
     this->move(m_backgroundRect.x(), m_backgroundRect.y());
     this->setFixedSize(m_backgroundRect.size());
+    this->showFullScreen();
     m_needSaveScreenshot = true;
     qCDebug(dsrApp) << "fullScreenshot m_needSaveScreenshot";
     //    m_toolBar = new ToolBar(this);


### PR DESCRIPTION
- Moved the showFullScreen() call to ensure the window is displayed in fullscreen mode during screenshot capture.
- Removed redundant showFullScreen() call to streamline the function.

Log: Adjust fullscreen handling for improved screenshot functionality.

bug: https://pms.uniontech.com/bug-view-318471.html