### PR TITLE
fix: Adjust margins in ShotToolWidget layout for better UI alignment

### DIFF
--- a/src/widgets/shottoolwidget.cpp
+++ b/src/widgets/shottoolwidget.cpp
@@ -345,7 +345,7 @@ void ShotToolWidget::initTextLabel()
     });
 
     QHBoxLayout *rectLayout = new QHBoxLayout(this);
-    rectLayout->setContentsMargins(0, 0, 0, 0);
+    rectLayout->setContentsMargins(0, 0, 5, 0);
 
     rectLayout->addWidget(t_blurArea);
 


### PR DESCRIPTION
- Updated the contents margins of the rectLayout in ShotToolWidget to improve the visual spacing of UI elements.
- Ensured consistent layout appearance by modifying the right margin from 0 to 5.

Log: Enhance the layout of ShotToolWidget for improved user interface alignment.

bug: https://pms.uniontech.com/bug-view-311413.html