### PR TITLE
feat(audio): disable system audio in virtual machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 Makefile
 moc_*.o
 moc_*.cpp
+moc_*.h
+qrc_*.cpp
 *.o
+*.so
 build/
 *.qm
 *.pro.user*
+deepin-screen-recorder
+deepin-pin-screenshots
+.qmake.stash

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -241,6 +241,35 @@ void Utils::showCurrentSys()
     //qDebug() << "udpateVersion: " << DSysInfo::udpateVersion();
     //qDebug() << "majorVersion: " << DSysInfo::majorVersion();
     //qDebug() << "majorVersion: " << DSysInfo::majorVersion();
+    qInfo() << "isVirtualMachine: " << isRunningInVirtualMachine();
+}
+
+//Detect whether running in a virtual machine
+bool Utils::isRunningInVirtualMachine(bool forceVirtualMachine)
+{
+    QProcess process;
+    process.start("/usr/bin/systemd-detect-virt");
+    process.waitForFinished();
+    QString output = process.readAllStandardOutput().trimmed();
+
+    // Print the output of systemd-detect-virt command
+    qInfo() << "systemd-detect-virt output: " << output;
+
+    // none: not a virtual machine
+    // kvm, vmware, virtualbox, xen, qemu, etc.: virtual machine
+    // empty output: also considered as not a virtual machine
+    if (forceVirtualMachine) {
+        qInfo() << "Force treat as virtual machine";
+        return true;
+    }
+
+    if (output.isEmpty() || output.toLower() == "none") {
+        qInfo() << "Running on physical machine, not a virtual machine";
+        return false;
+    } else {
+        qInfo() << "Running in a virtual machine, type:" << output;
+        return true;
+    }
 }
 void Utils::enableXGrabButton()
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -143,7 +143,14 @@ public:
      * @brief showCurrentSys 显示
      */
     static void showCurrentSys();
-
+    
+    /**
+     * @brief isRunningInVirtualMachine Detect whether running in a virtual machine
+     * @param forceVirtualMachine If true, force treat as virtual machine; if false, auto-detect
+     * @return true: running in a virtual machine; false: not running in a virtual machine
+     */
+    static bool isRunningInVirtualMachine(bool forceVirtualMachine = false);
+    
     /**
      * @brief 使能XGrabButton抓取所有的鼠标点击事件
      */

--- a/src/utils/voicevolumewatcher.cpp
+++ b/src/utils/voicevolumewatcher.cpp
@@ -1,10 +1,11 @@
 // Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "voicevolumewatcher.h"
 #include "audioutils.h"
+#include "utils.h"
 
 #include <QDebug>
 #include <QThread>

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1456,8 +1456,11 @@ void SubToolWidget::setSystemAudioEnable(bool status)
     m_haveSystemAudio = status;
     m_systemAudioAction->setEnabled(status);
     m_systemAudioAction->setCheckable(status);
-    m_systemAudioAction->setChecked(!status);
-    m_systemAudioAction->trigger();
+    m_systemAudioAction->setChecked(!status && !Utils::isRunningInVirtualMachine());
+    if (Utils::isRunningInVirtualMachine())
+        emit m_systemAudioAction->triggered(false);
+    else
+        m_systemAudioAction->trigger();
 }
 // 当m_microphoneAction或m_systemAudioAction被点击或者程序主动调用trigg()时，会触发工具栏音频采集图标的改变及发射实际需要录制的音频
 void SubToolWidget::onChangeAudioType(bool checked)


### PR DESCRIPTION
Add virtual machine detection using systemd-detect-virt to automatically disable system audio recording when running in a VM environment. System audio is now
unavailable in virtual machines due to driver compatibility issues. Add helper function to uncheck all audio recording options
 (microphone and system audio) for consistent UI state management.

bug: https://pms.uniontech.com/bug-view-360853.html
log: disable system audio in virtual machines