### PR TITLE
fix(toolbar): correct confirm button tooltip when launching record fr…

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1276,6 +1276,10 @@ void MainWindow::initSaveShortcut()
             } else {
                 saveScreenShotToClipboardOnly();
             }
+        } else if (status::record == m_functionType) {
+            // 录屏模式下启动倒计时
+            qCDebug(dsrApp) << "shortcut : returnSC (key: enter) in record mode";
+            confirm();
         }
     });
     // 截图模式/滚动模式 保存截图 小键盘
@@ -1287,6 +1291,10 @@ void MainWindow::initSaveShortcut()
             } else {
                 saveScreenShotToClipboardOnly();
             }
+        } else if (status::record == m_functionType) {
+            // 录屏模式下启动倒计时
+            qCDebug(dsrApp) << "shortcut : enterSC (key: enter) in record mode";
+            confirm();
         }
         if (status::record == m_functionType && Utils::isWaylandMode)
             m_showButtons->showContentButtons(KEY_ENTER);

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -2036,6 +2036,7 @@ void SubToolWidget::setRecordLaunchMode(const unsigned int funType)
     if (funType == MainWindow::record) {
         //setCurrentWidget(m_recordSubTool);
         switchContent("record");
+        emit changeShotToolFunc("record");
     } else if (funType == MainWindow::ocr) {
         m_ocrButton->click();
     } else if (funType == MainWindow::scrollshot) {

--- a/translations/deepin-screen-recorder_zh_CN.ts
+++ b/translations/deepin-screen-recorder_zh_CN.ts
@@ -52,7 +52,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Copy to clipboard (Enter)</source>
-        <translation>复制到剪贴板</translation>
+        <translation>复制到剪贴板 Enter</translation>
     </message>
 </context>
 <context>
@@ -767,7 +767,7 @@ Hold down Shift to draw squares or circles.</source>
     </message>
     <message>
         <source>Copy to clipboard (Enter)</source>
-        <translation>复制到剪贴板</translation>
+        <translation>复制到剪贴板 Enter</translation>
     </message>
     <message>
         <source>OK (Enter)</source>

--- a/translations/deepin-screen-recorder_zh_TW.ts
+++ b/translations/deepin-screen-recorder_zh_TW.ts
@@ -52,7 +52,7 @@ or press the shortcut again to stop recording</source>
     </message>
     <message>
         <source>Copy to clipboard (Enter)</source>
-        <translation>複製到剪貼板</translation>
+        <translation>複製到剪貼板 Enter</translation>
     </message>
 </context>
 <context>
@@ -767,7 +767,7 @@ Hold down Shift to draw squares or circles.</source>
     </message>
     <message>
         <source>Copy to clipboard (Enter)</source>
-        <translation>複製到剪貼板</translation>
+        <translation>複製到剪貼板 Enter</translation>
     </message>
     <message>
         <source>OK (Enter)</source>


### PR DESCRIPTION
…om plugin

- Add missing changeShotToolFunc signal in setRecordLaunchMode
- Fix missing (Enter) in Chinese tooltip translations (zh_CN, zh_HK, zh_TW)

This ensures the confirm button shows "OK (Enter)" instead of "Copy to clipboard (Enter)" when recording is launched via plugin or keyboard shortcut (Ctrl+Alt+R).

bug: https://pms.uniontech.com/bug-view-359847.html