### PR TITLE
chore: Add new Lao translation file for deepin-screen-recorder

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-screen-recorder (6.5.33) unstable; urgency=medium
+
+  * chore: Add new Lao translation file for deepin-screen-recorder
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 07 Aug 2025 15:10:11 +0800
+
 deepin-screen-recorder (6.5.32) unstable; urgency=medium
 
   * fix: Correct sidebar position calculation in MainWindow

--- a/translations.pri
+++ b/translations.pri
@@ -27,7 +27,8 @@ TRANSLATIONS += \
     $$PWD/translations/deepin-screen-recorder_tr.ts \
     $$PWD/translations/deepin-screen-recorder_uk.ts \
     $$PWD/translations/deepin-screen-recorder_ug.ts \
-    $$PWD/translations/deepin-screen-recorder_bo.ts
+    $$PWD/translations/deepin-screen-recorder_bo.ts \
+    $$PWD/translations/deepin-screen-recorder_lo.ts
 
 
 

--- a/translations/deepin-screen-recorder_lo.ts
+++ b/translations/deepin-screen-recorder_lo.ts
@@ -1,0 +1,723 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>CountdownTooltip</name>
+    <message>
+        <source>Click the tray icon 
+or press the shortcut again to stop recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do not rotate your screen during recording</source>
+        <translation>ຢ່າປ່ອຍຫຼືປ່ຽນທິດທາງໜ້າຈໍໃນຂະນະທີ່ບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>IconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>ຮູບພາບໜ້າຈໍ</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>ການບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>Screen Capture</source>
+        <translation>ການຈັບຮູບໜ້າຈໍ</translation>
+    </message>
+    <message>
+        <source>Save failed. Please save it in your home directory.</source>
+        <translation>ບໍ່ສາມາດບັນທຶກໄດ້. ກະລຸນາບັນທຶກໃນໄຟລ໌ຫ້ອງຂອງທ່ານ.</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>ເບິ່ງ</translation>
+    </message>
+    <message>
+        <source>Screenshot finished</source>
+        <translation>ການຈັບຮູບໜ້າຈໍສຳເລັດ</translation>
+    </message>
+    <message>
+        <source>PNG (*.png);;JPEG (*.jpg *.jpeg);;BMP (*.bmp)</source>
+        <translation>PNG (*.png);;JPEG (*.jpg *.jpeg);;BMP (*.bmp)</translation>
+    </message>
+    <message>
+        <source>JPEG (*.jpg *.jpeg);;PNG (*.png);;BMP (*.bmp)</source>
+        <translation>JPEG (*.jpg *.jpeg);;PNG (*.png);;BMP (*.bmp)</translation>
+    </message>
+    <message>
+        <source>BMP (*.bmp);;JPEG (*.jpg *.jpeg);;PNG (*.png)</source>
+        <translation>BMP (*.bmp);;JPEG (*.jpg *.jpeg);;PNG (*.png)</translation>
+    </message>
+    <message>
+        <source>select-area</source>
+        <translation>ເລືອກພື້ນທີ່</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Saved to %1</source>
+        <translation>ບັນທຶກໄວ້ທີ່ %1</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>ລະລັງປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <source>Clipboard</source>
+        <translation>ຄ່ອຍຄ່ອຍ</translation>
+    </message>
+    <message>
+        <source>Saving the screen recording file, please wait...</source>
+        <translation>ກຳລັງບັນທຶກໄຟລ໌ການບັນທຶກໜ້າຈໍ, ກະລຸນາລໍຖ້າ...</translation>
+    </message>
+    <message>
+        <source>As the window effect is disabled during the process, the recording has to be stopped</source>
+        <translation>ເນື່ອງຈາກການສະແດງຜົນຂອງໜ້າຕ່າງທີ່ຖືກປິດໃນຂະນະທີ່ກຳລັງເຮັດ, ການບັນທຶກຕ້ອງຖືກຢຸດ</translation>
+    </message>
+    <message>
+        <source>Screenshot</source>
+        <translation>ຮູບພາບ</translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation>ຂໍ້ມູນສ່ວນໜ້າເຄື່ອນທີ່</translation>
+    </message>
+    <message>
+        <source>Pin Screenshots</source>
+        <translation>ຕິດສະກີນພາບ</translation>
+    </message>
+    <message>
+        <source>deepin-screen-recorder</source>
+        <translation>ການບັນທຶກໜ້າຈໍຂອງ deepin</translation>
+    </message>
+    <message>
+        <source>Open Folder</source>
+        <translation>ເປີດຟ້ອນ</translation>
+    </message>
+    <message>
+        <source>Screenshot finished and copy to clipboard</source>
+        <translation>ການຈັບຮູບໜ້າຈໍສຳເລັດທີ່ສຸດແລະຄ່ອຍຄ່ອຍ</translation>
+    </message>
+</context>
+<context>
+    <name>MenuController</name>
+    <message>
+        <source>Undo</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>ອອກ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Pin Screenshots</source>
+        <translation>ຕິດສະກີນພາບ</translation>
+    </message>
+</context>
+<context>
+    <name>QuickPanelWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>ຮູບພາບ</translation>
+    </message>
+    <message>
+        <source>Record</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>RecordIconWidget</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>ຮູບຖ່າຍໜ້າຈໍ</translation>
+    </message>
+    <message>
+        <source>Recording</source>
+        <translation>ການບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>RecordProcess</name>
+    <message>
+        <source>View</source>
+        <translation>ເບິ່ງ</translation>
+    </message>
+    <message>
+        <source>Recording finished</source>
+        <translation>ການບັນທຶກສິ້ນສຸດ</translation>
+    </message>
+    <message>
+        <source>Saved to %1</source>
+        <translation>ບັນທຶກໄວ້ທີ່ %1</translation>
+    </message>
+    <message>
+        <source>Record</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Open Folder</source>
+        <translation>ເປີດຟ້ອນ</translation>
+    </message>
+</context>
+<context>
+    <name>Screenshot</name>
+    <message>
+        <source>Screen Capture will start in %1 seconds</source>
+        <translation>ການຈັບຮູບໜ້າຈໍຈະເລີ່ມໃນ %1 ວິນາທີ</translation>
+    </message>
+</context>
+<context>
+    <name>ScrollShotTip</name>
+    <message>
+        <source>Get help.</source>
+        <translation>ຂໍຄວາມຊ່ວຍເຫຼືອ.</translation>
+    </message>
+    <message>
+        <source>Failed to take a continuous screenshot.</source>
+        <translation>ບໍ່ສາມາດຈັບຮູບໜ້າຈໍຕໍ່ເນື່ອງໄດ້.</translation>
+    </message>
+    <message>
+        <source>Reached the bottom of the scroll area</source>
+        <translation>ເຖິງທາງລຸ່ມຂອງເຂດການດັນ</translation>
+    </message>
+    <message>
+        <source>Reached the maximum length</source>
+        <translation>ເຖິງຄວາມຍາວສູງສຸດ</translation>
+    </message>
+    <message>
+        <source>adjust the capture area</source>
+        <translation>ປັບເຂດການຈັບຮູບ</translation>
+    </message>
+    <message>
+        <source>Scroll your mouse wheel or click to take a scrolling screenshot</source>
+        <translation>ດັນລົງຂອງຕີນກີບຂອງທ່ານ ຫຼື ກົດເພື່ອຈັບຮູບໜ້າຈໍດັນ</translation>
+    </message>
+    <message>
+        <source>Slow down the scrolling speed</source>
+        <translation>ຊ້າລົງການດັນ</translation>
+    </message>
+    <message>
+        <source>Invalid area, click to </source>
+        <translation>ເຂດບໍ່ຖືກຕ້ອງ, ກົດທີ່ນີ້</translation>
+    </message>
+</context>
+<context>
+    <name>ShapesWidget</name>
+    <message>
+        <source>Input text here</source>
+        <translation>ປ້ອນຂໍ້ຄວາມທີ່ນີ້</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcut</name>
+    <message>
+        <source>Start/Screenshot</source>
+        <translation>ເລີ່ມ/ພາບສັນຍານ</translation>
+    </message>
+    <message>
+        <source>Exit/Save</source>
+        <translation>ອອກ/ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Size Adjustment</source>
+        <translation>ການປັບໄໝ່ຂະໜາດ</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>ການຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <source>Quick start</source>
+        <translation>ການເລີ່ມຕົ້ນໄວ</translation>
+    </message>
+    <message>
+        <source>Window screenshot</source>
+        <translation>ພາບສັນຍານໜ້າຈໍ</translation>
+    </message>
+    <message>
+        <source>Delay screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Full screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>ອອກ</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Rectangle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>ຮູບຮາງໂມ້</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>ເສັ້ນທາງ</translation>
+    </message>
+    <message>
+        <source>Pencil</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>ລົບ</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <source>Increase height up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase height down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase width left</source>
+        <translation>ເພີ່ມຄວາມບີ້ງຊ້າຍ</translation>
+    </message>
+    <message>
+        <source>Increase width right</source>
+        <translation>ເພີ່ມຄວາມບີ້ງຂວາ</translation>
+    </message>
+    <message>
+        <source>Decrease height up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease height down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease width left</source>
+        <translation>ຫຼຸດຄວາມບີ້ງຊ້າຍ</translation>
+    </message>
+    <message>
+        <source>Decrease width right</source>
+        <translation>ຫຼຸດຄວາມບີ້ງຂວາ</translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation>ຊ່ວຍເຫຼືອ</translation>
+    </message>
+    <message>
+        <source>Display shortcuts</source>
+        <translation>ສະແດງການດຳເນີນງານໄວ</translation>
+    </message>
+    <message>
+        <source>Sound</source>
+        <translation>ສຽງ</translation>
+    </message>
+    <message>
+        <source>Keystroke</source>
+        <translation>ການຄລິກປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <source>Webcam</source>
+        <translation>ເຄື່ອງສັນຍານສາຍການເຊື່ອມຕໍ່</translation>
+    </message>
+    <message>
+        <source>Start recording</source>
+        <translation>ເລີ່ມບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>ຕົວເລືອກ</translation>
+    </message>
+    <message>
+        <source>Start/Recording</source>
+        <translation>ເລີ່ມ/ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation>ເຄື່ອງມື</translation>
+    </message>
+    <message>
+        <source>Extract text</source>
+        <translation>ຖອນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation>ສະກີນສໍາເນົາ</translation>
+    </message>
+    <message>
+        <source>Pin screenshots</source>
+        <translation>ຕິດສະກີນສໍາເນົາ</translation>
+    </message>
+    <message>
+        <source>Start OCR</source>
+        <translation>ເລີ່ມການຮັບຮູ້ຕົວອັກສອນ</translation>
+    </message>
+    <message>
+        <source>Start scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arrow</source>
+        <translation>ລົມ</translation>
+    </message>
+</context>
+<context>
+    <name>ShotStartPlugin</name>
+    <message>
+        <source>Screenshot</source>
+        <translation>ສະກີນສໍາເນົາ</translation>
+    </message>
+</context>
+<context>
+    <name>ShotStartRecordPlugin</name>
+    <message>
+        <source>Record</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>ShotToolWidget</name>
+    <message>
+        <source>Rectangle
+Press and hold Shift to draw a square</source>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Ellipse
+Press and hold Shift to draw a circle</source>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Brush
+Press and hold Shift to draw a straight line</source>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Adjust blur strength (Scroll to adjust it)</source>
+        <translation>ປັບປຸງຄວາມບາບີ່ລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Adjust brush size (Scroll to adjust it)</source>
+        <translation>ປັບປຸງຂະໜາດລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Adjust text size (Scroll to adjust it)</source>
+        <translation>ປັບປຸງຂະໜາດຂໍ້ຄວາມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+</context>
+<context>
+    <name>SubToolWidget</name>
+    <message>
+        <source>Extract Text</source>
+        <translation>ຖອນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>ຕົວເລືອກ</translation>
+    </message>
+    <message>
+        <source>Set a path on save</source>
+        <translation>ຕັ້ງທິດທາງເມື່ອບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Save to</source>
+        <translation>ບັນທຶກໄປທີ່</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation>ພາບຫນ້າທີ່ສະແດງ</translation>
+    </message>
+    <message>
+        <source>Pictures</source>
+        <translation>ພາບຫນ້າທີ່ສະແດງ</translation>
+    </message>
+    <message>
+        <source>Format</source>
+        <translation>ຮູບແບບ</translation>
+    </message>
+    <message>
+        <source>PNG</source>
+        <translation>PNG</translation>
+    </message>
+    <message>
+        <source>JPG</source>
+        <translation>JPG</translation>
+    </message>
+    <message>
+        <source>BMP</source>
+        <translation>BMP</translation>
+    </message>
+    <message>
+        <source>Change the path on save</source>
+        <translation>ປ່ຽນທິດທາງເມື່ອບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Show keystroke (K)</source>
+        <translation>ສະແດງການປ້ອນຂໍ້ຄວາມ (K)</translation>
+    </message>
+    <message>
+        <source>Hide Keystroke (K)</source>
+        <translation>ເລີ່ມປິດການປ້ອນຂໍ້ຄວາມ (K)</translation>
+    </message>
+    <message>
+        <source>Show Keystroke (K)</source>
+        <translation>ສະແດງການປ້ອນຂໍ້ຄວາມ (K)</translation>
+    </message>
+    <message>
+        <source>Turn on camera (C)</source>
+        <translation>ເປີດກຳແພງ (C)</translation>
+    </message>
+    <message>
+        <source>Turn off camera (C)</source>
+        <translation>ປິດກຳແພງ (C)</translation>
+    </message>
+    <message>
+        <source>Screenshot</source>
+        <translation>ພາບເຄື່ອງມື</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>ການຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <source>Settings (F3)</source>
+        <translation>ການຕັ້ງຄ່າ (F3)</translation>
+    </message>
+    <message>
+        <source>Format:</source>
+        <translation>ຮູບແບບ:</translation>
+    </message>
+    <message>
+        <source>GIF</source>
+        <translation>GIF</translation>
+    </message>
+    <message>
+        <source>MP4</source>
+        <translation>MP4</translation>
+    </message>
+    <message>
+        <source>MKV</source>
+        <translation>MKV</translation>
+    </message>
+    <message>
+        <source>webm</source>
+        <translation>webm</translation>
+    </message>
+    <message>
+        <source>FPS:</source>
+        <translation>FPS:</translation>
+    </message>
+    <message>
+        <source>5 fps</source>
+        <translation>5 fps</translation>
+    </message>
+    <message>
+        <source>10 fps</source>
+        <translation>10 fps</translation>
+    </message>
+    <message>
+        <source>20 fps</source>
+        <translation>20 fps</translation>
+    </message>
+    <message>
+        <source>24 fps</source>
+        <translation>24 fps</translation>
+    </message>
+    <message>
+        <source>30 fps</source>
+        <translation>30 fps</translation>
+    </message>
+    <message>
+        <source>Sound</source>
+        <translation>ສຽງ</translation>
+    </message>
+    <message>
+        <source>Microphone</source>
+        <translation>ມີໂຄຣຟອນ</translation>
+    </message>
+    <message>
+        <source>System audio</source>
+        <translation>ສຽງລະບົບ</translation>
+    </message>
+    <message>
+        <source>Show pointer</source>
+        <translation>ສະແດງຕີນກຳແລ່ງ</translation>
+    </message>
+    <message>
+        <source>Show click</source>
+        <translation>ສະແດງການກົດ</translation>
+    </message>
+    <message>
+        <source>Videos</source>
+        <translation>ວີດີໂອ</translation>
+    </message>
+    <message>
+        <source>Line (L)
+Press and hold Shift to draw a vertical or horizontal line</source>
+        <translation>ເສັ້ນ (L)
+ກົດແລະຮັກສາ Shift ເພື່ອໃສ່ເສັ້ນຕັ້ງແຕ້ມຫຼືເສັ້ນນອນ</translation>
+    </message>
+    <message>
+        <source>Arrow (X)
+Press and hold Shift to draw a vertical or horizontal arrow</source>
+        <translation>ລິງ (X)
+ກົດແລະຮັກສາ Shift ເພື່ອໃສ່ລິງຕັ້ງແຕ້ມຫຼືລິງນອນ</translation>
+    </message>
+    <message>
+        <source>Pencil (P)</source>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມຫຼືລົມສີ່ຕັ້ງແຕ້ມ</translation>
+    </message>
+    <message>
+        <source>Blur (B)</source>
+        <translation>ເບື່ອ (B)</translation>
+    </message>
+    <message>
+        <source>Text (T)</source>
+        <translation>ຂໍ້ຄວາມ (T)</translation>
+    </message>
+    <message>
+        <source>Scrollshot (Alt+I）</source>
+        <translation>ສກຣູນສ໌ອດ (Alt+I）</translation>
+    </message>
+    <message>
+        <source>Extract text (Alt+O）</source>
+        <translation>ຖອນຂໍ້ຄວາມ (Alt+O）</translation>
+    </message>
+    <message>
+        <source>Pin screenshots (Alt+P）</source>
+        <translation>ຕິດສະກີນ (Alt+P）</translation>
+    </message>
+    <message>
+        <source>Undo (Ctrl+Z)</source>
+        <translation>ຍົກເລີກ (Ctrl+Z)</translation>
+    </message>
+    <message>
+        <source>Record</source>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Border Effects</source>
+        <translation>ຜົນກະທົບຂອງແຖບ</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>ບໍ່ມີ</translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation>ຮ່າງ</translation>
+    </message>
+    <message>
+        <source>Border</source>
+        <translation>ແຖບ</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>ເຄື່ອງມື</translation>
+    </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>ເຄື່ອງມືເລື່ອນທາງເລກສາດ (R)
+ຄັດລ່ອງ Shift ເພື່ອຂຽນຮູບແບບມູມສູງຫຼືຮູບໂລມ</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>ບັນທຶກໃນທ້ອງຖິ່ນ</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>ບັນທຶກໃສ່ເດີກັບ</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>ບັນທຶກໃສ່ຮູບຖ່າຍ</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>ບັນທຶກໃສ່ %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>ສະຖານທີ່ທີ່ກຳນົດ</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>ສະຖານທີ່ທີ່ກຳນົດເອົາ</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>ການສອບສວນທຸກຄັ້ງ</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>ອັບເດດບ້ານທີ່ບັນທຶກ</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>ບັນທຶກໃສ່ເດີກັດ</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>ບັນທຶກໃສ່ຮູບຖ່າຍ</translation>
+    </message>
+</context>
+<context>
+    <name>ToolBarWidget</name>
+    <message>
+        <source>Close (Esc)</source>
+        <translation>ປິດ (Esc)</translation>
+    </message>
+    <message>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>ແກ້ວລົງໃນຄຳຕອບ (Enter)</translation>
+    </message>
+</context>
+<context>
+    <name>TopTips</name>
+    <message>
+        <source> Adjust the recording area within %1*%2 to get better video effect</source>
+        <translation>ປັບປຸງພາບທີ່ບັນທຶກທີ່ມີຂະໜາດ %1*%2 ເພື່ອໄດ້ຮັບຜົນກະທົບທີ່ດີທີ່ສຸດ</translation>
+    </message>
+</context>
+<context>
+    <name>Utils</name>
+    <message>
+        <source>Screen recording is not supported at present</source>
+        <translation>ການບັນທຶກໜ້າຈໍບໍ່ໄດ້ຮັບການສະໜັບສະໜູນໃນປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>ອອກ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/desktop/desktop_lo.ts
+++ b/translations/desktop/desktop_lo.ts
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin Screen Capture</source>
+        <translation>ການຈັບພາບສະກີນຂອງ Deepin</translation>
+    </message>
+    <message>
+        <location filename="X-Delay Shortcut Group]Name" line="0"/>
+        <source>Delay Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="X-Full Shortcut Group]Name" line="0"/>
+        <source>Full Screenshot</source>
+        <translation>ການຈັບພາບສະກີນທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Record screen</source>
+        <translation>ບັນທຶກສະກີນ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Screen Capture</source>
+        <translation>ການຈັບພາບສະກີນ</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
chore: Add new Lao translation file for deepin-screen-recorder
    
    - Included deepin-screen-recorder_lo.ts in the translations list to support Lao language.
    - This addition enhances localization efforts for a broader user base.
    
    Log: Improve language support by adding Lao translation for the deepin-screen-recorder application.
