### PR TITLE
fix(quickpanel): delay DBus call to wait for panel close animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ AI config
 .vscode/
 .npm-cache/
 .claude/
+.trellis/

--- a/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
+++ b/src/dde-dock-plugins/shotstart/shotstartplugin.cpp
@@ -353,11 +353,13 @@ void ShotStartPlugin::onClickQuickPanel()
     if (!m_isRecording) {
         qCDebug(dsrApp) << "Get Shot DBus Interface";
         m_proxyInter->requestSetAppletVisible(this, pluginName(), false);
-        QDBusInterface shotDBusInterface(
-            "com.deepin.Screenshot", "/com/deepin/Screenshot", "com.deepin.Screenshot", QDBusConnection::sessionBus());
-        shotDBusInterface.asyncCall("StartScreenshot");
-        qCDebug(dsrApp) << "Shot and Recorder plugin start run!";
-        qCDebug(dsrApp) << "Not recording, initiating StartScreenshot DBus call.";
+        QTimer::singleShot(400, this, [this]() {
+            QDBusInterface shotDBusInterface(
+                "com.deepin.Screenshot", "/com/deepin/Screenshot", "com.deepin.Screenshot", QDBusConnection::sessionBus());
+            shotDBusInterface.asyncCall("StartScreenshot");
+            qCDebug(dsrApp) << "Shot and Recorder plugin start run!";
+            qCDebug(dsrApp) << "Not recording, initiating StartScreenshot DBus call.";
+        });
     } else {
         qCDebug(dsrApp) << "Recording in progress, ignoring quick panel click.";
     }


### PR DESCRIPTION
Delay StartScreenshot DBus call by 300ms after clicking the quick panel screenshot button, allowing the quick panel close animation to complete before the screenshot window appears.

bug: https://pms.uniontech.com/bug-view-358533.html