### PR TITLE
fix: Enhance keyboard interaction for shape adjustments in ShapesWidget

### DIFF
--- a/src/widgets/shapeswidget.h
+++ b/src/widgets/shapeswidget.h
@@ -15,6 +15,22 @@
 #include <DFrame>
 #include <QGestureEvent>
 #include <QMouseEvent>
+#include <QHash>
+
+namespace Direction {
+    const QString LEFT = "Left";
+    const QString RIGHT = "Right";
+    const QString UP = "Up";
+    const QString DOWN = "Down";
+    const QString CTRL_LEFT = "Ctrl+Left";
+    const QString CTRL_RIGHT = "Ctrl+Right";
+    const QString CTRL_UP = "Ctrl+Up";
+    const QString CTRL_DOWN = "Ctrl+Down";
+    const QString CTRL_SHIFT_LEFT = "Ctrl+Shift+Left";
+    const QString CTRL_SHIFT_RIGHT = "Ctrl+Shift+Right";
+    const QString CTRL_SHIFT_UP = "Ctrl+Shift+Up";
+    const QString CTRL_SHIFT_DOWN = "Ctrl+Shift+Down";
+}
 
 class ShapesWidget : public DFrame
 {


### PR DESCRIPTION
- Added handling for Delete and Backspace keys to delete the current shape.
- Implemented keyboard shortcuts for micro-adjustments of selected shapes using Ctrl and Shift modifiers.
- Improved movement logic for shapes using arrow keys and WASD keys, allowing for more intuitive control.
- Enhanced the adjustment logic for shapes of type "pen" and "effect" to maintain proportionality during resizing.

Log: Improve user experience in ShapesWidget by refining keyboard interactions for shape manipulation.

bug: https://pms.uniontech.com/bug-view-320491.html