### PR TITLE
fix(shot): align size tips with actual saved image dimensions

### DIFF
--- a/src/widgets/toptips.cpp
+++ b/src/widgets/toptips.cpp
@@ -70,7 +70,10 @@ void TopTips::updateTips(QPoint pos, const QSize &size)
 
     QPoint startPoint = pos;
     qreal pixelRatio = qApp->primaryScreen()->devicePixelRatio();
-    QSize s = QSize(static_cast<int>(size.width()*pixelRatio),static_cast<int>(size.height()*pixelRatio));
+    // 与实际截图裁剪逻辑保持一致：宽度-2、高度-1（避开选区虚线边框）
+    int tipWidth = qMax(static_cast<int>((size.width() - 2) * pixelRatio), 0);
+    int tipHeight = qMax(static_cast<int>((size.height() - 1) * pixelRatio), 0);
+    QSize s = QSize(tipWidth, tipHeight);
     setContent(s);
     startPoint.setX(pos.x());
 


### PR DESCRIPTION
The selection size tooltip displayed recordWidth×DPR × recordHeight×DPR, but the actual crop applies -2 width and -1 height adjustments to avoid capturing the dashed selection border, causing a few pixels discrepancy between the displayed size and the saved image file info.

bug: https://pms.uniontech.com/bug-view-353039.html