### PR TITLE
fix(topWindow): filter out dde-shell windows by correct WM_CLASS values

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2291,8 +2291,12 @@ void MainWindow::topWindow()
         //  经DTK确认，type存在bug。用flags替换，获取窗口类型功能。bug 77300；
         if (window->flags().testFlag(Qt::Window) || window->flags().testFlag(Qt::Desktop)) {
             // 排除dde-dock作为顶层窗口
-            if (window->wmClass() == "dde-dock" || window->wmClass() == "dde-shell") {
-                qCDebug(dsrApp) << "topWindow wmClass == dde-dock || wmClass == dde-shell, continue";
+            QString wmClass = window->wmClass();
+            static const QVector<QString> excludedWmClasses = {
+                "dde-dock", "dde-shell", "dde-shell/dock", "org.deepin.dde-shell"
+            };
+            if (excludedWmClasses.contains(wmClass)) {
+                qCDebug(dsrApp) << "topWindow excluded by wmClass:" << wmClass << ", continue";
                 continue;
             }
 


### PR DESCRIPTION
  Add "dde-shell/dock" and "org.deepin.dde-shell" to the exclusion list
  for topWindow screenshot, matching actual WM_CLASS values returned by
  dde-shell.

  补充 "dde-shell/dock" 和 "org.deepin.dde-shell" 到窗口截图排除列表，
  匹配 dde-shell 实际返回的 WM_CLASS 值。

  Log: 修复Alt+PrintScreen截图误捕获dde-shell窗口的问题
  PMS: BUG-361527
  Influence: 修复后Alt+PrintScreen截图将正确跳过桌面环境窗口，不再误截dde-shell/dock