### PR TITLE
fix: Disable cursor visibility toggle in Wayland screen recording

### DIFF
--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -278,8 +278,9 @@ void SubToolWidget::initRecordLabel()
     }
 
 
-
-    m_cursorMenu->addAction(m_recorderMouse);
+    if (!Utils::isWaylandMode) {
+        m_cursorMenu->addAction(m_recorderMouse);
+    }
     m_cursorMenu->addAction(m_recorderCheck);
 
 


### PR DESCRIPTION
Temporarily disabled the cursor visibility option for Wayland platform recordings, as cursor layer composition is currently handled by the window manager and requires significant architectural changes.

Log: Fix unintended cursor display in Wayland recordings
Bug: https://pms.uniontech.com/bug-view-326531.html