### PR TITLE
fix: Optimize image saving performance on LoongArch64

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1973,9 +1973,12 @@ bool MainWindow::saveImg(const QPixmap &pix, const QString &fileName, const char
             quality = 80;
         }
     }
+    if (QSysInfo::currentCpuArchitecture().startsWith("loongarch64")) {
+        quality = 60;
+    }
     if (status::pinscreenshots == m_functionType) return false;
     if (pix.save(fileName, format, quality)) {
-        qInfo() << __FUNCTION__ << __LINE__ << "保存图片成功！";
+        qInfo() << __FUNCTION__ << __LINE__ << "保存图片成功！保存质量: " << quality;
         return true;
     } else {
         qWarning() << __FUNCTION__ << __LINE__ << "保存图片失败！";


### PR DESCRIPTION
Improved local image saving speed on LoongArch64 architecture by configuring pixmap quality settings. Testing shows quality=60 provides optimal balance between speed and image fidelity.

Log: Enhance LoongArch64 image save performance
Bug: https://pms.uniontech.com/bug-view-326039.html