### PR TITLE
fix: Add directory write permission check

### DIFF
--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -163,7 +163,12 @@ bool ScreenGrabber::quickFullScreenshot()
     if (!saveDir.exists()) {
         saveDir.mkpath(savePath);
     }
-
+    QFileInfo dirInfo(savePath);
+    if (dirInfo.isDir() && dirInfo.exists()) {
+        if (!dirInfo.isWritable()) {
+            qWarning() << "Check the write permissions, the file cannot be written to: " << savePath;
+        }
+    }
     saveFileName = QString("%1/%2_%3.%4").arg(savePath, functionTypeStr, currentTime, formatSuffix);
 
     if (!screenshot.save(saveFileName, formatStr.toLatin1().data())) {


### PR DESCRIPTION
Added validation for write permissions before file operations. The code now checks if the target directory exists and is writable, issuing a warning when write access is denied.

Log: Improve file save error handling
Bug: https://pms.uniontech.com/bug-view-332349.html