### PR TITLE
feat: Add CPU architecture information to system debug output

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -234,6 +234,7 @@ void Utils::showCurrentSys()
     qInfo() << "ProductTypeName: " << DSysInfo::uosProductTypeName();
     qInfo() << "SystemVersion: " << DSysInfo::minorVersion();
     qInfo() << "uosEditionType: " << DSysInfo::uosEditionType();
+    qInfo() << "cpuArchitecture: " << QSysInfo::currentCpuArchitecture();
     //qDebug() << "spVersion: " << DSysInfo::spVersion();
     //qDebug() << "udpateVersion: " << DSysInfo::udpateVersion();
     //qDebug() << "majorVersion: " << DSysInfo::majorVersion();


### PR DESCRIPTION
Add CPU architecture information to system debug output, 
for more convenient for tracing platform-related issues

Log: Add CPU architecture information to system debug output
Bug: https://pms.uniontech.com/bug-view-326039.html