### PR TITLE
chore: remove event logging for screenshot and recording actions

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1527,8 +1527,6 @@ void MainWindow::initScreenRecorder()
 void MainWindow::initScrollShot()
 {
     qCInfo(dsrApp) << __LINE__ << __FUNCTION__ << "正在初始化滚动截图...";
-    QJsonObject obj{{"tid", EventLogUtils::StartScrollShot}, {"version", QCoreApplication::applicationVersion()}};
-    EventLogUtils::get().writeLogs(obj);
     m_zoomIndicator->hideMagnifier();
 
 #ifdef OCR_SCROLL_FLAGE_ON
@@ -2252,8 +2250,6 @@ void MainWindow::topWindow()
         return;
     }
 
-    QJsonObject obj{{"tid", EventLogUtils::StartScreenShot}, {"version", QCoreApplication::applicationVersion()}};
-    EventLogUtils::get().writeLogs(obj);
     int t_windowCount = DWindowManagerHelper::instance()->allWindowIdList().size();
     DForeignWindow *prewindow = nullptr;
     for (int i = t_windowCount - 1; i >= 0; i--) {
@@ -3734,8 +3730,6 @@ void MainWindow::changeShotToolEvent(const QString &func)
     qCDebug(dsrApp) << "MainWindow::changeShotToolEvent >> func: " << func;
     // 调用ocr功能时先截图后，退出截图录屏，将刚截图的图片串递到ocr识别界面；
     if (func == "ocr") {
-        QJsonObject obj{{"tid", EventLogUtils::StartOcr}, {"version", QCoreApplication::applicationVersion()}};
-        EventLogUtils::get().writeLogs(obj);
         // 调起OCR识别界面， 传入截图路径
         m_ocrInterface = new OcrInterface("com.deepin.Ocr", "/com/deepin/Ocr", QDBusConnection::sessionBus(), this);
         int delayTime = 0;
@@ -3757,6 +3751,13 @@ void MainWindow::changeShotToolEvent(const QString &func)
             });
         }
     } else if (func == "pinScreenshots") {
+        {
+            QJsonObject obj{{"tid", EventLogUtils::Start},
+                            {"version", QCoreApplication::applicationVersion()},
+                            {"mode", 1},
+                            {"startup_mode", "B8"}};
+            EventLogUtils::get().writeLogs(obj);
+        }
         m_functionType = status::pinscreenshots;
         m_pinInterface = new PinScreenShotsInterface(
             "com.deepin.PinScreenShots", "/com/deepin/PinScreenShots", QDBusConnection::sessionBus(), this);
@@ -3780,6 +3781,13 @@ void MainWindow::changeShotToolEvent(const QString &func)
     } else if (func == "record" || func == "shot") {
         changeFunctionButton(func);
     } else {
+        if (func == QStringLiteral("aiassistant")) {
+            QJsonObject obj{{"tid", EventLogUtils::Start},
+                            {"version", QCoreApplication::applicationVersion()},
+                            {"mode", 1},
+                            {"startup_mode", "B9"}};
+            EventLogUtils::get().writeLogs(obj);
+        }
         m_currentToolShape = func;
         //        if (!m_sideBar->isVisible()) {
         updateSideBarPos();
@@ -3805,9 +3813,6 @@ void MainWindow::prepareScreenshot()
 {
     qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "正在准备截图...";
     // 双击截图保存按钮会触发重复进入
-    QJsonObject obj{{"tid", EventLogUtils::StartScreenShot}, {"version", QCoreApplication::applicationVersion()}};
-    if (m_functionType == status::shot)
-        EventLogUtils::get().writeLogs(obj);
     static bool isSaving = false;
     if (isSaving)
         return;
@@ -4046,9 +4051,6 @@ void MainWindow::saveScreenShot()
 {
     qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "正在执行截图保存流程...";
     // 双击截图保存按钮会触发重复进入
-    QJsonObject obj{{"tid", EventLogUtils::StartScreenShot}, {"version", QCoreApplication::applicationVersion()}};
-    if (m_functionType == status::shot)
-        EventLogUtils::get().writeLogs(obj);
     static bool isSaving = false;
     if (isSaving)
         return;
@@ -7012,8 +7014,6 @@ void MainWindow::addCursorToImage()
 void MainWindow::shotFullScreen(bool isFull)
 {
     qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "正在截取全屏...";
-    QJsonObject obj{{"tid", EventLogUtils::StartScreenShot}, {"version", QCoreApplication::applicationVersion()}};
-    EventLogUtils::get().writeLogs(obj);
     QRect target = m_backgroundRect;
     qCDebug(dsrApp) << "m_backgroundRect" << m_backgroundRect;
     if (Utils::isWaylandMode) {

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -8,7 +8,6 @@
 #include "utils.h"
 #include "utils/audioutils.h"
 #include "gstrecord/gstinterface.h"
-#include "utils/eventlogutils.h"
 #include "utils/log.h"
 #ifdef KF5_WAYLAND_FLAGE_ON
 #include "waylandrecord/avlibinterface.h"
@@ -825,12 +824,6 @@ void RecordProcess::startRecord()
         }
     }
 
-    QJsonObject obj{
-        {"tid", EventLogUtils::StartRecording},
-        {"version", QCoreApplication::applicationVersion()},
-        {"type", m_recordType == Utils::kGIF ? "gif" : (m_recordType == Utils::kMKV ? "mkv" : "mp4")}
-    };
-    EventLogUtils::get().writeLogs(obj);
     if (Utils::isSysHighVersion1040() == false) {
         qCInfo(dsrApp) << "系统版本小于1040, 不显示录制时长功能。";
         return;
@@ -876,12 +869,6 @@ void RecordProcess::setFullScreenRecord(bool flag)
 
 void RecordProcess::stopRecord()
 {
-//    QJsonObject obj{
-//        {"tid", EventLogUtils::EndRecording},
-//        {"version", QCoreApplication::applicationVersion()},
-//        {"type", m_recordType == Utils::kGIF ? "gif" : (m_recordType == Utils::kMKV ? "mkv" : "mp4")}
-//    };
-//    EventLogUtils::get().writeLogs(obj);
     if (Utils::isSysHighVersion1040() == true) {
         qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "正在暂停录屏计时...";
         qCDebug(dsrApp) << "Pause the screen recording timer!";

--- a/src/utils/eventlogutils.h
+++ b/src/utils/eventlogutils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,10 +15,6 @@ public:
         OpeningTime         = 1000000000,
         ClosingTime         = 1000000001,
         Start               = 1000200000,
-        StartRecording      = 1000200001,
-        StartScreenShot     = 1000200002,
-        StartOcr            = 1000200003,
-        StartScrollShot     = 1000200004,
         EndRecording        = 1000200005,
         EndScreenShot       = 1000200006
     };


### PR DESCRIPTION
- Removed logging for various screenshot and recording events in MainWindow and RecordProcess classes to streamline functionality.
- Updated event log utility definitions to exclude unused event types related to screenshots and recordings.

Task: https://pms.uniontech.com/task-view-388229.html