### PR TITLE
fix: add TimeUtils to get system time

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -168,7 +168,8 @@ HEADERS += main_window.h \
     camera/majorimageprocessingthread.h \
     camera/LPF_V4L2.h \
     camera/devnummonitor.h \
-    utils/delaytime.h
+    utils/delaytime.h \
+    utils/timeutils.h
 contains(DEFINES , OCR_SCROLL_FLAGE_ON) {
     HEADERS += widgets/scrollshottip.h \
     utils/pixmergethread.h \
@@ -235,7 +236,8 @@ SOURCES += main.cpp \
     camera/majorimageprocessingthread.cpp \
     camera/LPF_V4L2.c \
     camera/devnummonitor.cpp \
-    utils/delaytime.cpp
+    utils/delaytime.cpp \
+    utils/timeutils.cpp
 
 contains(DEFINES , OCR_SCROLL_FLAGE_ON) {
     SOURCES += widgets/scrollshottip.cpp \

--- a/src/utils/timeutils.cpp
+++ b/src/utils/timeutils.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "timeutils.h"
+#include <time.h>
+#include <QDateTime>
+
+namespace TimeUtils {
+
+int64_t getMonotonicTimeUs()
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        return static_cast<int64_t>(ts.tv_sec) * 1000000LL + static_cast<int64_t>(ts.tv_nsec) / 1000LL;
+    }
+    // 如果获取单调时间失败，回退到系统时间
+    return static_cast<int64_t>(QDateTime::currentMSecsSinceEpoch()) * 1000LL;
+}
+
+int64_t getMonotonicTime()
+{
+    return getMonotonicTimeUs();
+}
+
+int64_t getMonotonicTimeMs()
+{
+    return getMonotonicTimeUs() / 1000LL;
+}
+
+int64_t getMonotonicTimeS()
+{
+    return getMonotonicTimeUs() / 1000000LL;
+}
+
+} // namespace TimeUtils

--- a/src/utils/timeutils.h
+++ b/src/utils/timeutils.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TIMEUTILS_H
+#define TIMEUTILS_H
+
+#include <cstdint>
+
+namespace TimeUtils {
+
+/**
+ * @brief 获取单调时间戳（微秒），避免系统时间调整导致的时间跳变
+ * 
+ * 使用Linux的CLOCK_MONOTONIC时钟，该时钟从系统启动开始计时，
+ * 不会因为系统时间调整（如NTP同步、手动修改时间）而跳变。
+ * 返回值与av_gettime()兼容，都是微秒级时间戳。
+ * 
+ * @return int64_t 微秒级时间戳
+ */
+int64_t getMonotonicTimeUs();
+
+/**
+ * @brief 获取单调时间戳（微秒），与av_gettime()兼容
+ * 
+ * 这是getMonotonicTimeUs()的别名，为了与FFmpeg的av_gettime()保持一致的命名。
+ * 
+ * @return int64_t 微秒级时间戳
+ */
+int64_t getMonotonicTime();
+
+/**
+ * @brief 获取单调时间戳（毫秒），避免系统时间调整导致的时间跳变
+ * 
+ * @return int64_t 毫秒级时间戳
+ */
+int64_t getMonotonicTimeMs();
+
+/**
+ * @brief 获取单调时间戳（秒），避免系统时间调整导致的时间跳变
+ * 
+ * @return int64_t 秒级时间戳
+ */
+int64_t getMonotonicTimeS();
+
+} // namespace TimeUtils
+
+#endif // TIMEUTILS_H

--- a/src/utils/utils.pri
+++ b/src/utils/utils.pri
@@ -5,7 +5,8 @@ HEADERS += \
     $$PWD/configsettings.h \
     $$PWD/shortcut.h \
     $$PWD/screenutils.h \
-    $$PWD/tempfile.h
+    $$PWD/tempfile.h \
+    $$PWD/timeutils.h
 
 SOURCES += \
     $$PWD/baseutils.cpp \
@@ -14,4 +15,5 @@ SOURCES += \
     $$PWD/configsettings.cpp \
     $$PWD/shortcut.cpp \
     $$PWD/screenutils.cpp \
-    $$PWD/tempfile.cpp
+    $$PWD/tempfile.cpp \
+    $$PWD/timeutils.h


### PR DESCRIPTION
add TimeUtils to get system time to avoid user change system get wrong time

Log: add TimeUtils to get system time
Bug: https://pms.uniontech.com/bug-view-268369.html