### PR TITLE
fix(shot): prevent abnormal shape drawing when AI assistant button is…

### DIFF
--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -1341,6 +1341,11 @@ void ShapesWidget::mousePressEvent(QMouseEvent *e)
     m_pressedPoint = e->pos();
     m_isPressed = true;
     if (!clickedOnShapes(m_pressedPoint)) {
+        // AI助手不是绘图工具，不进入绘制逻辑
+        if (m_currentType == "aiassistant") {
+            DFrame::mousePressEvent(e);
+            return;
+        }
 
         m_isRecording = true;
         //qDebug() << "no one shape be clicked!" << m_selectedIndex << m_shapes.length();


### PR DESCRIPTION
… clicked

AI assistant is not a drawing tool, but ShapesWidget treated it as one. When m_currentType was set to "aiassistant", dragging in the capture area would enter the shape recording logic (m_isRecording = true) and fall through to the "non-text" branch in mouseReleaseEvent, creating an unexpected shape on the canvas.

Skip the drawing logic in mousePressEvent when m_currentType is "aiassistant" so that existing shapes are preserved and no new shapes are created.

bug: https://pms.uniontech.com/bug-view-356039.html