### PR TITLE
fix(text): Sync text color with theme highlight color in pressed state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ AI config
 .cursorindexingignore
 .specstory/
 .vscode/
+.npm-cache/
+.claude/

--- a/src/widgets/toolbutton.cpp
+++ b/src/widgets/toolbutton.cpp
@@ -272,9 +272,14 @@ void ToolButton::paintEvent(QPaintEvent *event)
             ip.setCompositionMode(QPainter::CompositionMode_SourceIn);
             ip.fillRect(tinted.rect(), palette().highlight().color());
             ip.end();
-            
+
             opt.icon = QIcon(tinted);
         }
+        // 设置文字为主题色
+        opt.palette.setColor(QPalette::ButtonText, palette().highlight().color());
+        opt.palette.setColor(QPalette::WindowText, palette().highlight().color());
+        opt.palette.setColor(QPalette::Text, palette().highlight().color());
+
         opt.state &= ~QStyle::State_MouseOver;
         opt.state &= ~QStyle::State_Sunken;
         style()->drawControl(QStyle::CE_ToolButtonLabel, &opt, &p, this);


### PR DESCRIPTION
When ToolButton is in pressed (isSunken) state, the icon already changes to the theme highlight color, but the text remains unchanged. This causes inconsistent visual feedback between the icon and text.

Now both icon and text use palette().highlight().color() in pressed state, providing a unified user experience across all theme modes.

bug: https://pms.uniontech.com/bug-view-356023.html