### PR TITLE
fix(main_window): update sendSavingNotify to return notification ID

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -988,10 +988,10 @@ QString MainWindow::libPath(const QString &strlib)
     return list.last();
 }
 
-void MainWindow::sendSavingNotify()
+quint32 MainWindow::sendSavingNotify()
 {
     if (Utils::isRootUser) {
-        return;
+        return RecordProcess::RECORD_SAVING_NOTIFY_ID_INVALID;
     }
     // Popup notify.
     QDBusInterface notification("org.freedesktop.Notifications",
@@ -1001,7 +1001,7 @@ void MainWindow::sendSavingNotify()
     QStringList actions;
     actions << "_close" << tr("Ignore");
     int timeout = 3000;
-    unsigned int id = 0;
+    quint32 id = RecordProcess::RECORD_SAVING_NOTIFY_ID_INVALID;
 
     QList<QVariant> arg;
     arg << Utils::appName                                                   // (QCoreApplication::applicationName()) appname
@@ -1012,7 +1012,10 @@ void MainWindow::sendSavingNotify()
         << actions                                                          // actions
         << QVariantMap()                                                    // hints
         << timeout;                                                         // timeout
-    notification.callWithArgumentList(QDBus::AutoDetect, "Notify", arg);
+    QDBusMessage reply = notification.callWithArgumentList(QDBus::AutoDetect, "Notify", arg);
+    if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
+        return reply.arguments().constFirst().toUInt();
+    return RecordProcess::RECORD_SAVING_NOTIFY_ID_INVALID;
 }
 
 void MainWindow::forciblySavingNotify()
@@ -1028,7 +1031,7 @@ void MainWindow::forciblySavingNotify()
     QStringList actions;
     actions << "_close" << tr("Ignore");
     int timeout = 3000;
-    unsigned int id = 0;
+    quint32 id = RecordProcess::RECORD_SAVING_NOTIFY_ID_INVALID;
 
     QList<QVariant> arg;
     arg << Utils::appName                     //(QCoreApplication::applicationName()) // appname
@@ -7268,9 +7271,9 @@ void MainWindow::stopRecord()
         }
         hide();
         emit releaseEvent();
-        // 正在保存录屏文件通知,全屏录制时不需进行通知
+        // 正在保存录屏文件通知，全屏录制时不需进行通知；完成时用 CloseNotification 关闭本条再弹「录制完成」
         if (!m_isFullScreenRecord)
-            sendSavingNotify();
+            recordProcess.setRecordSavingNotifyId(sendSavingNotify());
         // 状态栏闪烁停止
         if (Utils::isTabletEnvironment && m_tabletRecorderHandle) {
             m_tabletRecorderHandle->stop();

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -389,7 +389,7 @@ public:
      * @return true=完整文件路径，false=目录路径
      */
     bool parsePathArgument(const QString &path, QString &outDir, QString &outFileName, QString &outFormat);
-    void sendSavingNotify();
+    quint32 sendSavingNotify();
     // 强制录屏保存退出通知,3D->2D模式
     void forciblySavingNotify();
 

--- a/src/record_process.cpp
+++ b/src/record_process.cpp
@@ -87,6 +87,22 @@ static QDBusMessage callTrayRecorderIcon(const QString &function)
     return recorderInterface.call(function);
 }
 
+static void closeFdoNotification(quint32 id)
+{
+    if (id == RecordProcess::RECORD_SAVING_NOTIFY_ID_INVALID)
+        return;
+    QDBusInterface notification("org.freedesktop.Notifications",
+                                "/org/freedesktop/Notifications",
+                                "org.freedesktop.Notifications",
+                                QDBusConnection::sessionBus());
+    notification.call("CloseNotification", id);
+}
+
+void RecordProcess::setRecordSavingNotifyId(quint32 id)
+{
+    m_recordSavingNotifyId = id;
+}
+
 RecordProcess::RecordProcess(QObject *parent) : QObject(parent)
 {
     qCDebug(dsrApp) << "Record process control class initialized.";
@@ -804,6 +820,7 @@ void RecordProcess::onExitGstRecord()
 //开始录屏
 void RecordProcess::startRecord()
 {
+    m_recordSavingNotifyId = RECORD_SAVING_NOTIFY_ID_INVALID;
     getScreenRecordSavePath();
     //使用QtConcurrent::run受cpu核心线程数的影响，线程池默认大小为CPU核心线程数大小，由于程序中通过此方法启动的线程数超出4个，故再次设置线程池大小
     QThreadPool::globalInstance()->setMaxThreadCount(QThreadPool::globalInstance()->maxThreadCount() > 6 ? QThreadPool::globalInstance()->maxThreadCount() : 10);
@@ -959,7 +976,11 @@ void RecordProcess::stopRecord()
 void RecordProcess::exitRecord(QString newSavePath)
 {
     if (!Utils::isRootUser && !m_isFullScreenRecord) {
-        qCInfo(dsrApp) << __LINE__ << __func__ << "正在弹出保存完成的通知...";
+        qCInfo(dsrApp) << __LINE__ << __func__ << "关闭「正在保存」通知（若有）并弹出保存完成通知";
+        if (m_recordSavingNotifyId != RECORD_SAVING_NOTIFY_ID_INVALID) {
+            closeFdoNotification(m_recordSavingNotifyId);
+            m_recordSavingNotifyId = RECORD_SAVING_NOTIFY_ID_INVALID;
+        }
         // Popup notify.
         QDBusInterface notification("org.freedesktop.Notifications",
                                     "/org/freedesktop/Notifications",

--- a/src/record_process.h
+++ b/src/record_process.h
@@ -41,6 +41,8 @@ public:
     static const int RECORD_FRAMERATE_24;
     static const int RECORD_FRAMERATE_30;
 
+    static constexpr quint32 RECORD_SAVING_NOTIFY_ID_INVALID = 0;
+
     explicit RecordProcess(QObject *parent = nullptr);
     ~RecordProcess();
 
@@ -72,6 +74,12 @@ public:
      * @param flag
      */
     void setFullScreenRecord(bool flag);
+
+    /**
+     * @brief 由 MainWindow 在弹出「正在保存」通知后传入 Notify 返回的 id，
+     *        exitRecord 弹出「录制完成」前会先 CloseNotification 关闭该通知。
+     */
+    void setRecordSavingNotifyId(quint32 id);
 private:
     /**
      * @brief x11协议下ffmpeg录制视频
@@ -194,6 +202,8 @@ private:
      * @brief m_isFullScreenRecord 是否是快捷全屏录制，默认为false
      */
     bool m_isFullScreenRecord = false;
+
+    quint32 m_recordSavingNotifyId = RECORD_SAVING_NOTIFY_ID_INVALID;
 
 signals:
     void recordingStopped();


### PR DESCRIPTION
- Change sendSavingNotify from void to unsigned int to return the notification ID.
- Implement logic to close the notification in exitRecord using the returned ID.
- Adjust related calls in stopRecord to handle the notification ID correctly.

This improves the notification handling during the recording process, ensuring that users receive accurate feedback on the saving status.

bug: https://pms.uniontech.com/bug-view-359845.html