### PR TITLE
Bug fix 5 21

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -3819,8 +3819,20 @@ void MainWindow::changeShotToolEvent(const QString &func)
             "com.deepin.PinScreenShots", "/com/deepin/PinScreenShots", QDBusConnection::sessionBus(), this);
         // 保存贴图到剪贴板
         saveScreenShot();
-        m_pinInterface->openImageAndName(m_resultPixmap.toImage(), m_saveFileName, QPoint(recordX, recordY));
-        QTimer::singleShot(2, [=] { exitApp(); });
+        QImage pinImage = m_resultPixmap.toImage();
+        QDBusPendingCall pendingCall = m_pinInterface->openImageAndName(pinImage, m_saveFileName, QPoint(recordX, recordY));
+        auto *watcher = new QDBusPendingCallWatcher(pendingCall, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher]() {
+            if (watcher->isError()) {
+                qCWarning(dsrApp) << "[PIN_DIAG] D-Bus openImageAndName failed:"
+                                  << watcher->error().name()
+                                  << watcher->error().message();
+            } else {
+                qCWarning(dsrApp) << "[PIN_DIAG] D-Bus openImageAndName succeeded";
+            }
+            watcher->deleteLater();
+            exitApp();
+        });
 
     } else if (func == "scrollShot") {  // 点击滚动截图
         {
@@ -7012,20 +7024,25 @@ QPixmap MainWindow::paintImage()
         backgroundImage = m_backgroundPixmap.toImage(); // 非treeland模式下的背景图像
     }
     QImage saveImage;
-    // 修正方案：对逻辑坐标进行相同的边界调整，然后转换为物理坐标
-    // 虚线绘制的调整逻辑：x=max(x,1), y=max(y,1), width=min(width-2, maxWidth-2), height=min(height-1, maxHeight-2)
-    int adjustedX = std::max(recordX, 1);
-    int adjustedY = std::max(recordY, 1);
-    int adjustedWidth = std::min(recordWidth - 2, m_backgroundRect.width() - 2);
-    int adjustedHeight = std::min(recordHeight - 1, m_backgroundRect.height() - 2);
-    
-    QRect target(static_cast<int>(adjustedX * m_pixelRatio),
-                 static_cast<int>(adjustedY * m_pixelRatio),
-                 static_cast<int>(adjustedWidth * m_pixelRatio),
-                 static_cast<int>(adjustedHeight * m_pixelRatio));
-    
-    // 从背景图中裁剪出截图区域
-    saveImage = backgroundImage.copy(target);
+    // Treeland：capture 帧已是 captureRegion/cropRect 大小的选区图（与 test_capture 一致），
+    // 不能再按全屏 recordX/recordY 二次裁剪，否则坐标越界导致截图残缺。
+    if (Utils::isTreelandMode) {
+        saveImage = backgroundImage;
+    } else {
+        // 修正方案：对逻辑坐标进行相同的边界调整，然后转换为物理坐标
+        // 虚线绘制的调整逻辑：x=max(x,1), y=max(y,1), width=min(width-2, maxWidth-2), height=min(height-1, maxHeight-2)
+        int adjustedX = std::max(recordX, 1);
+        int adjustedY = std::max(recordY, 1);
+        int adjustedWidth = std::min(recordWidth - 2, m_backgroundRect.width() - 2);
+        int adjustedHeight = std::min(recordHeight - 1, m_backgroundRect.height() - 2);
+
+        QRect target(static_cast<int>(adjustedX * m_pixelRatio),
+                     static_cast<int>(adjustedY * m_pixelRatio),
+                     static_cast<int>(adjustedWidth * m_pixelRatio),
+                     static_cast<int>(adjustedHeight * m_pixelRatio));
+
+        saveImage = backgroundImage.copy(target);
+    }
     if (m_shapesWidget)
         // 在图片上绘制编辑的内容
         m_shapesWidget->paintImage(saveImage);

--- a/src/pin_screenshots/main.cpp
+++ b/src/pin_screenshots/main.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2019 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Deepin Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +22,7 @@
 
 #include <QScreen>
 #include <QGuiApplication>
+#include <QSurfaceFormat>
 
 DWIDGET_USE_NAMESPACE
 
@@ -30,9 +31,11 @@ bool isWaylandProtocol()
     qCDebug(dsrApp) << "Checking if Wayland protocol is in use.";
     QProcessEnvironment e = QProcessEnvironment::systemEnvironment();
 
-    // check is treeland environment.
-    if (e.value(QStringLiteral("DDE_CURRENT_COMPOSITOR")) == QStringLiteral("TreeLand")) {
-        qCDebug(dsrApp) << "DDE_CURRENT_COMPOSITOR is TreeLand, not Wayland.";
+    // TreeLand：环境变量取值在不同版本可能有大小写差异，与主程序一致做不区分大小写判断
+    const QString compositor = e.value(QStringLiteral("DDE_CURRENT_COMPOSITOR"));
+    if (compositor.compare(QStringLiteral("treeland"), Qt::CaseInsensitive) == 0) {
+        PUtils::isTreelandMode = true;
+        qCDebug(dsrApp) << "DDE_CURRENT_COMPOSITOR is TreeLand-like:" << compositor;
         return false;
     }
 
@@ -53,18 +56,20 @@ int main(int argc, char *argv[])
         return 0;
     }
     PUtils::isWaylandMode = isWaylandProtocol();
+    qCInfo(dsrApp) << "PinScreenShots session: isWaylandMode=" << PUtils::isWaylandMode
+                   << "isTreelandMode=" << PUtils::isTreelandMode;
     if (PUtils::isWaylandMode) {
         qCDebug(dsrApp) << "Setting Wayland shell integration";
         qputenv("QT_WAYLAND_SHELL_INTEGRATION", "kwayland-shell");
     }
-
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::UnknownType);
-    qCDebug(dsrApp) << "Set palette type for Qt6.";
-#else
-    DGuiApplicationHelper::setUseInactiveColorGroup(false);
-    qCDebug(dsrApp) << "Set inactive color group for Qt5.";
-#endif
+    // Treeland 时 isWaylandMode 为 false，不会走上面的 Wayland 分支；Wayland 下透明/模糊常需默认 surface 带 alpha
+    if (PUtils::isTreelandMode) {
+        QSurfaceFormat format;
+        format.setAlphaBufferSize(8);
+        format.setRenderableType(QSurfaceFormat::OpenGLES);
+        QSurfaceFormat::setDefaultFormat(format);
+        qCInfo(dsrApp) << "Treeland: QSurfaceFormat default alpha buffer set (before QApplication).";
+    }
 
 #if(DTK_VERSION < DTK_VERSION_CHECK(5,4,0,0))
     DApplication::loadDXcbPlugin();
@@ -75,6 +80,15 @@ int main(int argc, char *argv[])
     QScopedPointer<DApplication> app(DApplication::globalApplication(argc, argv));
     qCDebug(dsrApp) << "Created DApplication for DTK >= 5.4.0.0.";
 #endif
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::UnknownType);
+    qCDebug(dsrApp) << "Set palette type for Qt6 (after QApplication).";
+#else
+    DGuiApplicationHelper::setUseInactiveColorGroup(false);
+    qCDebug(dsrApp) << "Set inactive color group for Qt5.";
+#endif
+
     app->setOrganizationName("deepin");
     app->setApplicationName("deepin-screen-recorder");
     app->setProductName(QObject::tr("Pin Screenshots"));

--- a/src/pin_screenshots/mainwindow.cpp
+++ b/src/pin_screenshots/mainwindow.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2019 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Deepin Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,8 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QWindow>
+#include <QShowEvent>
 
 #define MOVENUM 1
 
@@ -57,8 +59,14 @@ void MainWindow::initMainWindow()
     m_ocrInterface = nullptr;
     m_toolBar = nullptr;
     //去菜单栏，置顶窗口
-    setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::BypassWindowManagerHint);
-    qCDebug(dsrApp) << "Set window flags.";
+    if (PUtils::isTreelandMode) {
+        // Treeland: 由合成器管理主窗口移动，工具栏作为 subsurface 跟随。
+        setWindowFlags(Qt::FramelessWindowHint | Qt::Window | Qt::WindowStaysOnTopHint);
+        qCDebug(dsrApp) << "Set window flags for Treeland mode.";
+    } else {
+        setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::BypassWindowManagerHint);
+        qCDebug(dsrApp) << "Set window flags.";
+    }
 
     //设置可以进行鼠标操作
     setMouseTracking(true);
@@ -432,18 +440,28 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 {
     //qCDebug(dsrApp) << this << __FUNCTION__ << __LINE__ ;
     switch (event->button()) {
-    case Qt::LeftButton:
+    case Qt::LeftButton: {
+        const QPointF globalPress = event->globalPosition();
+        if (PUtils::isTreelandMode) {
+            region(globalPress.toPoint());
+            if (dir == NONE && windowHandle()) {
+                windowHandle()->startSystemMove();
+                event->accept();
+                return;
+            }
+        }
         isLeftPressDown = true;
         if (dir != NONE) {
             this->mouseGrabber();
         } else {
-            dragPosition = (event->globalPosition() - this->frameGeometry().topLeft()).toPoint();
+            dragPosition = (globalPress - this->frameGeometry().topLeft()).toPoint();
         }
-        // 鼠标按下时隐藏工具栏
-        if (!m_toolBar->isHidden())
+        // 鼠标按下时隐藏工具栏；Treeland 下工具栏是 subsurface，可随主窗口移动。
+        if (!PUtils::isTreelandMode && !m_toolBar->isHidden())
             m_toolBar->hide();
         //qCDebug(dsrApp) << this << __FUNCTION__ << __LINE__ ;
         break;
+    }
     case Qt::RightButton:
         handleMouseRightBtn(event);
         break;
@@ -465,7 +483,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         this->region(gloPoint);
     } else {
         // 确保在拖动过程中隐藏工具栏
-        if (!m_toolBar->isHidden()) {
+        if (!PUtils::isTreelandMode && !m_toolBar->isHidden()) {
             m_toolBar->hide();
         }
         
@@ -604,23 +622,30 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
     int x = this->pos().x();
     int y = this->pos().y();
     bool isNeedUpdateToolBar = false;
+    const auto applyWindowMove = [this](int nx, int ny) {
+        if (PUtils::isTreelandMode && windowHandle()) {
+            windowHandle()->setPosition(nx, ny);
+        } else {
+            move(nx, ny);
+        }
+    };
     if (event->key() == Qt::Key_Left) {
-        this->move(x - MOVENUM, y);
+        applyWindowMove(x - MOVENUM, y);
         isNeedUpdateToolBar = true;
     } else if (event->key() == Qt::Key_Right) {
-        this->move(x + MOVENUM, y);
+        applyWindowMove(x + MOVENUM, y);
         isNeedUpdateToolBar = true;
     } else if (event->key() == Qt::Key_Up) {
         // 适配wayland
         if (y - MOVENUM < 0) {
-            this->move(x, 0);
+            applyWindowMove(x, 0);
         } else {
-            this->move(x, y - MOVENUM);
+            applyWindowMove(x, y - MOVENUM);
         }
 
         isNeedUpdateToolBar = true;
     } else if (event->key() == Qt::Key_Down) {
-        this->move(x, y + MOVENUM);
+        applyWindowMove(x, y + MOVENUM);
         isNeedUpdateToolBar = true;
     }
 
@@ -686,7 +711,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
             
             // 检查鼠标是否在工具栏上，如果是则不隐藏工具栏
             QPoint globalPos = QCursor::pos();
-            if (m_toolBar->isActiveWindow() || m_toolBar->geometry().contains(globalPos))
+            if (m_toolBar->isActiveWindow() || m_toolBar->rect().contains(m_toolBar->mapFromGlobal(globalPos)))
                 return false;
             
             // 检查是否有菜单正在显示
@@ -861,7 +886,6 @@ void MainWindow::sendNotify(QString savePath, bool bSaveState)
     onExit();
 }
 
-// 更新工具栏显示位置
 void MainWindow::updateToolBarPosition()
 {
     //获取贴图界面右下角的点
@@ -893,9 +917,23 @@ void MainWindow::updateToolBarPosition()
     } else if (x + m_toolBar->width() > m_screenSize.width()) {
         x = m_screenSize.width() - m_toolBar->width();
     }
-    m_toolBar->showAt(QPoint(x, y), m_isfirstTime);
-    m_toolBar->activateWindow();
+    QPoint toolbarPos(x, y);
+    if (toolbarAttachedToWindow()) {
+        toolbarPos = mapFromGlobal(toolbarPos);
+    }
+    m_toolBar->showAt(toolbarPos, m_isfirstTime);
+    // Treeland subsurface 下工具栏 QWindow 已 setParent，非顶层；activateWindow 会触发 Qt Warning
+    if (!(PUtils::isTreelandMode && toolbarAttachedToWindow())) {
+        m_toolBar->activateWindow();
+    }
     m_isfirstTime = false;
+}
+
+bool MainWindow::toolbarAttachedToWindow() const
+{
+    const QWindow *mainWindow = windowHandle();
+    const QWindow *toolbarWindow = m_toolBar ? m_toolBar->windowHandle() : nullptr;
+    return mainWindow && toolbarWindow && toolbarWindow->parent() == mainWindow;
 }
 
 void MainWindow::checkToolbarVisibility()
@@ -924,13 +962,14 @@ void MainWindow::checkToolbarVisibility()
         }
     }
     
-    const bool mouseOnToolBar = m_toolBar && m_toolBar->isVisible() && m_toolBar->geometry().contains(globalPos);
+    const bool mouseOnToolBar = m_toolBar && m_toolBar->isVisible()
+        && m_toolBar->rect().contains(m_toolBar->mapFromGlobal(globalPos));
 
     bool mouseOnMenu = false;
     if (m_toolBar && m_toolBar->isVisible()) {
         QList<QMenu*> menus = m_toolBar->findChildren<QMenu*>();
         for (QMenu* menu : menus) {
-            if (menu->isVisible() && menu->geometry().contains(globalPos)) {
+            if (menu->isVisible() && menu->rect().contains(menu->mapFromGlobal(globalPos))) {
                 mouseOnMenu = true;
                 break;
             }
@@ -946,6 +985,26 @@ void MainWindow::checkToolbarVisibility()
             m_toolBar->hide();
         }
     }
+}
+
+void MainWindow::showEvent(QShowEvent *event)
+{
+    DWidget::showEvent(event);
+    if (!PUtils::isTreelandMode || !m_toolBar) {
+        return;
+    }
+
+    createWinId();
+    m_toolBar->createWinId();
+    if (!windowHandle() || !m_toolBar->windowHandle() || toolbarAttachedToWindow()) {
+        return;
+    }
+
+    m_toolBar->windowHandle()->setParent(windowHandle());
+    m_toolBar->hide();
+    m_toolBar->show();
+    qCDebug(dsrApp) << "[Treeland] pin toolbar QWindow::setParent (subsurface with custom style)";
+    updateToolBarPosition();
 }
 
 void MainWindow::enterEvent(QEnterEvent *event)

--- a/src/pin_screenshots/mainwindow.h
+++ b/src/pin_screenshots/mainwindow.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2019 ~ 2019 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2019 ~ 2026 Deepin Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -121,6 +121,7 @@ protected:
     void enterEvent(QEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
     /**
      * @brief 快捷键初始化
      */
@@ -142,6 +143,7 @@ protected:
      * @brief 更新工具栏显示位置
      */
     void updateToolBarPosition(); // 工具栏显示位置
+    bool toolbarAttachedToWindow() const;
 
 private:
     /**

--- a/src/pin_screenshots/putils.cpp
+++ b/src/pin_screenshots/putils.cpp
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "putils.h"
 
 bool PUtils::isWaylandMode = false;
+bool PUtils::isTreelandMode = false;

--- a/src/pin_screenshots/putils.h
+++ b/src/pin_screenshots/putils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,8 @@ class PUtils : public QObject
 {
 public:
     static bool isWaylandMode;
+    /** TreeLand 合成器（Wayland 会话下 DDE_CURRENT_COMPOSITOR=TreeLand） */
+    static bool isTreelandMode;
 };
 
 #endif  // PUTILS_H

--- a/src/pin_screenshots/ui/toolbarwidget.cpp
+++ b/src/pin_screenshots/ui/toolbarwidget.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 
 #include <QActionGroup>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QTimer>
 #include "mainwindow.h"
 
@@ -30,6 +31,10 @@ ToolBarWidget::ToolBarWidget(DWidget *parent): DBlurEffectWidget(parent)
     if (PUtils::isWaylandMode) {
         setWindowFlags(Qt::Sheet | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
         qCDebug(dsrApp) << "Window flags set for Wayland mode.";
+    } else if (PUtils::isTreelandMode) {
+        // Treeland：作为主贴图窗口的 subsurface；背景改为自绘，避免 DBlur 在 subsurface 下失效。
+        setWindowFlags(Qt::FramelessWindowHint | Qt::Tool | Qt::WindowStaysOnTopHint);
+        qCDebug(dsrApp) << "Window flags set for Treeland mode.";
     } else if (sysIsV23) {
         //v23上ToolTip会导致工具栏的圆角失效
         setWindowFlags(Qt::FramelessWindowHint /*| Qt::WindowStaysOnTopHint*/ | Qt::ToolTip);
@@ -38,12 +43,18 @@ ToolBarWidget::ToolBarWidget(DWidget *parent): DBlurEffectWidget(parent)
         setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
         qCDebug(dsrApp) << "Window flags set for default mode.";
     }
-    this->setWindowFlags(windowFlags() | Qt::BypassWindowManagerHint);
+    if (!PUtils::isTreelandMode) {
+        this->setWindowFlags(windowFlags() | Qt::BypassWindowManagerHint);
+    }
 
     this->setRadius(30);
-    this->setBlurEnabled(true);
+    this->setBlurEnabled(!PUtils::isTreelandMode);
     this->setMode(DBlurEffectWidget::GaussianBlur);
     this->setBlendMode(DBlurEffectWidget::InWidgetBlend);
+    if (PUtils::isTreelandMode) {
+        setAttribute(Qt::WA_TranslucentBackground, true);
+        setAutoFillBackground(false);
+    }
     qCDebug(dsrApp) << "Blur effect properties set.";
     // 初始化主题样式
     if (DGuiApplicationHelper::instance()->themeType() == THEMETYPE) {
@@ -141,6 +152,31 @@ void ToolBarWidget::initToolBarWidget()
     setLayout(hLayout);
     qCDebug(dsrApp) << "Layout set for toolbar widget.";
     setMouseTracking(true);
+}
+
+void ToolBarWidget::paintEvent(QPaintEvent *event)
+{
+    if (!PUtils::isTreelandMode) {
+        DBlurEffectWidget::paintEvent(event);
+        return;
+    }
+
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    // 铺满客户区的不透明圆角底（单色、无描边）
+    const QRectF backgroundRect = QRectF(rect());
+    const qreal radius = 16.0;
+
+    const QColor backgroundColor =
+        (DGuiApplicationHelper::instance()->themeType() == THEMETYPE)
+            ? QColor(237, 237, 237, 255)
+            : QColor(48, 48, 48, 255);
+
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(backgroundColor);
+    painter.drawRoundedRect(backgroundRect, radius, radius);
 }
 
 //重写鼠标移动事件：解决工具栏可以被拖动的问题

--- a/src/pin_screenshots/ui/toolbarwidget.h
+++ b/src/pin_screenshots/ui/toolbarwidget.h
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026 Uniontech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,7 @@ protected:
      * 工具栏暂无鼠标移动事件
      * @param event
      */
+    void paintEvent(QPaintEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     
     /**

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -669,9 +669,7 @@ void SubToolWidget::initShotLabel()
         qCDebug(dsrApp) << "贴图按钮按下！";
         emit changeShotToolFunc("pinScreenshots");
     });
-    // TODO: treeland适配，初版暂时屏蔽
-    if (!(Utils::isTreelandMode))
-         btnList.append(m_pinButton);
+    btnList.append(m_pinButton);
 
     m_aiAssistantButton = new ToolButton();
     m_aiAssistantButton->setIconSize(SMALL_TOOL_ICON_SIZE);


### PR DESCRIPTION
   fix(pin_screenshot): adapt toolbar and window management for Treeland compositor
    
    - Add isTreelandMode flag with case-insensitive DDE_CURRENT_COMPOSITOR check
    - Use QSurfaceFormat alpha buffer for Treeland before QApplication creation
    - Move DGuiApplicationHelper palette setup after QApplication to fix Treeland crash
    - Make toolbar a subsurface of the main pin window via QWindow::setParent
    - Replace DBlurEffectWidget blur with custom QPainter rounded-rect background
      (DBlur is non-functional under Treeland subsurface)
    - Use startSystemMove() / windowHandle()->setPosition() for drag & key move
    - Fix geometry() vs mapFromGlobal() coordinate mismatch for toolbar hit-test
    
    TASK: https://pms.uniontech.com/task-view-389563.html
