### PR TITLE
fix(screenshot): disable right-click menu on lock screen

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -715,6 +715,7 @@ void MainWindow::checkIsLockScreen()
     bool isLockScreen = sessionManagerIntert.property("Locked").toBool();
 
     qInfo() << "Current Screen is LockScreen?" << isLockScreen;
+    m_isLockedState = isLockScreen;
     if (isLockScreen) {
         pinScreenshotsLockScreen(isLockScreen);
         m_toolBar->setScrollShotDisabled(true);
@@ -4431,6 +4432,9 @@ bool MainWindow::eventFilter(QObject *, QEvent *event)
             }
 
             if (mouseEvent->button() == Qt::RightButton) {
+                if (m_isLockedState) {
+                    return false;
+                }
                 if (!isFirstPressButton) {
                     return false;
                 }
@@ -5387,6 +5391,9 @@ void MainWindow::onLockScreenEvent(QDBusMessage msg)
     }
     qDebug() << ">>>>>>>>> isLocked: " << isLocked;
     m_isLockedState = isLocked;
+    if (m_shapesWidget) {
+        m_shapesWidget->setLockedState(isLocked);
+    }
     if (status::scrollshot == m_functionType) {
         scrollShotLockScreen(isLocked);
     } else if (status::shot == m_functionType) {
@@ -5408,6 +5415,9 @@ void MainWindow::onPowersource(bool flag)
 {
     qDebug() << "The Powersource is show? " << flag;
     m_isLockedState = flag;
+    if (m_shapesWidget) {
+        m_shapesWidget->setLockedState(flag);
+    }
     if (status::scrollshot == m_functionType) {
         scrollShotLockScreen(flag);
     } else if (status::shot == m_functionType) {
@@ -6329,6 +6339,7 @@ void MainWindow::initShapeWidget(QString type)
 {
     qDebug() << "function: " << __func__ << " , line: " << __LINE__;
     m_shapesWidget = new ShapesWidget(this);
+    m_shapesWidget->setLockedState(m_isLockedState);
     m_shapesWidget->setShiftKeyPressed(m_isShiftPressed);
 
     if (type != "color")

--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -152,6 +152,12 @@ void ShapesWidget::setCurrentShape(QString shapeType)
     if (shapeType != "text")
         setAllTextEditReadOnly();
 }
+
+void ShapesWidget::setLockedState(bool locked)
+{
+    m_isLockedState = locked;
+}
+
 /*
 void ShapesWidget::setPenColor(QColor color)
 {
@@ -1230,6 +1236,10 @@ void ShapesWidget::mousePressEvent(QMouseEvent *e)
 
     //鼠标右键点击
     if (Qt::MouseEventSource::MouseEventSynthesizedByQt != e->source() && e->button() == Qt::RightButton) {
+        if (m_isLockedState) {
+            DFrame::mousePressEvent(e);
+            return;
+        }
         m_pos1 = QPointF(0, 0); // 修复触控屏绘制矩形后，长按屏幕会出现多余矩形的问题
         qDebug() << "RightButton clicked!" << e->source();
         m_menuController->showMenu(QPoint(mapToGlobal(e->pos())));

--- a/src/widgets/shapeswidget.h
+++ b/src/widgets/shapeswidget.h
@@ -64,6 +64,7 @@ public slots:
      */
     void updateSelectedShape(const QString &group, const QString &key, int index);
     void setCurrentShape(QString shapeType);
+    void setLockedState(bool locked);
     //void updatePenColor();
     //void setPenColor(QColor color);
     /**
@@ -270,6 +271,7 @@ private:
     void updateTextRect(TextEdit *edit, QRectF newRect, QString text, int fontsize);
     Toolshapes m_shapes;
     MenuController *m_menuController;
+    bool m_isLockedState = false;
     //SideBar *m_sideBar;
 
     QRect m_globalRect;


### PR DESCRIPTION
- Set m_isLockedState at startup in checkIsLockScreen() to fix initial value always being false
- Skip right-click menu popup in eventFilter when locked
- Sync lock state to ShapesWidget on creation and DBus changes

修复(screenshot): 禁用锁屏界面下的右键菜单

- 在 checkIsLockScreen() 启动时设置 m_isLockedState，修复初始值始终为 false 的问题
- 在 eventFilter 中锁屏状态下跳过右键菜单弹出
- 在 ShapesWidget 创建及 DBus 状态变化时同步锁屏状态

Log: 修复锁屏界面截图时右键菜单弹出后立即消失的问题
Bug: https://pms.uniontech.com/bug-view-256531.html