### PR TITLE
fix: Enhance fullscreen screenshot reliability in Wayland S3/S4 transitions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -456,7 +456,7 @@ int main(int argc, char *argv[])
         Dtk::Core::DLogManager::registerConsoleAppender();
         Dtk::Core::DLogManager::registerFileAppender();
 
-        QCommandLineOption  delayOption(QStringList() << "d" << "delay", "Take a screenshot after NUM seconds.", "NUM");
+        QCommandLineOption delayOption(QStringList() << "d" << "delay", "Take a screenshot after NUM seconds.", "NUM");
         QCommandLineOption fullscreenOption(QStringList() << "f" << "fullscreen", "Take a screenshot the whole screen.");
         QCommandLineOption topWindowOption(QStringList() << "w" << "top-window", "Take a screenshot of the most top window.");
         QCommandLineOption savePathOption(QStringList() << "s" << "save-path", "Specify a path to save the screenshot.", "PATH");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QDir>
+#include "utils/screengrabber.h"
 #define Bool int
 #include <X11/extensions/Xinerama.h>
 DWIDGET_USE_NAMESPACE
@@ -194,148 +195,148 @@ static bool checkSpecificScreenLayout()
         }
         return false;
     }
-    
+
     // Get X server setup information
     const xcb_setup_t *setup = xcb_get_setup(connection);
     if (!setup) {
         xcb_disconnect(connection);
         return false;
     }
-    
+
     xcb_screen_t *screen = xcb_setup_roots_iterator(setup).data;
     if (!screen) {
         xcb_disconnect(connection);
         return false;
     }
-    
+
     // Check if RANDR extension is available (version 1.3 or higher)
-    xcb_randr_query_version_cookie_t version_cookie = 
+    xcb_randr_query_version_cookie_t version_cookie =
         xcb_randr_query_version(connection, 1, 3);
     xcb_generic_error_t *error = nullptr;
-    xcb_randr_query_version_reply_t *version_reply = 
+    xcb_randr_query_version_reply_t *version_reply =
         xcb_randr_query_version_reply(connection, version_cookie, &error);
-    
+
     // Check for errors
     if (error) {
         free(error);
         error = nullptr;
     }
-    
+
     if (!version_reply) {
         xcb_disconnect(connection);
         return false;
     }
-    
+
     free(version_reply);
     version_reply = nullptr;
-    
+
     // Get screen resources (outputs, CRTCs, modes)
-    xcb_randr_get_screen_resources_cookie_t resources_cookie = 
+    xcb_randr_get_screen_resources_cookie_t resources_cookie =
         xcb_randr_get_screen_resources(connection, screen->root);
-    
+
     error = nullptr; // Reset error pointer
-    xcb_randr_get_screen_resources_reply_t *resources_reply = 
+    xcb_randr_get_screen_resources_reply_t *resources_reply =
         xcb_randr_get_screen_resources_reply(connection, resources_cookie, &error);
-    
+
     if (error) {
         free(error);
         error = nullptr;
     }
-    
+
     if (!resources_reply) {
         xcb_disconnect(connection);
         return false;
     }
-    
+
     // Get output ports (monitors)
     xcb_randr_output_t *outputs = xcb_randr_get_screen_resources_outputs(resources_reply);
     int num_outputs = xcb_randr_get_screen_resources_outputs_length(resources_reply);
-    
+
     if (num_outputs < 2 || !outputs) {
         free(resources_reply);
         xcb_disconnect(connection);
         return false;
     }
-    
+
     // Structure to store position and dimensions of active screens
     struct ScreenInfo {
         int x, y;        // Top-left corner coordinates
         int width, height; // Dimensions
     };
-    
+
     // Pre-allocate memory to avoid multiple reallocations
     std::vector<ScreenInfo> screens;
     screens.reserve(num_outputs);
-    
+
     // Collect information about all active screens
     for (int i = 0; i < num_outputs; i++) {
-        xcb_randr_get_output_info_cookie_t output_cookie = 
+        xcb_randr_get_output_info_cookie_t output_cookie =
             xcb_randr_get_output_info(connection, outputs[i], XCB_CURRENT_TIME);
-        
+
         error = nullptr; // Reset error pointer
-        xcb_randr_get_output_info_reply_t *output_reply = 
+        xcb_randr_get_output_info_reply_t *output_reply =
             xcb_randr_get_output_info_reply(connection, output_cookie, &error);
-            
-        // Handle errors or invalid replies    
+
+        // Handle errors or invalid replies
         if (error) {
             free(error);
             error = nullptr;
         }
-        
+
         if (!output_reply) {
             continue;
         }
-        
+
         // Only process connected outputs with an assigned CRTC
         if (output_reply->connection != XCB_RANDR_CONNECTION_CONNECTED ||
             output_reply->crtc == XCB_NONE) {
             free(output_reply);
             continue;
         }
-        
+
         // Get CRTC information (contains position and dimensions)
-        xcb_randr_get_crtc_info_cookie_t crtc_cookie = 
+        xcb_randr_get_crtc_info_cookie_t crtc_cookie =
             xcb_randr_get_crtc_info(connection, output_reply->crtc, XCB_CURRENT_TIME);
-        
+
         error = nullptr; // Reset error pointer
-        xcb_randr_get_crtc_info_reply_t *crtc_reply = 
+        xcb_randr_get_crtc_info_reply_t *crtc_reply =
             xcb_randr_get_crtc_info_reply(connection, crtc_cookie, &error);
-            
+
         // Handle errors or invalid replies
         if (error) {
             free(error);
             error = nullptr;
         }
-        
+
         if (!crtc_reply) {
             free(output_reply);
             continue;
         }
-        
+
         // Store valid screen information
         ScreenInfo info;
         info.x = crtc_reply->x;
         info.y = crtc_reply->y;
         info.width = crtc_reply->width;
         info.height = crtc_reply->height;
-        
+
         screens.push_back(info);
-        
+
         // Free resources
         free(crtc_reply);
         free(output_reply);
     }
-    
+
     // Release resources no longer needed
     free(resources_reply);
     resources_reply = nullptr;
-    
+
     // Exit if fewer than 2 active screens detected
     if (screens.size() < 2) {
         xcb_disconnect(connection);
         return false;
     }
-        
+
     // 1. Find the leftmost screen
     int leftIndex = 0;
     for (size_t i = 1; i < screens.size(); ++i) {
@@ -343,11 +344,11 @@ static bool checkSpecificScreenLayout()
             leftIndex = i;
         }
     }
-    
+
     // 2. Find the closest screen to the right of the leftmost screen
     int rightIndex = -1;
     int minDistance = INT_MAX;
-    
+
     for (size_t i = 0; i < screens.size(); ++i) {
         if (i != (size_t)leftIndex && screens[i].x > screens[leftIndex].x) {
             int distance = screens[i].x - (screens[leftIndex].x + screens[leftIndex].width);
@@ -357,22 +358,22 @@ static bool checkSpecificScreenLayout()
             }
         }
     }
-    
+
     // Exit if no right screen found
     if (rightIndex == -1) {
         xcb_disconnect(connection);
         return false;
     }
-    
+
     // Check for specific layout condition: screens at different vertical and horizontal positions
     bool result = false;
-    bool screenPositionsDifferent = (screens[leftIndex].y != screens[rightIndex].y) && 
+    bool screenPositionsDifferent = (screens[leftIndex].y != screens[rightIndex].y) &&
                                    (screens[leftIndex].x != screens[rightIndex].x);
-    
+
     result = screenPositionsDifferent;
 
     xcb_disconnect(connection);
-    
+
     return result;
 }
 
@@ -514,6 +515,18 @@ int main(int argc, char *argv[])
             Utils::isFFmpegEnv = false;
         }
 
+        // 在 Wayland 环境下，如果是全屏截图，使用快速方式，避免创建 Screenshot 对象
+        if (Utils::isWaylandMode && cmdParser.isSet(fullscreenOption)) {
+            qInfo() << "检测到 Wayland 环境下的全屏截图，使用快速方式";
+            if (ScreenGrabber::quickFullScreenshot()) {
+                qInfo() << "快速全屏截图成功完成";
+                return 0;
+            } else {
+                qWarning() << "快速全屏截图失败，退出应用";
+                return 1;
+            }
+        }
+
         QString t_launchMode = "screenShot";
         if (cmdParser.isSet(screenRecordOption)) {
             t_launchMode = "screenRecord";
@@ -557,6 +570,7 @@ int main(int argc, char *argv[])
                 qDebug() << "cmd delay screenshot";
                 window.delayScreenshot(cmdParser.value(delayOption).toInt());
             } else if (cmdParser.isSet(fullscreenOption)) {
+                qDebug() << "cmd fullscreen screenshot";
                 window.fullscreenScreenshot();
             } else if (cmdParser.isSet(topWindowOption)) {
                 qDebug() << "cmd topWindow screenshot";

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -6,6 +6,9 @@
 #include "screengrabber.h"
 
 #include "../utils.h"
+#include "configsettings.h"
+#include "saveutils.h"
+#include "../dbusinterface/dbusnotify.h"
 
 #include <QDBusInterface>
 #include <QDBusReply>
@@ -18,6 +21,13 @@
 #include <QDesktopWidget>
 #include <QStandardPaths>
 #include <QThread>
+#include <QMimeData>
+#include <QClipboard>
+#include <QBuffer>
+#include <QDateTime>
+#include <QFileInfo>
+#include <QCoreApplication>
+#include <ctime>
 ScreenGrabber::ScreenGrabber(QObject *parent)
     : QObject(parent)
 {
@@ -62,4 +72,169 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool &ok, const QRect &rect, const qrea
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
     // 在多屏模式下, winId 不是0
     return t_primaryScreen->grabWindow(QApplication::desktop()->winId(), rect.x(), rect.y(), rect.width(), rect.height());
+}
+
+bool ScreenGrabber::quickFullScreenshot()
+{
+    qInfo() << "开始执行快速全屏截图...";
+
+    int count = 0;
+
+    // 调用 KWin D-Bus 接口获取全屏截图
+    QDBusInterface kwinInterface(QStringLiteral("org.kde.KWin"),
+                                QStringLiteral("/Screenshot"),
+                                QStringLiteral("org.kde.kwin.Screenshot"));
+    QDBusReply<QString> reply = kwinInterface.call(QStringLiteral("screenshotFullscreen"));
+    
+    QPixmap screenshot;
+    while (count < 6) {
+        reply = kwinInterface.call(QStringLiteral("screenshotFullscreen"));
+        screenshot = QPixmap(reply.value());
+        qDebug() << __FUNCTION__ << __LINE__ << "screenshotFullscreen reply:" << reply;
+        if (!screenshot.isNull()) {
+            break;
+        }
+        count++;
+        QThread::msleep(1000);
+    }
+
+    if (!reply.isValid() || reply.value().isEmpty()) {
+        qWarning() << "获取全屏截图失败:" << reply.error().message();
+        qDebug() << __FUNCTION__ << __LINE__ << "Get Pixmap:" << screenshot.size() << "try failed at " << count << "times";
+        return false;
+    }
+    
+    QString tempImagePath = reply.value();
+    
+    if (screenshot.isNull()) {
+        qWarning() << "无法加载截图文件:" << tempImagePath;
+        QFile::remove(tempImagePath);
+        return false;
+    }
+    
+    // 获取用户配置
+    ConfigSettings *config = ConfigSettings::instance();
+    SaveAction saveAction = static_cast<SaveAction>(config->value("save", "save_op").toInt());
+    int pictureFormat = config->value("save", "format").toInt();
+    
+    QString formatStr, formatSuffix;
+    switch (pictureFormat) {
+    case 0:
+        formatStr = "PNG";
+        formatSuffix = "png";
+        break;
+    case 1:
+        formatStr = "JPG";
+        formatSuffix = "jpg";
+        break;
+    case 2:
+        formatStr = "BMP";
+        formatSuffix = "bmp";
+        break;
+    default:
+        formatStr = "PNG";
+        formatSuffix = "png";
+    }
+    
+    QString currentTime = QDateTime::currentDateTime().toString("yyyyMMddHHmmss");
+    QString functionTypeStr = QObject::tr("FullScreenshot");
+    QString saveFileName;
+    
+    // 保存到文件
+    QString savePath;
+    switch (saveAction) {
+    case SaveToDesktop:
+        savePath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+        break;
+    case SaveToImage:
+        savePath = QStandardPaths::standardLocations(QStandardPaths::PicturesLocation).first() + QDir::separator() + "Screenshots";
+        break;
+    case SaveToSpecificDir:
+        savePath = config->value("save", "savepath").toString();
+        if (savePath.isEmpty()) {
+            savePath = QStandardPaths::standardLocations(QStandardPaths::PicturesLocation).first() + QDir::separator() + "Screenshots";
+        }
+        break;
+    default:
+        savePath = QStandardPaths::standardLocations(QStandardPaths::PicturesLocation).first() + QDir::separator() + "Screenshots";
+    }
+
+    QDir saveDir(savePath);
+    if (!saveDir.exists()) {
+        saveDir.mkpath(savePath);
+    }
+
+    saveFileName = QString("%1/%2_%3.%4").arg(savePath, functionTypeStr, currentTime, formatSuffix);
+
+    if (!screenshot.save(saveFileName, formatStr.toLatin1().data())) {
+        qWarning() << "保存截图失败:" << saveFileName;
+        QFile::remove(tempImagePath);
+        return false;
+    }
+
+    // 保存到剪贴板
+    QMimeData *imageData = new QMimeData;
+    QByteArray bytes;
+    QBuffer buffer(&bytes);
+    buffer.open(QIODevice::WriteOnly);
+    screenshot.save(&buffer, "PNG", 75);  // 使用 PNG 格式，75% 质量以优化性能
+    imageData->setData("image/png", bytes);
+
+    QClipboard *clipboard = QGuiApplication::clipboard();
+    clipboard->setMimeData(imageData, QClipboard::Clipboard);
+
+    // Wayland 模式下添加等待机制，确保剪贴板数据传输完成
+    if (Utils::isWaylandMode) {
+        qInfo() << "Wayland 模式下等待剪贴板数据传输完成...";
+        time_t endTime = time(nullptr) + 1;  // 等待 1 秒
+        while (time(nullptr) < endTime) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        }
+        qInfo() << "剪贴板等待完成";
+    }
+
+    // 发送系统通知
+    QDBusInterface notification("org.freedesktop.Notifications",
+                                "/org/freedesktop/Notifications",
+                                "org.freedesktop.Notifications",
+                                QDBusConnection::sessionBus());
+    
+    QStringList actions;
+    QVariantMap hints;
+    QString notifyTitle = QString("");
+    QString notifyBody;
+    
+    if (saveAction == SaveToClipboard) {
+        notifyBody = QCoreApplication::translate("MainWindow", "Screenshot finished and copy to clipboard");
+    } else {
+        notifyBody = QCoreApplication::translate("MainWindow", "Screenshot finished");
+        actions << "_open" << QCoreApplication::translate("MainWindow", "View");
+        actions << "_open1" << QCoreApplication::translate("MainWindow", "Open Folder");
+        
+        QString command = QString("xdg-open,%1").arg(saveFileName);
+        QString savepathcommand;
+        if (!QStandardPaths::findExecutable("dde-file-manager").isEmpty()) {
+            savepathcommand = QString("dde-file-manager,--show-item,%1").arg(saveFileName);
+        }
+        hints["x-deepin-action-_open"] = command;
+        hints["x-deepin-action-_open1"] = savepathcommand;
+    }
+    
+    QList<QVariant> arg;
+    arg << QCoreApplication::applicationName()
+        << (unsigned int) 0
+        << QString("deepin-screen-recorder")
+        << QCoreApplication::translate("MainWindow", "Screen Capture")
+        << notifyBody
+        << actions
+        << hints
+        << 5000;
+    
+    notification.callWithArgumentList(QDBus::AutoDetect, "Notify", arg);
+    
+    // 清理临时文件
+    QFile::remove(tempImagePath);
+    
+    qInfo() << "快速全屏截图完成！";
+    return true;
 }

--- a/src/utils/screengrabber.h
+++ b/src/utils/screengrabber.h
@@ -14,6 +14,12 @@ class ScreenGrabber : public QObject
 public:
     explicit ScreenGrabber(QObject *parent = nullptr);
     QPixmap grabEntireDesktop(bool &ok, const QRect &rect, const qreal devicePixelRatio);
+    
+    /**
+     * @brief 快速全屏截图，绕过MainWindow初始化，避免S3/S4问题
+     * @return 截图成功返回true，失败返回false
+     */
+    static bool quickFullScreenshot();
 };
 
 #endif // SCREENGRABBER_H


### PR DESCRIPTION
Improved the quickFullScreenshot function with retry mechanism and simplified save logic to prevent hanging during suspend/resume cycles. Key changes:
- Added 6-retry loop with 1s delay for KWin screenshot calls
- Unified save logic to always save to file and clipboard
- Enhanced path handling with dedicated Screenshots subdirectory
- Improved debug logging for troubleshooting

Log: Fix fullscreen screenshot hanging during S3/S4 state changes
Bug: @https://pms.uniontech.com/bug-view-328797.html