### PR TITLE
fix(shapeswidget): improve text shape handling and logging

### DIFF
--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -157,8 +157,22 @@ void ShapesWidget::setCurrentShape(QString shapeType)
 {
     qDebug() << __FUNCTION__ << __LINE__ << "type: " << shapeType;
     m_currentType = shapeType;
-    if (shapeType != "text")
+    if (shapeType == "text") {
+        resetForTextToolSwitch();
+    } else {
         setAllTextEditReadOnly();
+    }
+}
+
+void ShapesWidget::resetForTextToolSwitch()
+{
+    // 切换到 text 时仍保留上一个图形的选中态，
+    // 导致第一次点击先“清选中”，第二次点击才进入文本创建。
+    // 这里在工具切换时清理选中态，保证首次点击直接进入文本输入。
+    clearSelected();
+    m_isRotated = false;
+    m_isResize = false;
+    m_clickedKey = Unknow;
 }
 
 void ShapesWidget::clearSelected()

--- a/src/widgets/shapeswidget.h
+++ b/src/widgets/shapeswidget.h
@@ -227,6 +227,8 @@ protected:
     void tapTriggered(QTapGesture *tap);
 
 private:
+    void resetForTextToolSwitch();
+
     QPointF m_pos1 = QPointF(0, 0);
     QPointF m_pos2 = QPointF(0, 0);
     QPointF m_pos3, m_pos4;


### PR DESCRIPTION
- Clear selection state when switching to text shape to ensure immediate text input on first click.
- Enhance logging in mouse press events for better debugging of shape interactions and text editing states.

This update addresses user experience issues related to shape selection and text input, ensuring a smoother workflow when using the text tool.

bug: https://pms.uniontech.com/bug-view-359843.html