### PR TITLE
fix: Integrate recording state management in Screenshot and MainWindow

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
         // Register debus service.
         dbus.registerObject("/com/deepin/ScreenRecorder",
                             &window,
-                            QDBusConnection::ExportScriptableSignals | QDBusConnection::ExportScriptableSlots);
+                            QDBusConnection::ExportScriptableSignals | QDBusConnection::ExportScriptableSlots | QDBusConnection::ExportScriptableProperties);
         qCDebug(dsrApp) << "DBus object /com/deepin/ScreenRecorder registered.";
         QDBusConnection conn = QDBusConnection::sessionBus();
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -308,6 +308,10 @@ void MainWindow::initMainWindow()
 
     qCInfo(dsrApp) << __LINE__ << __FUNCTION__ << "截图录屏主窗口已初始化";
     m_isSaveScrollShot = false;
+    
+    // 连接录屏进程的开始和停止信号
+    connect(&recordProcess, &RecordProcess::recordingStarted, this, &MainWindow::onRecordingStarted);
+    connect(&recordProcess, &RecordProcess::recordingStopped, this, &MainWindow::onRecordingStopped);
 }
 
 void MainWindow::initTreelandtAttributes() //initTreelandtAttributes
@@ -7253,6 +7257,24 @@ void MainWindow::updateCaptureRegion()
             m_toolBar->hide();
             m_toolBar->show();
         }
+    }
+}
+
+void MainWindow::onRecordingStarted()
+{
+    qCDebug(dsrApp) << "onRecordingStarted: Recording actually started";
+    // 调用回调函数通知录屏状态变化
+    if (m_recordingStateCallback) {
+        m_recordingStateCallback(true);
+    }
+}
+
+void MainWindow::onRecordingStopped()
+{
+    qCDebug(dsrApp) << "onRecordingStopped: Recording actually stopped";
+    // 调用回调函数通知录屏状态变化
+    if (m_recordingStateCallback) {
+        m_recordingStateCallback(false);
     }
 }
 

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -18,6 +18,7 @@
 #include "show_buttons.h"
 #include "widgets/shapeswidget.h"
 #include "widgets/toptips.h"
+#include <functional>
 #include "widgets/toolbar.h"
 #include "widgets/sidebar.h"
 #include "widgets/keybuttonwidget.h"
@@ -441,6 +442,9 @@ public slots:
 
     Q_SCRIPTABLE void stopRecord();
     Q_SCRIPTABLE void stopApp();
+    
+    // 设置录屏状态变化通知回调
+    void setRecordingStateCallback(std::function<void(bool)> callback) { m_recordingStateCallback = callback; }
 
     /**
      * @brief 启动录屏倒计时
@@ -452,6 +456,8 @@ public slots:
     void responseEsc();
     void compositeChanged();
     void updateToolBarPos();
+    void onRecordingStarted(); // 录屏开始
+    void onRecordingStopped(); // 录屏停止
     /**
      * @brief 更新二级工具栏的位置信息
      */
@@ -1396,6 +1402,9 @@ private:
     bool isWayland = false;
     // Note: m_toolBar already exists as ShowButtons *m_showButtons
     bool isHideToolBar = false;
+    
+    // 录屏状态变化回调函数
+    std::function<void(bool)> m_recordingStateCallback;
 };
 
 #endif //MAINWINDOW_H

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -741,6 +741,11 @@ void RecordProcess::startRecord()
 
     qCDebug(dsrApp) << "已通知录屏插件开始录屏! currentTime: " << QTime::currentTime();
     m_recordingFlag = true;
+    
+    // 发送录屏开始信号
+    emit recordingStarted();
+    qCDebug(dsrApp) << "Recording started signal emitted";
+    
     QtConcurrent::run([this]() {
         this->emitRecording();
     });
@@ -871,6 +876,10 @@ void RecordProcess::exitRecord(QString newSavePath)
         callTrayRecorderIcon(DBUS_FUNC_ON_STOP);
         qCInfo(dsrApp) << __LINE__ << __func__ << "录屏计时图标已退出";
     }
+    
+    // 发送录屏的信号
+    emit recordingStopped();
+    qCDebug(dsrApp) << "Recording stopped signal emitted";
 
     //保存到剪切板
     save2Clipboard(newSavePath);

--- a/src/record_process.h
+++ b/src/record_process.h
@@ -190,6 +190,10 @@ private:
      */
     bool m_isFullScreenRecord = false;
 
+signals:
+    void recordingStopped();
+    void recordingStarted(); // 录屏开始信号 
+
 };
 
 #endif //RECORDPROCESS_H

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -26,6 +26,13 @@ Screenshot::Screenshot(QObject *parent)
             m_isCustomScreenshot = false; // 重置标记
         }
     });
+    
+    // 设置录屏状态变化回调
+    m_window.setRecordingStateCallback([this](bool isRecording) {
+        m_isRecording = isRecording;
+        emit RecordingModeChanged(isRecording);
+        qCDebug(dsrApp) << "Recording state updated via callback:" << isRecording;
+    });
 }
 
 void Screenshot::startScreenshot()
@@ -186,7 +193,7 @@ void Screenshot::initLaunchMode(const QString &launchmode)
 void Screenshot::fullScreenRecord(QString fileName)
 {
     qCDebug(dsrApp) << "Start Full Screen Record! File name:" << fileName << ".";
-     m_window.fullScreenRecord(fileName);
+    m_window.fullScreenRecord(fileName);
 }
 
 void Screenshot::stopRecord()
@@ -205,6 +212,12 @@ QString Screenshot::getRecorderNormalIcon()
 {
     qCDebug(dsrApp) << "getRecorderNormalIcon() called.";
     return RecorderTablet::getRecorderNormalIcon();
+}
+
+bool Screenshot::isRecording() const
+{
+    qCDebug(dsrApp) << "isRecording() called, returning:" << m_isRecording;
+    return m_isRecording;
 }
 
 Screenshot::~Screenshot()

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -16,6 +16,7 @@ class Screenshot : public QObject
     Q_OBJECT
 
     Q_CLASSINFO("D-Bus Interface", "com.deepin.ScreenRecorder")
+    Q_PROPERTY(bool IsRecording READ isRecording)
 public:
     explicit Screenshot(QObject *parent = nullptr);
     ~Screenshot();
@@ -40,9 +41,14 @@ public slots:
     Q_SCRIPTABLE void stopRecord();
     Q_SCRIPTABLE void stopApp();
     Q_SCRIPTABLE QString getRecorderNormalIcon();
+    
 signals:
     Q_SCRIPTABLE void RecorderState(const bool isStart); // true begin recorder; false stop recorder;
+    Q_SCRIPTABLE void RecordingModeChanged(const bool isRecording); // 录屏模式变化
     void screenshotSaved(const QString &savePath); // 截图保存完成信号，返回保存路径
+
+private:
+    bool isRecording() const;
 
 private:
     //void initUI();
@@ -51,6 +57,7 @@ private:
     QString m_launchMode;
     MainWindow m_window;
     bool m_isCustomScreenshot = false; // 标记是否是自定义截图
+    bool m_isRecording = false; // 实际录屏状态
 
 };
 


### PR DESCRIPTION
- Added signals for recording state changes in RecordProcess and connected them to MainWindow for handling recording start and stop events.
- Implemented callback functionality in Screenshot to update the recording state and emit corresponding signals.
- Enhanced MainWindow to manage recording state changes and provide feedback through logging.

Log: Improve screen recording functionality by integrating state management and callbacks for better user experience.