### PR TITLE
fix(pin): correct OCR button size in pin screenshot toolbar

### DIFF
--- a/src/pin_screenshots/ui/subtoolwidget.cpp
+++ b/src/pin_screenshots/ui/subtoolwidget.cpp
@@ -40,8 +40,8 @@ void SubToolWidget::initShotLable()
     m_ocrButton = new ToolButton(this);
     m_ocrButton->setObjectName(AC_SUBTOOLWIDGET_PIN_OCR_BUT);
     m_ocrButton->setAccessibleName(AC_SUBTOOLWIDGET_PIN_OCR_BUT);
-    m_ocrButton->setIconSize(QSize(32, 32));
-    m_ocrButton->setFixedSize(32, 32);
+    m_ocrButton->setIconSize(QSize(36, 36));
+    m_ocrButton->setFixedSize(36, 36);
     m_ocrButton->setIcon(QIcon::fromTheme("ocr-normal"));
     m_ocrButton->setToolTip(tr("Extract Text"));
     connect(m_ocrButton, SIGNAL(clicked()), this, SIGNAL(signalOcrButtonClicked()));


### PR DESCRIPTION
The OCR icon SVG (ocr-normal_32px.svg) has a 36x36 viewBox with built-in padding around the 18x18 glyph. Setting iconSize and fixedSize to 32x32 scaled the SVG down, making both the icon and its hover background visually smaller than adjacent buttons.

Change both to 36x36 to match the SVG's native size and align with the main screenshot toolbar where the same icon uses TOOL_ICON_SIZE (36x36) and TOOL_BUTTON_SIZE (36x36).

bug: https://pms.uniontech.com/bug-view-356087.html