### PR TITLE
fix: Update translations for various languages in deepin-screen-recorder

### DIFF
--- a/translations/deepin-screen-recorder_ar.ts
+++ b/translations/deepin-screen-recorder_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>جاري التسجيل</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>تسجيل</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>لقطة شاشة</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>لقطة شاشة</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>فشلت عملية التقاط الشاشة</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>انقر أو اسحب ل
-اختيار المنطقة للتسجيل</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ select the area to record</source>
         <translation>مقاطع</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>مستطيل (R)
-اضغط واسمح للصيغة لرسم مربع</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>овал (O)
-اضغط واسمح للصيغة لرسم دائرة</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>خط (L)
@@ -631,16 +597,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>تسجيل</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>حافظة</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>صور</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>مجلد</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,51 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <source>Extract Text</source>
         <translation>استخراج النص</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>اضغط واسمح للصيغة لرسم مربعات أو دوائر</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>حفظ إلى الموقع المحلي</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>حفظ إلى المكتب</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>حفظ إلى الصور</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>حفظ إلى %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>موقع محدد</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>موقع مخصص</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>كل سؤال</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>تحديث الموقع عند الحفظ</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>حفظ إلى المكتب</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>حفظ إلى الصور</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +701,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>موافق</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>نسخ إلى الحافظة</translation>
     </message>
 </context>
 <context>
@@ -718,13 +721,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>خروج</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>تسجيل جديد</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_bo.ts
+++ b/translations/deepin-screen-recorder_bo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>བརྙན་ཕབ།</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>བརྙན་ཕབ།</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>བརྙན་བཤུས།</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>བརྙན་བཤུས།</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>པར་དྲས་མ་ཐུབ།</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,14 +439,6 @@ Shiftམནན་ནས་དྲང་ཐིག་འབྲི་ཐུབ།</t
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>གྲླབས་བྱེད་པ་དང་པོ་སྐྱེད་ཞིང་གི་རླབས་བྱེད་པ་རེད་འདུག</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -574,18 +553,6 @@ select the area to record</source>
         <translation>བཪྙན་ཟློས།</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>གྲུ་བཞི་ནར་མོ། (R)
-Shiftམནན་ནས་གྲུ་བཞི་ཁ་གང་འབྲི་ཐུབ།</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>འཇོང་དབྱིབས་ (O)
-Shiftམནན་ནས་སྒོར་དབྱིབས་འབྲི་ཐུབ། </translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>ཕག་ཏོ་ (L)
@@ -630,16 +597,8 @@ Shiftམནན་ནས་ཐད་དཔྱང་དང་ཆུ་སྙོམ
         <translation>བརྙན་ཕབ།</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>དྲས་སྦྱར་པང་།</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>པར་རིས།</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>དམིགས་བཙུགས་ས་གནས།</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -689,6 +648,52 @@ Shiftམནན་ནས་ཐད་དཔྱང་དང་ཆུ་སྙོམ
         <source>Extract Text</source>
         <translation>ཡི་གེ་ངོས་འཛིན།</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>གྲུ་བཞི་ནར་མོ།
+Shiftམནན་ནས་གྲུ་བཞི་ཁ་གང་འབྲི་ཐུབ།</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>ཅོག་ངོས།</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>པར་རིས།</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>དུ་ཉར་བ།</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>ཅོག་ངོས།</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>པར་རིས།</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -697,8 +702,8 @@ Shiftམནན་ནས་ཐད་དཔྱང་དང་ཆུ་སྙོམ
         <translation>ཁ་རྒྱག་(Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>གཏན་འཁེལ་ (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>ཁ་རྒྱག་(Enter)</translation>
     </message>
 </context>
 <context>
@@ -717,13 +722,6 @@ Shiftམནན་ནས་ཐད་དཔྱང་དང་ཆུ་སྙོམ
     <message>
         <source>Exit</source>
         <translation>ཕྱིར་འཐེན།</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>གསར་གྱི་རླབས་བྱེད་པ་ཡིན།</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_br.ts
+++ b/translations/deepin-screen-recorder_br.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="br">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ pe bouezit adarre war ar verradenn evit paouez an enrolladenn</translation>
     <message>
         <source>Recording</source>
         <translation>التسجيل</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Enrollañ</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Tapadenn-skramm</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ pe bouezit adarre war ar verradenn evit paouez an enrolladenn</translation>
     <message>
         <source>Screenshot</source>
         <translation>Tapadenn-skramm</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>فشل التقاط الشاشة.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>اضغط أو اسحب ل
-تحديد المنطقة التي سيتم تسجيلها</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ select the area to record</source>
         <translation>الفيديوهات</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>مستطيل (R)
-اضغط واحتفظ بـ Shift لرسم مربع</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>مستطيل بيضاوي (O)
-اضغط واحتفظ بـ Shift لرسم دائرة</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>الخط (L)
@@ -631,16 +597,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Enrollañ</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>اللصق</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Skeudennoù</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Teuliad</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,51 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <source>Extract Text</source>
         <translation>استخراج النص</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>اضغط واحتفظ بـ Shift لرسم مربعات أو دوائر</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>حفظ إلى الموقع المحلي</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>حفظ إلى المكتب</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>حفظ إلى الصور</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>حفظ إلى %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>موقع محدد</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>موقع مخصص</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>كل سؤال</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>تحديث الموقع عند الحفظ</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>حفظ إلى المكتب</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>حفظ إلى الصور</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +701,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>إغلاق (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>موافق (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>نسخ إلى الحافظة (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +721,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>Kuitaat</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Enrolladenn nevez</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_ca.ts
+++ b/translations/deepin-screen-recorder_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ o premeu la drecera de nou per aturar la gravació.</translation>
     <message>
         <source>Recording</source>
         <translation>Gavació</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Grava</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Captura de pantalla</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ o premeu la drecera de nou per aturar la gravació.</translation>
     <message>
         <source>Screenshot</source>
         <translation>Captura de pantalla</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Ha fallat la captura</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Manteniu premuda la tecla Maj per dibuixar una línia recta.</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Cliqueu o arrossegueu
-per seleccionar l&apos;àrea a gravar</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ per seleccionar l&apos;àrea a gravar</translation>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rectangle (R) 
-Manteniu premuda la tecla Maj per dibuixar un quadrat.</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>El·lipse (O)
-Manteniu premuda la tecla Maj per dibuixar un cercle.</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Línia (L)
@@ -631,16 +597,8 @@ Manteniu premuda la tecla Maj per dibuixar una fletxa vertical o horitzontal.</t
         <translation>Grava</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Porta-retalls</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Fotos</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Carpeta</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,51 @@ Manteniu premuda la tecla Maj per dibuixar una fletxa vertical o horitzontal.</t
         <source>Extract Text</source>
         <translation>Extreu-ne el text</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Manteniu premuda la tecla Maj per dibuixar quadrats o cercles.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Desa a local</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Desa a l&apos;escriptori</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Desa a fotos</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Desa a %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Ubicació especificada</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Ubicació personalitzada</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cada pregunta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Actualitza la ubicació al desar</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Desa a l&apos;escriptori</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Desa a fotos</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +701,8 @@ Manteniu premuda la tecla Maj per dibuixar una fletxa vertical o horitzontal.</t
         <translation>Tanca (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>D&apos;acord (Retorn)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copia a la porta-retalls (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +721,6 @@ Manteniu premuda la tecla Maj per dibuixar una fletxa vertical o horitzontal.</t
     <message>
         <source>Exit</source>
         <translation>Surt</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Gravació nova</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_cs.ts
+++ b/translations/deepin-screen-recorder_cs.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ v oznamovací oblasti panelu nebo stiskněte klávesovou zkratku</translation>
     <message>
         <source>Recording</source>
         <translation>Nahrávání</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Pořídit záznam</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Pořídit snímek obrazovky</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ v oznamovací oblasti panelu nebo stiskněte klávesovou zkratku</translation>
     <message>
         <source>Screenshot</source>
         <translation>Snímek obrazovky</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Pořízení snímku obrazovky se nezdařilo.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Stiskněte a podržte klávesu Shift pro kreslení přímky</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Klepněte nebo táhněte
-pro vybrání oblasti k nahrávání</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ pro vybrání oblasti k nahrávání</translation>
         <translation>Videa</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Obdélník (R)
-Stiskněte a podržte klávesu Shift pro kreslení čtverce</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elipsa (O)
-Stiskněte a podržte klávesu Shift pro kreslení kruhu</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Čára (L)
@@ -631,16 +597,8 @@ Stiskněte a podržte klávesu Shift pro kreslení svislé nebo vodorovné šipk
         <translation>Pořídit záznam</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Schránka</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Obrázky</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Složka</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,51 @@ Stiskněte a podržte klávesu Shift pro kreslení svislé nebo vodorovné šipk
         <source>Extract Text</source>
         <translation>Rozpoznat text</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Držte stisknutou klávesu Shift pro kreslení čtverců nebo kruhů.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Uložit do místního</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Uložit do plochy</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Uložit do obrázků</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Uložit do %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Určené umístění</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Vlastní umístění</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Každá otázka</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Aktualizovat umístění při ukládání</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Uložit do plochy</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Uložit do obrázků</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +701,8 @@ Stiskněte a podržte klávesu Shift pro kreslení svislé nebo vodorovné šipk
         <translation>Zavřít (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Vložit do schránky (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +721,6 @@ Stiskněte a podržte klávesu Shift pro kreslení svislé nebo vodorovné šipk
     <message>
         <source>Exit</source>
         <translation>Ukončit</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nová nahrávka</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_da.ts
+++ b/translations/deepin-screen-recorder_da.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="da">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ eller tryk på genvejen igen, for at stoppe optagelse</translation>
     <message>
         <source>Recording</source>
         <translation>Optagelse</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Optag</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Skærmbillede</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ eller tryk på genvejen igen, for at stoppe optagelse</translation>
     <message>
         <source>Screenshot</source>
         <translation>Skærmbillede</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Skærmbilledet fejler.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Hold Shift nede for at tegne en ret linje</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Klik eller træk for at
-vælge område som skal optages</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ vælge område som skal optages</translation>
         <translation>Videos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rektangel (R)
-Hold Shift nede for at tegne et kvadrat</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipse (O)
-Hold Shift nede for at tegne en cirkel</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linje (L)
@@ -631,16 +597,8 @@ Tryk og hold Shift for at tegne en vertikal eller horisontal pil</translation>
         <translation>Optag</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Udskærsplade</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Billeder</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Mappe</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Tryk og hold Shift for at tegne en vertikal eller horisontal pil</translation>
         <source>Extract Text</source>
         <translation>Udtræk tekst</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometriske værktøjer (R)
+Hold Shift nede for at tegne kvadrater eller cirkler.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Gem til lokal</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Gem til skrivebord</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Gem til billeder</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Gem til %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Angivet sted</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Tilpasset sted</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Hver spørgsmål</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Opdater sted ved gemning</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Gem til skrivebord</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Gem til billeder</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Tryk og hold Shift for at tegne en vertikal eller horisontal pil</translation>
         <translation>Luk (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Kopier til udklipsholder (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Tryk og hold Shift for at tegne en vertikal eller horisontal pil</translation>
     <message>
         <source>Exit</source>
         <translation>Afslut</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Ny optagelse</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_de.ts
+++ b/translations/deepin-screen-recorder_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ oder drücken Sie die Tastenkombination erneut, um die Aufnahme zu stoppen</tran
     <message>
         <source>Recording</source>
         <translation>Wird aufgenommen</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Aufnehmen</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Bildschirmaufnahme</translation>
     </message>
 </context>
 <context>
@@ -97,10 +88,6 @@ oder drücken Sie die Tastenkombination erneut, um die Aufnahme zu stoppen</tran
         <translation>Bildschirmaufnahme</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Bildschirmaufnahme fehlgeschlagen.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Bildlaufaufnahme</translation>
     </message>
@@ -110,7 +97,7 @@ oder drücken Sie die Tastenkombination erneut, um die Aufnahme zu stoppen</tran
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>Deepin Bildschirmaufnahme</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ oder drücken Sie die Tastenkombination erneut, um die Aufnahme zu stoppen</tran
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Bildschirmaufnahme beendet und in die Zwischenablage kopiert</translation>
     </message>
 </context>
 <context>
@@ -452,14 +439,6 @@ Umschalttaste gedrückt halten, um eine gerade Linie zu zeichnen</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Klicken oder ziehen, um den Bildschirmbereich auszuwählen, der aufgenommen wird.</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -574,18 +553,6 @@ select the area to record</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rechteck (R)
-Umschalttaste gedrückt halten, um ein Rechteck zu zeichnen</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipse (O)
-Umschalttaste gedrückt halten, um einen Kreis zu zeichnen</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linie (L)
@@ -630,16 +597,8 @@ Umschalttaste gedrückt halten, um einen vertikalen oder horizontalen Pfeil zu z
         <translation>Aufnehmen</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Zwischenablage</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Bilder</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Ordner</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -689,6 +648,52 @@ Umschalttaste gedrückt halten, um einen vertikalen oder horizontalen Pfeil zu z
         <source>Extract Text</source>
         <translation>Text extrahieren</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometrische Werkzeuge (R)
+Halten Sie die Umschalttaste gedrückt, um Quadrate oder Kreise zu zeichnen.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Lokal speichern</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Auf das Desktop-Verzeichnis speichern</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Auf das Bildverzeichnis speichern</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Auf %1 speichern</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Ange Ort</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Benutzerdefiniertes Ort</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Jede Frage</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Ort beim Speichern aktualisieren</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Auf das Desktop-Verzeichnis speichern</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Auf das Bildverzeichnis speichern</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -697,8 +702,8 @@ Umschalttaste gedrückt halten, um einen vertikalen oder horizontalen Pfeil zu z
         <translation>Schließen (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>In die Zwischenablage kopieren (Enter)</translation>
     </message>
 </context>
 <context>
@@ -717,13 +722,6 @@ Umschalttaste gedrückt halten, um einen vertikalen oder horizontalen Pfeil zu z
     <message>
         <source>Exit</source>
         <translation>Beenden</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Neue Aufnahme</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_en_US.ts
+++ b/translations/deepin-screen-recorder_en_US.ts
@@ -26,17 +26,6 @@ or press the shortcut again to stop recording</translation>
     </message>
 </context>
 <context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Record</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Screenshot</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <source>Screen Capture</source>
@@ -99,10 +88,6 @@ or press the shortcut again to stop recording</translation>
         <translation>Screenshot</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Screenshot failed.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Scrollshot</translation>
     </message>
@@ -112,15 +97,15 @@ or press the shortcut again to stop recording</translation>
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"></translation>
+        <translation>deepin-screen-recorder</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation type="unfinished">Open Folder</translation>
+        <translation>Open Folder</translation>
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Screenshot finished and copy to clipboard</translation>
     </message>
 </context>
 <context>
@@ -149,22 +134,22 @@ or press the shortcut again to stop recording</translation>
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">Screenshot</translation>
+        <translation>Screenshot</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">Record</translation>
+        <translation>Record</translation>
     </message>
 </context>
 <context>
     <name>RecordIconWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">Screenshot</translation>
+        <translation>Screenshot</translation>
     </message>
     <message>
         <source>Recording</source>
-        <translation type="unfinished">Recording</translation>
+        <translation>Recording</translation>
     </message>
 </context>
 <context>
@@ -403,7 +388,7 @@ or press the shortcut again to stop recording</translation>
     </message>
     <message>
         <source>Arrow</source>
-        <translation type="unfinished">Arrow</translation>
+        <translation>Arrow</translation>
     </message>
 </context>
 <context>
@@ -417,7 +402,7 @@ or press the shortcut again to stop recording</translation>
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished">Record</translation>
+        <translation>Record</translation>
     </message>
 </context>
 <context>
@@ -425,275 +410,300 @@ or press the shortcut again to stop recording</translation>
     <message>
         <source>Rectangle
 Press and hold Shift to draw a square</source>
-        <translation type="unfinished"></translation>
+        <translation>Rectangle
+Press and hold Shift to draw a square</translation>
     </message>
     <message>
         <source>Ellipse
 Press and hold Shift to draw a circle</source>
-        <translation type="unfinished"></translation>
+        <translation>Ellipse
+Press and hold Shift to draw a circle</translation>
     </message>
     <message>
         <source>Brush
 Press and hold Shift to draw a straight line</source>
-        <translation type="unfinished"></translation>
+        <translation>Brush
+Press and hold Shift to draw a straight line</translation>
     </message>
     <message>
         <source>Adjust blur strength (Scroll to adjust it)</source>
-        <translation type="unfinished"></translation>
+        <translation>Adjust blur strength (Scroll to adjust it)</translation>
     </message>
     <message>
         <source>Adjust brush size (Scroll to adjust it)</source>
-        <translation type="unfinished"></translation>
+        <translation>Adjust brush size (Scroll to adjust it)</translation>
     </message>
     <message>
         <source>Adjust text size (Scroll to adjust it)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation type="unfinished"></translation>
+        <translation>Adjust text size (Scroll to adjust it)</translation>
     </message>
 </context>
 <context>
     <name>SubToolWidget</name>
     <message>
         <source>Extract Text</source>
-        <translation type="unfinished">Extract Text</translation>
+        <translation>Extract Text</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="unfinished">Options</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation type="unfinished">Folder</translation>
+        <translation>Options</translation>
     </message>
     <message>
         <source>Set a path on save</source>
-        <translation type="unfinished">Set a path on save</translation>
+        <translation>Set a path on save</translation>
     </message>
     <message>
         <source>Save to</source>
-        <translation type="unfinished">Save to</translation>
+        <translation>Save to</translation>
     </message>
     <message>
         <source>Desktop</source>
-        <translation type="unfinished">Desktop</translation>
+        <translation>Desktop</translation>
     </message>
     <message>
         <source>Pictures</source>
-        <translation type="unfinished">Pictures</translation>
-    </message>
-    <message>
-        <source>Clipboard</source>
-        <translation type="unfinished">Clipboard</translation>
+        <translation>Pictures</translation>
     </message>
     <message>
         <source>Format</source>
-        <translation type="unfinished">Format</translation>
+        <translation>Format</translation>
     </message>
     <message>
         <source>PNG</source>
-        <translation type="unfinished">PNG</translation>
+        <translation>PNG</translation>
     </message>
     <message>
         <source>JPG</source>
-        <translation type="unfinished">JPG</translation>
+        <translation>JPG</translation>
     </message>
     <message>
         <source>BMP</source>
-        <translation type="unfinished">BMP</translation>
+        <translation>BMP</translation>
     </message>
     <message>
         <source>Change the path on save</source>
-        <translation type="unfinished">Change the path on save</translation>
+        <translation>Change the path on save</translation>
     </message>
     <message>
         <source>Show keystroke (K)</source>
-        <translation type="unfinished"></translation>
+        <translation>Show keystroke (K)</translation>
     </message>
     <message>
         <source>Hide Keystroke (K)</source>
-        <translation type="unfinished"></translation>
+        <translation>Hide Keystroke (K)</translation>
     </message>
     <message>
         <source>Show Keystroke (K)</source>
-        <translation type="unfinished"></translation>
+        <translation>Show Keystroke (K)</translation>
     </message>
     <message>
         <source>Turn on camera (C)</source>
-        <translation type="unfinished"></translation>
+        <translation>Turn on camera (C)</translation>
     </message>
     <message>
         <source>Turn off camera (C)</source>
-        <translation type="unfinished"></translation>
+        <translation>Turn off camera (C)</translation>
     </message>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">Screenshot</translation>
+        <translation>Screenshot</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished">Settings</translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Settings (F3)</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings (F3)</translation>
     </message>
     <message>
         <source>Format:</source>
-        <translation type="unfinished">Format:</translation>
+        <translation>Format:</translation>
     </message>
     <message>
         <source>GIF</source>
-        <translation type="unfinished">GIF</translation>
+        <translation>GIF</translation>
     </message>
     <message>
         <source>MP4</source>
-        <translation type="unfinished">MP4</translation>
+        <translation>MP4</translation>
     </message>
     <message>
         <source>MKV</source>
-        <translation type="unfinished">MKV</translation>
+        <translation>MKV</translation>
     </message>
     <message>
         <source>webm</source>
-        <translation type="unfinished">webm</translation>
+        <translation>webm</translation>
     </message>
     <message>
         <source>FPS:</source>
-        <translation type="unfinished">FPS:</translation>
+        <translation>FPS:</translation>
     </message>
     <message>
         <source>5 fps</source>
-        <translation type="unfinished">5 fps</translation>
+        <translation>5 fps</translation>
     </message>
     <message>
         <source>10 fps</source>
-        <translation type="unfinished">10 fps</translation>
+        <translation>10 fps</translation>
     </message>
     <message>
         <source>20 fps</source>
-        <translation type="unfinished">20 fps</translation>
+        <translation>20 fps</translation>
     </message>
     <message>
         <source>24 fps</source>
-        <translation type="unfinished">24 fps</translation>
+        <translation>24 fps</translation>
     </message>
     <message>
         <source>30 fps</source>
-        <translation type="unfinished">30 fps</translation>
+        <translation>30 fps</translation>
     </message>
     <message>
         <source>Sound</source>
-        <translation type="unfinished">Sound</translation>
+        <translation>Sound</translation>
     </message>
     <message>
         <source>Microphone</source>
-        <translation type="unfinished">Microphone</translation>
+        <translation>Microphone</translation>
     </message>
     <message>
         <source>System audio</source>
-        <translation type="unfinished"></translation>
+        <translation>System audio</translation>
     </message>
     <message>
         <source>Show pointer</source>
-        <translation type="unfinished">Show pointer</translation>
+        <translation>Show pointer</translation>
     </message>
     <message>
         <source>Show click</source>
-        <translation type="unfinished"></translation>
+        <translation>Show click</translation>
     </message>
     <message>
         <source>Videos</source>
-        <translation type="unfinished">Videos</translation>
-    </message>
-    <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation type="unfinished"></translation>
+        <translation>Videos</translation>
     </message>
     <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
-        <translation type="unfinished"></translation>
+        <translation>Line (L)
+Press and hold Shift to draw a vertical or horizontal line</translation>
     </message>
     <message>
         <source>Arrow (X)
 Press and hold Shift to draw a vertical or horizontal arrow</source>
-        <translation type="unfinished"></translation>
+        <translation>Arrow (X)
+Press and hold Shift to draw a vertical or horizontal arrow</translation>
     </message>
     <message>
         <source>Pencil (P)</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencil (P)</translation>
     </message>
     <message>
         <source>Blur (B)</source>
-        <translation type="unfinished"></translation>
+        <translation>Blur (B)</translation>
     </message>
     <message>
         <source>Text (T)</source>
-        <translation type="unfinished"></translation>
+        <translation>Text (T)</translation>
     </message>
     <message>
         <source>Scrollshot (Alt+I）</source>
-        <translation type="unfinished"></translation>
+        <translation>Scrollshot (Alt+I）</translation>
     </message>
     <message>
         <source>Extract text (Alt+O）</source>
-        <translation type="unfinished"></translation>
+        <translation>Extract text (Alt+O）</translation>
     </message>
     <message>
         <source>Pin screenshots (Alt+P）</source>
-        <translation type="unfinished"></translation>
+        <translation>Pin screenshots (Alt+P）</translation>
     </message>
     <message>
         <source>Undo (Ctrl+Z)</source>
-        <translation type="unfinished"></translation>
+        <translation>Undo (Ctrl+Z)</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished">Record</translation>
+        <translation>Record</translation>
     </message>
     <message>
         <source>Border Effects</source>
-        <translation type="unfinished"></translation>
+        <translation>Border Effects</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>None</translation>
     </message>
     <message>
         <source>Shadow</source>
-        <translation type="unfinished"></translation>
+        <translation>Shadow</translation>
     </message>
     <message>
         <source>Border</source>
-        <translation type="unfinished"></translation>
+        <translation>Border</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Device</translation>
+    </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Save to local</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Save to Desktop</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Save to Pictures</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Save to %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Specified Location</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Custom Location</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Each inquiry</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Update location on save</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Save to desktop</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Save to pictures</translation>
     </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
     <message>
         <source>Close (Esc)</source>
-        <translation type="unfinished"></translation>
+        <translation>Close (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation type="unfinished"></translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copy to clipboard (Enter)</translation>
     </message>
 </context>
 <context>
@@ -712,13 +722,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>Exit</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_es.ts
+++ b/translations/deepin-screen-recorder_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ o haga clic en el icono de la bandeja</translation>
     <message>
         <source>Recording</source>
         <translation>Grabaciones</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Grabación</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Captura de pantalla</translation>
     </message>
 </context>
 <context>
@@ -97,10 +88,6 @@ o haga clic en el icono de la bandeja</translation>
         <translation>Captura de pantalla</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Captura de pantalla fallida</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Capturar desplazamiento</translation>
     </message>
@@ -110,7 +97,7 @@ o haga clic en el icono de la bandeja</translation>
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>deepin-screen-recorder</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ o haga clic en el icono de la bandeja</translation>
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Captura de pantalla finalizada y copiada al portapapeles</translation>
     </message>
 </context>
 <context>
@@ -452,15 +439,6 @@ Mantenga presionada la tecla Mayús para dibujar una línea recta</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Haz clic o arrástrala
-para seleccionar el área a grabar.</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ para seleccionar el área a grabar.</translation>
         <translation>Videos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rectángulo (R)
-Mantenga presionada la tecla Mayús para dibujar un cuadrado</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipse (O)
-Mantenga presionada la tecla Mayús para dibujar un círculo</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Línea (L)
@@ -631,16 +597,8 @@ Mantenga presionada la tecla Mayús para dibujar una flecha vertical u horizonta
         <translation>Grabación</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Portapapeles</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Imágenes</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Carpeta</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Mantenga presionada la tecla Mayús para dibujar una flecha vertical u horizonta
         <source>Extract Text</source>
         <translation>Extraer texto</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Herramientas geométricas (R)
+Mantenga presionada la tecla Shift para dibujar cuadrados o círculos.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Guardar en local</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Guardar en escritorio</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Guardar en imágenes</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Guardar en %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Ubicación especificada</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Ubicación personalizada</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cada consulta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Actualizar ubicación al guardar</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Guardar en escritorio</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Guardar en imágenes</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Mantenga presionada la tecla Mayús para dibujar una flecha vertical u horizonta
         <translation>Cerrar (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Aceptar (Entrar)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copiar al portapapeles (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Mantenga presionada la tecla Mayús para dibujar una flecha vertical u horizonta
     <message>
         <source>Exit</source>
         <translation>Salir</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nueva grabación</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_fi.ts
+++ b/translations/deepin-screen-recorder_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ tai lopeta tallennus painamalla pikakuvaketta uudelleen</translation>
     <message>
         <source>Recording</source>
         <translation>Tallennus</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Tallenna</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Kaappaus</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ tai lopeta tallennus painamalla pikakuvaketta uudelleen</translation>
     <message>
         <source>Screenshot</source>
         <translation>Kaappaus</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Kaappaus epäonnistui.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Vedä suora viiva pitämällä Shift-painettuna</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Napsauta tai vedä
-valitse tallennettava alue</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ valitse tallennettava alue</translation>
         <translation>Videot</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Suorakulmio (R)
-Piirrä neliö pitämällä Shift-painettuna</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipsi (O).
-Piirrä ympyrä pitämällä Shift-painettuna</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Viiva (L)
@@ -631,16 +597,8 @@ Vedä suora pysty- tai vaakanuoli pitämällä Shift-painettuna</translation>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Leikepöydälle</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Kuvat</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Kansio</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Vedä suora pysty- tai vaakanuoli pitämällä Shift-painettuna</translation>
         <source>Extract Text</source>
         <translation>Poimi tekstiä</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometriset työkalut (R)
+Pidä Shift-näppäintä painettuna piirtääksesi neliöitä tai ympyröitä.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Tallenna paikallisesti</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Tallenna työpöydälle</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Tallenna kuvakkeisiin</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Tallenna nimellä %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Määritetty sijainti</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Mukautettu sijainti</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Jokainen kysely</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Päivitä sijainti tallessa</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Tallenna työpöydälle</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Tallenna kuvakkeisiin</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Vedä suora pysty- tai vaakanuoli pitämällä Shift-painettuna</translation>
         <translation>Sulje (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Kopioi leikepöydälle (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Vedä suora pysty- tai vaakanuoli pitämällä Shift-painettuna</translation>
     <message>
         <source>Exit</source>
         <translation>Poistu</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Uusi äänitys</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_fr.ts
+++ b/translations/deepin-screen-recorder_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ ou appuyer à nouveau sur le raccourci pour arrêter l&apos;enregistrement</tran
     <message>
         <source>Recording</source>
         <translation>Enregistrement</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Enregistrer</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Capture d&apos;écran</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ ou appuyer à nouveau sur le raccourci pour arrêter l&apos;enregistrement</tran
     <message>
         <source>Screenshot</source>
         <translation>Capture d&apos;écran</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Échec de la capture d&apos;écran.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Maintenir la touche Maj enfoncée pour dessiner une ligne</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Cliquer ou maintenir le bouton de la souris
-afin de sélectionner la zone à enregistrer</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ afin de sélectionner la zone à enregistrer</translation>
         <translation>Vidéos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rectangle (R)
-Maintenir la touche Maj enfoncée pour dessiner un carré</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipse (O)
-Maintenir la touche Maj enfoncée pour dessiner un cercle</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Ligne (L)
@@ -631,16 +597,8 @@ Maintenir la touche Maj enfoncée pour dessiner une flèche verticale ou horizon
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Presse-papiers</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Images</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Dossier</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Maintenir la touche Maj enfoncée pour dessiner une flèche verticale ou horizon
         <source>Extract Text</source>
         <translation>Extraire le texte</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Outils géométriques (R)
+Maintenir la touche Maj enfoncée pour dessiner des carrés ou des cercles.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Enregistrer localement</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Enregistrer sur le bureau</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Enregistrer dans les images</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Enregistrer dans %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Emplacement spécifié</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Emplacement personnalisé</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Chaque demande</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Mettre à jour l&apos;emplacement lors de l&apos;enregistrement</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Enregistrer sur le bureau</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Enregistrer dans les images</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Maintenir la touche Maj enfoncée pour dessiner une flèche verticale ou horizon
         <translation>Fermer (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Entrée)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copier dans le presse-papiers (Entrée)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Maintenir la touche Maj enfoncée pour dessiner une flèche verticale ou horizon
     <message>
         <source>Exit</source>
         <translation>Quitter</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nouveau enregistrement</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_gl_ES.ts
+++ b/translations/deepin-screen-recorder_gl_ES.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ ou prema de novo o atallo para deixar de gravar</translation>
     <message>
         <source>Recording</source>
         <translation>Gravando</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Gravar</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Captura de pantalla</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ ou prema de novo o atallo para deixar de gravar</translation>
     <message>
         <source>Screenshot</source>
         <translation>Captura de pantalla</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Produciuse un erro na captura de pantalla.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Manteña premida a tecla Maiúsculas para debuxar unha liña recta</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Fai clic ou arrastra
-para seleccionar a área a gravar</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ para seleccionar a área a gravar</translation>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rectángulo (R)
-Manteña premida a tecla Maiúsculas para debuxar un cadrado</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elipse (O)
-Manteña premida a tecla Maiúsculas para debuxar un círculo</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Liña (L)
@@ -631,16 +597,8 @@ Manteña premida a tecla Maiúsculas para debuxar unha frecha vertical ou horizo
         <translation>Gravar</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Portapapeis</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Imaxes</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Cartafol</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Manteña premida a tecla Maiúsculas para debuxar unha frecha vertical ou horizo
         <source>Extract Text</source>
         <translation>Extraer texto</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Ferramentas xeométricas (R)
+Mantén premida a tecla Maiús para debuxar cadrados ou círculos.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Gardar no local</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Gardar no escritorio</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Gardar en imaxes</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Gardar en %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Localización especificada</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Localización personalizada</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cada consulta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Actualizar a localización ao gardar</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Gardar no escritorio</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Gardar en imaxes</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Manteña premida a tecla Maiúsculas para debuxar unha frecha vertical ou horizo
         <translation>Pechar (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Aceptar (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copiar ao portapapeis (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Manteña premida a tecla Maiúsculas para debuxar unha frecha vertical ou horizo
     <message>
         <source>Exit</source>
         <translation>Saír</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nova gravación</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_hu.ts
+++ b/translations/deepin-screen-recorder_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ vagy nyomja le a gyorsbillentyűt ismét a felvétel megállításához</transla
     <message>
         <source>Recording</source>
         <translation>Rögzítés</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Felvétel</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Képernyőkép</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ vagy nyomja le a gyorsbillentyűt ismét a felvétel megállításához</transla
     <message>
         <source>Screenshot</source>
         <translation>Képernyőkép</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>A képernyőkép készítése sikertelen</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Egyenes vonal rajzolásához tartsa lenyomva a Shift billentyűt</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Terület felvételéhez
-használjuk az egeret</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ használjuk az egeret</translation>
         <translation>Videók</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Téglalap (R)
-Négyzet rajzolásához tartsa lenyomva a Shift billentyűt</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellipszis (O)
-Kör rajzolásához tartsa lenyomva a Shift billentyűt</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Vonal (L)
@@ -631,16 +597,8 @@ Függőleges vagy vízszintes nyíl rajzolásához tartsa lenyomva a Shift bille
         <translation>Felvétel</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Vágólap</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Képek</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Mappa</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Függőleges vagy vízszintes nyíl rajzolásához tartsa lenyomva a Shift bille
         <source>Extract Text</source>
         <translation>Szöveg kivonat</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometriai eszközök (R)
+Tartsa lenyomva a Shift billentyűt négyzetek vagy körök rajzolásához.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Mentés helyi könyvtárba</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Mentés asztalra</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Mentés képekhez</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Mentés ide: %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Megadott hely</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Egyedi hely</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Minden kérés</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Mentéskor frissítse a helyet</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Mentés asztalra</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Mentés képekhez</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Függőleges vagy vízszintes nyíl rajzolásához tartsa lenyomva a Shift bille
         <translation>Bezárás (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Másolás a vágólapra (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Függőleges vagy vízszintes nyíl rajzolásához tartsa lenyomva a Shift bille
     <message>
         <source>Exit</source>
         <translation>Kilépés</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Új felvétel</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_it.ts
+++ b/translations/deepin-screen-recorder_it.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
     <message>
         <source>Recording</source>
         <translation>Registrazione in corso</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Registrazione</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Screenshot</translation>
     </message>
 </context>
 <context>
@@ -97,10 +88,6 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
         <translation>Screenshot</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Screenshot fallito.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Screenshot a scorrimento</translation>
     </message>
@@ -110,7 +97,7 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>Deepin Screen Recorder</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Screenshot completato e copiato negli appunti</translation>
     </message>
 </context>
 <context>
@@ -147,22 +134,22 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
     <name>QuickPanelWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished"/>
+        <translation>Screenshot</translation>
     </message>
     <message>
         <source>Record</source>
-        <translation type="unfinished"/>
+        <translation>Registrazione</translation>
     </message>
 </context>
 <context>
     <name>RecordIconWidget</name>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished"/>
+        <translation>Screenshot</translation>
     </message>
     <message>
         <source>Recording</source>
-        <translation type="unfinished"/>
+        <translation>Registrazione in corso</translation>
     </message>
 </context>
 <context>
@@ -415,7 +402,7 @@ o utilizza nuovamente la scorciatoia da tastiera per terminare la registrazione<
     <name>ShotStartRecordPlugin</name>
     <message>
         <source>Record</source>
-        <translation type="unfinished"/>
+            <translation>Registrazione</translation>
     </message>
 </context>
 <context>
@@ -449,15 +436,6 @@ Tieni premuto Maiusc per tracciare una linea retta</translation>
     <message>
         <source>Adjust text size (Scroll to adjust it)</source>
         <translation>Regola la dimensione testo (scorri per regolarla)</translation>
-    </message>
-</context>
-<context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Clicca o trascina
-seleziona l&apos;area da registrare</translation>
     </message>
 </context>
 <context>
@@ -575,18 +553,6 @@ seleziona l&apos;area da registrare</translation>
         <translation>Video</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rettangolo (R)
-Tieni premuto Maiusc per disegnare un quadrato</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ellisse (O)
-Tieni premuto Maiusc per disegnare un cerchio</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linea (L)
@@ -631,16 +597,8 @@ Tieni premuto Maiusc per disegnare una freccia verticale o orizzontale</translat
         <translation>Registrazione</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Appunti</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Immagini</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Cartella</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Tieni premuto Maiusc per disegnare una freccia verticale o orizzontale</translat
         <source>Extract Text</source>
         <translation>Estrai testo</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Strumenti geometrici (R)
+Tieni premuto Maiusc per disegnare quadrati o cerchi.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Salva nella cartella locale</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Salva sul desktop</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Salva nelle immagini</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Salva in %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Posizione specificata</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Posizione personalizzata</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Ogni richiesta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Aggiorna la posizione al salvataggio</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Salva sul desktop</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Salva nelle immagini</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Tieni premuto Maiusc per disegnare una freccia verticale o orizzontale</translat
         <translation>Chiudi (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Invio)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copia negli appunti (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Tieni premuto Maiusc per disegnare una freccia verticale o orizzontale</translat
     <message>
         <source>Exit</source>
         <translation>Esci</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nuova registrazione</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_ko.ts
+++ b/translations/deepin-screen-recorder_ko.ts
@@ -1,10 +1,12 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>CountdownTooltip</name>
     <message>
         <source>Click the tray icon 
 or press the shortcut again to stop recording</source>
-        <translation>트레이 아이콘 클릭 
+        <translation>트레이 아이콘 클릭&#xa0;
 또는 단축키를 다시 눌러 녹화를 중지하십시오</translation>
     </message>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>녹화</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>녹화하기</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>스크린샷</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>스크린샷</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>화면 캡처 실패</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -455,15 +442,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>클릭하거나 드래그하여
-녹화할 영역 선택</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -578,20 +556,6 @@ select the area to record</source>
         <translation>비디오</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>|-
- 사각형 (R)
- Shift를 누르고 놓아 정사각형을 그립니다</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>|-
- 타원 (O)
- Shift를 누르고 놓아 원을 그립니다</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>|-
@@ -637,16 +601,8 @@ Shift를 누르고 놓아 수직 또는 수평 화살표를 그립니다</transl
         <translation>녹화하기</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>클립보드</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>사진</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>폴더</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -696,6 +652,52 @@ Shift를 누르고 놓아 수직 또는 수평 화살표를 그립니다</transl
         <source>Extract Text</source>
         <translation>텍스트 추출</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>도형 도구 (R)
+Shift 키를 누른 채로 정사각형이나 원을 그립니다.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>로컬에 저장</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>바탕화면에 저장</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>사진에 저장</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>%1에 저장</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>지정된 위치</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>사용자 지정 위치</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>각 조회</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>저장 시 위치 업데이트</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>바탕화면에 저장</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>사진에 저장</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -704,8 +706,8 @@ Shift를 누르고 놓아 수직 또는 수평 화살표를 그립니다</transl
         <translation>닫기 (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>확인 (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>클립보드에 복사 (Enter)</translation>
     </message>
 </context>
 <context>
@@ -724,13 +726,6 @@ Shift를 누르고 놓아 수직 또는 수평 화살표를 그립니다</transl
     <message>
         <source>Exit</source>
         <translation>종료</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>새 녹화</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_lo.ts
+++ b/translations/deepin-screen-recorder_lo.ts
@@ -6,7 +6,8 @@
     <message>
         <source>Click the tray icon 
 or press the shortcut again to stop recording</source>
-        <translation type="unfinished"></translation>
+        <translation>ກົດທີ່ລູກຕີນກີບຂອງທ່ານ
+ຫຼືກົດລະຫັດທີ່ສະແດງອີກຄັ້ງເພື່ອຢຸດການບັນທຶກ</translation>
     </message>
     <message>
         <source>Do not rotate your screen during recording</source>
@@ -251,11 +252,11 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Delay screenshot</source>
-        <translation type="unfinished"></translation>
+        <translation>ພາບສັນຍານຫ້ອຍ</translation>
     </message>
     <message>
         <source>Full screenshot</source>
-        <translation type="unfinished"></translation>
+        <translation>ພາບສັນຍານທັງຫມົດ</translation>
     </message>
     <message>
         <source>Exit</source>
@@ -267,7 +268,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Rectangle</source>
-        <translation type="unfinished"></translation>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມ</translation>
     </message>
     <message>
         <source>Ellipse</source>
@@ -279,11 +280,11 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Pencil</source>
-        <translation type="unfinished"></translation>
+        <translation>ລົມສີ່ຕັ້ງແຕ້ມ</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="unfinished"></translation>
+        <translation>ຂໍ້ຄວາມ</translation>
     </message>
     <message>
         <source>Delete</source>
@@ -295,11 +296,11 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Increase height up</source>
-        <translation type="unfinished"></translation>
+        <translation>ເພີ່ມຄວາມຍາວຂຶ້ນ</translation>
     </message>
     <message>
         <source>Increase height down</source>
-        <translation type="unfinished"></translation>
+        <translation>ເພີ່ມຄວາມຍາວລຸ່ມ</translation>
     </message>
     <message>
         <source>Increase width left</source>
@@ -311,11 +312,11 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Decrease height up</source>
-        <translation type="unfinished"></translation>
+        <translation>ລົດຄວາມຍາວຂຶ້ນ</translation>
     </message>
     <message>
         <source>Decrease height down</source>
-        <translation type="unfinished"></translation>
+        <translation>ລົດຄວາມຍາວລຸ່ມ</translation>
     </message>
     <message>
         <source>Decrease width left</source>
@@ -359,7 +360,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation>ຕີນກີບ</translation>
     </message>
     <message>
         <source>Tools</source>
@@ -383,7 +384,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Start scrollshot</source>
-        <translation type="unfinished"></translation>
+        <translation>ເລີ່ມສະກີນສໍາເນົາ</translation>
     </message>
     <message>
         <source>Arrow</source>

--- a/translations/deepin-screen-recorder_ms.ts
+++ b/translations/deepin-screen-recorder_ms.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ atau klik pintasan sekali lagi untuk hentikan rakaman</translation>
     <message>
         <source>Recording</source>
         <translation>Rakaman</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Rakam</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Tangkap Layar</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ atau klik pintasan sekali lagi untuk hentikan rakaman</translation>
     <message>
         <source>Screenshot</source>
         <translation>Tangkap Layar</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Gagal ditangkap layar.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Tekan dan tahan kekunci Shift untuk membentuk satu garisan lurus</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Klik atau seret untuk
-pilih kawasan rakaman</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ pilih kawasan rakaman</translation>
         <translation>Video</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Segiempat (R)
-Tekan dan tahan kekunci Shift untuk melukis sebuah segiempat</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elips (O)
-Tekan dan tahan kekunci Shift untuk melukis sebuah bulatan</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Garisan (L)
@@ -631,16 +597,8 @@ Tekan dan tahan kekunci Shift untuk melukis anak panah menegak atau mengufuk</tr
         <translation>Rakam</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Papan keratan</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Gambar</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Folder</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Tekan dan tahan kekunci Shift untuk melukis anak panah menegak atau mengufuk</tr
         <source>Extract Text</source>
         <translation>Ekstrak Teks</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Alat Geometri (R)
+Tahan Shift untuk melukis segi empat sama atau bulatan.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Simpan ke lokal</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Simpan ke Desktop</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Simpan ke Gambar</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Simpan ke %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Lokasi Tertentu</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Lokasi Pilihan</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Setiap pertanyaan</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Kemaskini lokasi semasa simpan</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Simpan ke Desktop</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Simpan ke Gambar</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Tekan dan tahan kekunci Shift untuk melukis anak panah menegak atau mengufuk</tr
         <translation>Tutup (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Salin ke papan klip (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Tekan dan tahan kekunci Shift untuk melukis anak panah menegak atau mengufuk</tr
     <message>
         <source>Exit</source>
         <translation>Keluar</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Rakaman baharu</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_nl.ts
+++ b/translations/deepin-screen-recorder_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ of druk nogmaals op de sneltoets om te stoppen</translation>
     <message>
         <source>Recording</source>
         <translation>Opname</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Opnemen</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Schermfoto</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ of druk nogmaals op de sneltoets om te stoppen</translation>
     <message>
         <source>Screenshot</source>
         <translation>Schermfoto</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>De schermfoto kan niet worden gemaakt.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Houd Shift ingedrukt om een rechte lijn te trekken</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Klik of sleep om
-het opnamegebied te kiezen</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ het opnamegebied te kiezen</translation>
         <translation>Video&apos;s</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rechthoek (R)
-Houd Shift ingedrukt om een vierkant te trekken</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Ovaal (O)
-Houd Shift ingedrukt om een cirkel te trekken</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Lijn (L)
@@ -631,16 +597,8 @@ Houd Shift ingedrukt om een verticale of horizontale pijl te tekenen</translatio
         <translation>Opnemen</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Klembord</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Afbeeldingen</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Andere map</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Houd Shift ingedrukt om een verticale of horizontale pijl te tekenen</translatio
         <source>Extract Text</source>
         <translation>Tekst extraheren</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometrische hulpmiddelen (R)
+Houd Shift ingedrukt om vierkanten of cirkels te tekenen.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Opslaan naar lokale map</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Opslaan naar bureaublad</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Opslaan naar afbeeldingen</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Opslaan naar %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Specifieke locatie</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Aangepaste locatie</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Elke vraag</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Locatie bijwerken bij opslaan</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Opslaan naar bureaublad</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Opslaan naar afbeeldingen</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Houd Shift ingedrukt om een verticale of horizontale pijl te tekenen</translatio
         <translation>Sluiten (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Oké (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Kopiëren naar klembord (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Houd Shift ingedrukt om een verticale of horizontale pijl te tekenen</translatio
     <message>
         <source>Exit</source>
         <translation>Afsluiten</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Opname maken</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_pl.ts
+++ b/translations/deepin-screen-recorder_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ lub naciśnij ponownie skrót, aby zatrzymać nagrywanie</translation>
     <message>
         <source>Recording</source>
         <translation>Nagrywanie</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Nagrywanie</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Zrzut ekranu</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ lub naciśnij ponownie skrót, aby zatrzymać nagrywanie</translation>
     <message>
         <source>Screenshot</source>
         <translation>Zrzut ekranu</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Zrzut ekranu nie powiódł się.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Przytrzymaj Shift, aby rysować prostą linię</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Kliknij lub przeciągnij do zaznaczonego
-obszaru, aby zacząć nagrywać</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ obszaru, aby zacząć nagrywać</translation>
         <translation>Filmy</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Prostokąt (R)
-Przytrzymaj Shift, aby rysować kwadrat</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elipsa (O)
-Przytrzymaj Shift, aby rysować koło</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linia (L)
@@ -631,16 +597,8 @@ Przytrzymaj Shift, aby rysować pionową lub poziomą strzałkę</translation>
         <translation>Nagrywanie</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Schowek</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Zdjęcia</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Folder</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Przytrzymaj Shift, aby rysować pionową lub poziomą strzałkę</translation>
         <source>Extract Text</source>
         <translation>Wydobądź tekst</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Narzędzia geometryczne (R)
+Przytrzymaj Shift, aby narysować kwadraty lub koła.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Zapisz lokalnie</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Zapisz na pulpicie</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Zapisz na zdjęcia</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Zapisz w %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Określone miejsce</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Niestandardowe miejsce</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Każde zapytanie</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Zaktualizuj lokalizację przy zapisie</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Zapisz na pulpicie</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Zapisz na zdjęcia</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Przytrzymaj Shift, aby rysować pionową lub poziomą strzałkę</translation>
         <translation>Zamknij (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Skopiuj do schowka (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Przytrzymaj Shift, aby rysować pionową lub poziomą strzałkę</translation>
     <message>
         <source>Exit</source>
         <translation>Wyjdź</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nowe nagranie</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_pt.ts
+++ b/translations/deepin-screen-recorder_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ ou pressione novamente o atalho para parar de gravar</translation>
     <message>
         <source>Recording</source>
         <translation>Gravação</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Gravar</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Captura de ecrã</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ ou pressione novamente o atalho para parar de gravar</translation>
     <message>
         <source>Screenshot</source>
         <translation>Captura de ecrã</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>A captura de ecrã falhou.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Pressionar e manter Shift para desenhar uma linha reta</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Clique ou arraste para
-selecionar a área a gravar</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ selecionar a área a gravar</translation>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Rectângulo (R)
-Pressionar e manter Shift para desenhar um quadrado</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elipse (O)
-Pressionar e manter Shift para desenhar um círculo</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linha (L)
@@ -631,16 +597,8 @@ Pressionar e manter Shift para desenhar uma seta vertical ou horizontal</transla
         <translation>Gravar</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Área de transferência</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Imagens</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Pasta</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Pressionar e manter Shift para desenhar uma seta vertical ou horizontal</transla
         <source>Extract Text</source>
         <translation>Extrair texto</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Ferramentas geométricas (R)
+Mantenha pressionada a tecla Shift para desenhar quadrados ou círculos.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Salvar localmente</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Salvar no ambiente de trabalho</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Salvar em imagens</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Salvar em %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Localização especificada</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Localização personalizada</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cada consulta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Atualizar localização ao salvar</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Salvar no ambiente de trabalho</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Salvar em imagens</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Pressionar e manter Shift para desenhar uma seta vertical ou horizontal</transla
         <translation>Fechar (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Aceitar (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copiar para a área de transferência (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Pressionar e manter Shift para desenhar uma seta vertical ou horizontal</transla
     <message>
         <source>Exit</source>
         <translation>Sair</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nova gravação</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_pt_BR.ts
+++ b/translations/deepin-screen-recorder_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ clique no ícone da bandeja ou use o atalho</translation>
     <message>
         <source>Recording</source>
         <translation>Gravando</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Gravar</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Capturar</translation>
     </message>
 </context>
 <context>
@@ -97,10 +88,6 @@ clique no ícone da bandeja ou use o atalho</translation>
         <translation>Capturar</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>A captura de tela falhou.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Tela de rolagem</translation>
     </message>
@@ -110,7 +97,7 @@ clique no ícone da bandeja ou use o atalho</translation>
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>Gravador de Tela Deepin</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ clique no ícone da bandeja ou use o atalho</translation>
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Captura concluída e copiada para a área de transferência</translation>
     </message>
 </context>
 <context>
@@ -452,15 +439,6 @@ Mantenha pressionada a tecla Shift para desenhar uma linha reta</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Clique ou arraste para
-selecione a área para gravar</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ selecione a área para gravar</translation>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Retângulo (R)
-Mantenha pressionada a tecla Shift para desenhar um quadrado</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elipse (O)
-Mantenha pressionada a tecla Shift para desenhar um círculo</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Linha (L)
@@ -631,16 +597,8 @@ Mantenha pressionada a tecla Shift para desenhar uma seta vertical ou horizontal
         <translation>Gravar</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Área de Transferência</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Imagens</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Pasta</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Mantenha pressionada a tecla Shift para desenhar uma seta vertical ou horizontal
         <source>Extract Text</source>
         <translation>Extrair texto</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Ferramentas geométricas (R)
+Mantenha pressionada a tecla Shift para desenhar quadrados ou círculos.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Salvar localmente</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Salvar na área de trabalho</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Salvar em imagens</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Salvar em %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Localização especificada</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Localização personalizada</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cada consulta</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Atualizar localização ao salvar</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Salvar na área de trabalho</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Salvar em imagens</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Mantenha pressionada a tecla Shift para desenhar uma seta vertical ou horizontal
         <translation>Fechar (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Ok (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Copiar para a área de transferência (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Mantenha pressionada a tecla Shift para desenhar uma seta vertical ou horizontal
     <message>
         <source>Exit</source>
         <translation>Sair</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Nova gravação</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_ru.ts
+++ b/translations/deepin-screen-recorder_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>Запись</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Запись</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Скриншот</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>Скриншот</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Не удалось создать Снимок экрана</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Щелкните или тащите
-выбранную область записи</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ select the area to record</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Прямоугольник (R)
-Нажмите и удерживайте Shift, чтобы нарисовать квадрат</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Эллипс (O)
-Нажмите и удерживайте Shift, чтобы нарисовать окружность</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Линия (L)
@@ -631,16 +597,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Запись</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Буфер обмена</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Изображения</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Папка</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <source>Extract Text</source>
         <translation>Извлечь Текст</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Геометрические инструменты (R)
+Удерживайте Shift для рисования квадратов или кругов.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Сохранить локально</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Сохранить на рабочий стол</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Сохранить в изображения</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Сохранить в %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Указанное место</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Пользовательское место</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Каждый запрос</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Обновить место при сохранении</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Сохранить на рабочий стол</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Сохранить в изображения</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Закрыть (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>ОК (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Скопировать в буфер обмена (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>Выход</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Новая запись</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_sq.ts
+++ b/translations/deepin-screen-recorder_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
     <message>
         <source>Recording</source>
         <translation>Regjistrim</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Regjistroje</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Foto ekrani</translation>
     </message>
 </context>
 <context>
@@ -97,12 +88,8 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
         <translation>Foto ekrani</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Fotografimi i ekranit dështoi.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation>Foto ekrani me rrëshqitje</translation>
     </message>
     <message>
         <source>Pin Screenshots</source>
@@ -110,7 +97,7 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>deepin-screen-recorder</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Fotoja e ekranit u bë dhe u kopjua te papastër</translation>
     </message>
 </context>
 <context>
@@ -385,7 +372,7 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation>Foto ekrani me rrëshqitje</translation>
     </message>
     <message>
         <source>Pin screenshots</source>
@@ -397,7 +384,7 @@ klikoni ikonën e panelit, ose rishtypni shkurtoren</translation>
     </message>
     <message>
         <source>Start scrollshot</source>
-        <translation type="unfinished"/>
+        <translation>Fillo foto ekrani me rrëshqitje</translation>
     </message>
     <message>
         <source>Arrow</source>
@@ -449,15 +436,6 @@ Shtypni dhe mbani të shtypur tastin Shift që të vizatohet një vijë e drejt�
     <message>
         <source>Adjust text size (Scroll to adjust it)</source>
         <translation>Rregulloni madhësi teksti (Për ta rregulluar, rrëshqitni)</translation>
-    </message>
-</context>
-<context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Që të përzgjidhet zona për
-regjistrim, klikoni, ose tërhiqeni</translation>
     </message>
 </context>
 <context>
@@ -575,18 +553,6 @@ regjistrim, klikoni, ose tërhiqeni</translation>
         <translation>Video</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Drejtkëndësh (R)
-Shtypni dhe mbani të shtypur tastin Shift që të vizatohet një katror</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elips (O)
-Shtypni dhe mbani të shtypur tastin Shift që të vizatohet një rreth</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Vijë (L)
@@ -612,7 +578,7 @@ Shtypni dhe mbani të shtypur tastin Shift, që të vizatohet një shigjetë ver
     </message>
     <message>
         <source>Scrollshot (Alt+I）</source>
-        <translation type="unfinished"/>
+        <translation>Foto ekrani me rrëshqitje (Alt+I）</translation>
     </message>
     <message>
         <source>Extract text (Alt+O）</source>
@@ -631,16 +597,8 @@ Shtypni dhe mbani të shtypur tastin Shift, që të vizatohet një shigjetë ver
         <translation>Regjistro</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>E papastër</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Foto</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Dosje</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Shtypni dhe mbani të shtypur tastin Shift, që të vizatohet një shigjetë ver
         <source>Extract Text</source>
         <translation>Përfto Tekst</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Mjete Geometrike (R)
+Mbani të shtypur tastin Shift që të vizatohet një drejtkëndësh ose një rreth.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Ruaje te lokali</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Ruaje te Desktop</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Ruaje te Foto</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Ruaje te %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Vendndodhje Specifikuar</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Vendndodhje Përzgjedhje</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Cdo pyetje</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Përditëso vendndodhjen gjatë ruajtjes</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Ruaje te Desktop</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Ruaje te Foto</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Shtypni dhe mbani të shtypur tastin Shift, që të vizatohet një shigjetë ver
         <translation>Mbylle (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>OK (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Kopjo te papastër (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Shtypni dhe mbani të shtypur tastin Shift, që të vizatohet një shigjetë ver
     <message>
         <source>Exit</source>
         <translation>Dil</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Regjistrim i ri</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_sr.ts
+++ b/translations/deepin-screen-recorder_sr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>Запис</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Снимање</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Усликавање</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>Усликавање</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Неуспешно усликавање.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Кликни или превуци да
-обележиш површину снимања</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ select the area to record</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Прavоугаоник (R)
-Притисните и задржите Shift да бисте цртали квадрат</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Елипса (O)
-Притисните и задржите Shift да бисте цртали кружић</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Линија (L)
@@ -631,16 +597,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Снимање</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Остава</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Слике</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Фасцикла</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <source>Extract Text</source>
         <translation>Издвоји текст</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Геометријски алати (R)
+Држите Shift да нацртате квадрате или кругове.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Сачувај на локалном</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Сачувај на радној површини</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Сачувај на слике</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Сачувај у %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Одређено место</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Прилагођено место</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Сваки захтев</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Ажурирај место при сачувању</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Сачувај на радној површини</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Сачувај на слике</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Затвори (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Да (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Копирај у клипборд (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>Изађи</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Нови снимци</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_tr.ts
+++ b/translations/deepin-screen-recorder_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ tepsi simgesine tıklayın ya da kısayola yeniden basın</translation>
     <message>
         <source>Recording</source>
         <translation>Kaydediyor</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Kayıt</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Ekran Görüntüsü</translation>
     </message>
 </context>
 <context>
@@ -95,10 +86,6 @@ tepsi simgesine tıklayın ya da kısayola yeniden basın</translation>
     <message>
         <source>Screenshot</source>
         <translation>Ekran Görüntüsü</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>Ekran görüntüsü başarısız oldu.</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -452,15 +439,6 @@ Düz bir çizgi çizmek için Shift tuşunu basılı tutun</translation>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Kaydedilecek alanı
-seçmek için tıklayın ya da sürükleyin</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ seçmek için tıklayın ya da sürükleyin</translation>
         <translation>Videoalar</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Dikdörtgen (R)
-Kare çizmek için Shift tuşunu basılı tutun</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Elips (O)
-Bir daire çizmek için Shift tuşunu basılı tutun</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Çizgi (L)
@@ -631,16 +597,8 @@ Dikey veya yatay ok çizmek için Shift tuşunu basılı tutun</translation>
         <translation>Kayıt</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Pano</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Resimler</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Klasör</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Dikey veya yatay ok çizmek için Shift tuşunu basılı tutun</translation>
         <source>Extract Text</source>
         <translation>Metni Çıkar</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Geometrik Araçlar (R)
+Kare veya daire çizmek için Shift tuşunu basılı tutun.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Yerel olarak kaydet</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Masaüstüne kaydet</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Resimlere kaydet</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>%1&apos;e kaydet</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Belirtilen Konum</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Özel Konum</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Her sorgulama</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Kaydet sırasında konumu güncelle</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Masaüstüne kaydet</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Resimlere kaydet</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Dikey veya yatay ok çizmek için Shift tuşunu basılı tutun</translation>
         <translation>Kapat (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Tamam (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Panoya kopyala (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Dikey veya yatay ok çizmek için Shift tuşunu basılı tutun</translation>
     <message>
         <source>Exit</source>
         <translation>Çıkış</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Yeni kayıt</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_ug.ts
+++ b/translations/deepin-screen-recorder_ug.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -20,17 +22,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>ئېكراننى سىنغا ئېلىش</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>سىنغا ئېلىش</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>رەسىم تۇتۇش</translation>
     </message>
 </context>
 <context>
@@ -94,10 +85,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Screenshot</source>
         <translation>رەسىم تۇتۇش</translation>
-    </message>
-    <message>
-        <source>Screenshot failed.</source>
-        <translation>رەسىم تۇتۇلمىدى</translation>
     </message>
     <message>
         <source>Scrollshot</source>
@@ -451,14 +438,6 @@ Shift نى بېسىپ تۇرسىڭىز تۈز سىزىق سىزغىلى بولى
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>چېكىپ ياكى سۈرۈش ئارقىلىق سىنغا ئېلىش رايونىنى تاللاڭ</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -573,18 +552,6 @@ select the area to record</source>
         <translation>ۋىدېئو</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>تىك تۆت بۇلۇڭ  (R)
-Shift نى بېسىپ تۇرسىڭىز كۋادرات سىزغىلى بولىدۇ</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>ئېللىپىس (O)
-Shift نى بېسىپ تۇرسىڭىز چەمبەر سىزغىلى بولىدۇ</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>تۈز سىزىق (L)
@@ -629,16 +596,8 @@ Shift نى بېسىپ تۇرسىڭىز تىك ۋە توغرىسىغا تۈز ك�
         <translation>سىنغا ئېلىش</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>چاپلاش تاختىسى</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>رەسىم</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>بەلگىلەنگەن ئورۇن</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -688,6 +647,52 @@ Shift نى بېسىپ تۇرسىڭىز تىك ۋە توغرىسىغا تۈز ك�
         <source>Extract Text</source>
         <translation>تېكىستنى تونۇتۇش</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>گېئومېتىرىيىلىك قورال (R)
+تۆت تەرەپ تەڭ تىك تۆت بۇلۇڭ ياكى چەمبەر سىزىش ئۈچۈن Shift كۇنۇپكىسىنى بېسىپ تۇرۇڭ.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>لوكال ساقلاش</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>ئۈستەليۈز ساقلاش</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>رەسىم ساقلاش</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>%1 ساقلاش</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>بىرلىك ھەرپ</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>ئاددىيەتلىك ھەرپ</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>ھەر قورال</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>ساقلىغاندا ھەرپنى ئەڭگە قىلىش</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>ئۈستەليۈز ساقلاش</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>رەسىم ساقلاش</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -696,8 +701,8 @@ Shift نى بېسىپ تۇرسىڭىز تىك ۋە توغرىسىغا تۈز ك�
         <translation>تاقاش (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>جەزملەش (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>پاستەر ساقلاش (Enter)</translation>
     </message>
 </context>
 <context>
@@ -716,13 +721,6 @@ Shift نى بېسىپ تۇرسىڭىز تىك ۋە توغرىسىغا تۈز ك�
     <message>
         <source>Exit</source>
         <translation>چېكىنىش</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>يېڭى ھەجىم قىلىش</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-screen-recorder_uk.ts
+++ b/translations/deepin-screen-recorder_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CountdownTooltip</name>
     <message>
@@ -21,17 +23,6 @@ or press the shortcut again to stop recording</source>
     <message>
         <source>Recording</source>
         <translation>Записування</translation>
-    </message>
-</context>
-<context>
-    <name>MainToolWidget</name>
-    <message>
-        <source>Record</source>
-        <translation>Записати</translation>
-    </message>
-    <message>
-        <source>Screenshot</source>
-        <translation>Знімок</translation>
     </message>
 </context>
 <context>
@@ -97,10 +88,6 @@ or press the shortcut again to stop recording</source>
         <translation>Знімок</translation>
     </message>
     <message>
-        <source>Screenshot failed.</source>
-        <translation>Не вдалося створити знімок.</translation>
-    </message>
-    <message>
         <source>Scrollshot</source>
         <translation>Знімок із гортанням</translation>
     </message>
@@ -110,7 +97,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>deepin-screen-recorder</source>
-        <translation type="unfinished"/>
+        <translation>Засіб запису екрана Deepin</translation>
     </message>
     <message>
         <source>Open Folder</source>
@@ -118,7 +105,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Screenshot finished and copy to clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Знімок завершено і скопійовано до буфера обміну</translation>
     </message>
 </context>
 <context>
@@ -452,15 +439,6 @@ Press and hold Shift to draw a straight line</source>
     </message>
 </context>
 <context>
-    <name>StartTooltip</name>
-    <message>
-        <source>Click or drag to
-select the area to record</source>
-        <translation>Натисніть або перетяніть,
-щоб вибрати область для запису</translation>
-    </message>
-</context>
-<context>
     <name>SubToolWidget</name>
     <message>
         <source>Show keystroke (K)</source>
@@ -575,18 +553,6 @@ select the area to record</source>
         <translation>Відео</translation>
     </message>
     <message>
-        <source>Rectangle (R)
-Press and hold Shift to draw a square</source>
-        <translation>Прямокутник (R)
-Натисніть і утримуйте клавішу Shift, щоб намалювати квадрат</translation>
-    </message>
-    <message>
-        <source>Ellipse (O)
-Press and hold Shift to draw a circle</source>
-        <translation>Еліпс (O)
-Натисніть і утримуйте клавішу Shift, щоб намалювати коло</translation>
-    </message>
-    <message>
         <source>Line (L)
 Press and hold Shift to draw a vertical or horizontal line</source>
         <translation>Пряма (L)
@@ -631,16 +597,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Записати</translation>
     </message>
     <message>
-        <source>Clipboard</source>
-        <translation>Буфер обміну</translation>
-    </message>
-    <message>
         <source>Pictures</source>
         <translation>Зображення</translation>
-    </message>
-    <message>
-        <source>Folder</source>
-        <translation>Тека</translation>
     </message>
     <message>
         <source>Set a path on save</source>
@@ -690,6 +648,52 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <source>Extract Text</source>
         <translation>Видобути текст</translation>
     </message>
+    <message>
+        <source>Geometric Tools (R)
+Hold down Shift to draw squares or circles.</source>
+        <translation>Геометричні інструменти (R)
+Утримуйте Shift для малювання квадратів або кіл.</translation>
+    </message>
+    <message>
+        <source>Save to local</source>
+        <translation>Зберегти локально</translation>
+    </message>
+    <message>
+        <source>Save to Desktop</source>
+        <translation>Зберегти на стільниці</translation>
+    </message>
+    <message>
+        <source>Save to Pictures</source>
+        <translation>Зберегти в зображення</translation>
+    </message>
+    <message>
+        <source>Save to %1</source>
+        <translation>Зберегти до %1</translation>
+    </message>
+    <message>
+        <source>Specified Location</source>
+        <translation>Вказане місце</translation>
+    </message>
+    <message>
+        <source>Custom Location</source>
+        <translation>Власний шлях</translation>
+    </message>
+    <message>
+        <source>Each inquiry</source>
+        <translation>Кожне запитування</translation>
+    </message>
+    <message>
+        <source>Update location on save</source>
+        <translation>Оновлення місця збереження</translation>
+    </message>
+    <message>
+        <source>Save to desktop</source>
+        <translation>Зберегти на стільниці</translation>
+    </message>
+    <message>
+        <source>Save to pictures</source>
+        <translation>Зберегти в зображення</translation>
+    </message>
 </context>
 <context>
     <name>ToolBarWidget</name>
@@ -698,8 +702,8 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
         <translation>Закрити (Esc)</translation>
     </message>
     <message>
-        <source>OK (Enter)</source>
-        <translation>Гаразд (Enter)</translation>
+        <source>Copy to clipboard (Enter)</source>
+        <translation>Скопіювати до буфера обміну (Enter)</translation>
     </message>
 </context>
 <context>
@@ -718,13 +722,6 @@ Press and hold Shift to draw a vertical or horizontal arrow</source>
     <message>
         <source>Exit</source>
         <translation>Вийти</translation>
-    </message>
-</context>
-<context>
-    <name>VoiceRecordProcess</name>
-    <message>
-        <source>New recording</source>
-        <translation>Новий запис</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
- Added encoding declaration to XML header for better compatibility.
- Removed unused context entries for MainToolWidget and VoiceRecordProcess across multiple language files.
- Updated action text for saving options in MainWindow to include "Save to desktop" and "Save to pictures" in various translations.
- Changed "OK (Enter)" to "Copy to clipboard (Enter)" in ToolBarWidget translations for improved clarity.

Log: Enhance localization support and improve user understanding of save actions in the deepin-screen-recorder application.