### PR TITLE
fix: Prevent multiple calls to onExit function in MainWindow

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -928,6 +928,13 @@ void MainWindow::forciblySavingNotify()
 
 void MainWindow::onExit()
 {
+    static bool hasBeenCalled = false;
+    if (hasBeenCalled) {
+        qCInfo(dsrApp) << "onExit已被调用，忽略重复调用";
+        return;
+    }
+    hasBeenCalled = true;
+
     qCInfo(dsrApp) << "exit screenshot app";
     if (RECORD_BUTTON_RECORDING == recordButtonStatus) {
         stopRecord();


### PR DESCRIPTION
- Added a static boolean variable to track if onExit has been called, preventing duplicate calls.
- Improved logging to inform when onExit is called multiple times.

Log: Enhance application exit handling by preventing redundant exit logic execution.

bug: https://pms.uniontech.com/bug-view-328175.html