### PR TITLE
fix(recordtime-plugin): replace heartbeat polling with QDBusServiceWa…

### DIFF
--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.cpp
@@ -16,8 +16,8 @@ RecordTimePlugin::RecordTimePlugin(QObject *parent)
 {
     qCDebug(dsrApp) << "RecordTimePlugin constructor called.";
     m_timer = nullptr;
-    m_checkTimer = nullptr;
     m_timeWidget = nullptr;
+    m_serviceWatcher = nullptr;
 }
 
 const QString RecordTimePlugin::pluginName() const
@@ -102,11 +102,10 @@ void RecordTimePlugin::clear()
         m_timeWidget = nullptr;
     }
 
-    if (nullptr != m_checkTimer) {
-        qCDebug(dsrApp) << "Stopping and deleting check timer";
-        m_checkTimer->stop();
-        m_checkTimer->deleteLater();
-        m_checkTimer = nullptr;
+    if (nullptr != m_serviceWatcher) {
+        qCDebug(dsrApp) << "Deleting service watcher";
+        m_serviceWatcher->deleteLater();
+        m_serviceWatcher = nullptr;
     }
     qCDebug(dsrApp) << "clear method finished.";
 }
@@ -120,7 +119,6 @@ void RecordTimePlugin::onStart(bool resetTime)
         qCDebug(dsrApp) << "Clearing time widget settings";
         m_timeWidget->clearSetting();
     }
-    m_checkTimer = nullptr;
     m_timer->start(600);
     connect(m_timer, &QTimer::timeout, this, &RecordTimePlugin::refresh);
 
@@ -142,19 +140,14 @@ void RecordTimePlugin::onStart(bool resetTime)
 void RecordTimePlugin::onStop()
 {
     qCDebug(dsrApp) << "onStop method called.";
-    if (m_timeWidget->enabled()) {
+    // m_timeWidget 可能已被前一次 onStop->clear() 置空。
+    // 例如主程序先正常停录、随后退出，watcher 会再触发一次进来——
+    // 此时直接解引用会崩，先保护再判 enabled。
+    if (m_timeWidget && m_timeWidget->enabled()) {
         qInfo() << "unload plugin";
         qCDebug(dsrApp) << "Time widget enabled, unloading plugin.";
         m_proxyInter->itemRemoved(this, pluginName());
         m_bshow = false;
-        if (nullptr != m_checkTimer) {
-            qCDebug(dsrApp) << "Stopping check timer";
-            m_checkTimer->stop();
-            m_checkTimer->deleteLater();
-            m_checkTimer = nullptr;
-        }
-        m_count = 0;
-        m_nextCount = 0;
         clear();
     }
     qInfo() << "stop record time";
@@ -173,23 +166,20 @@ void RecordTimePlugin::onRecording()
 
     if (m_timeWidget->enabled() && m_bshow) {
         qCDebug(dsrApp) << "Time widget enabled and visible.";
-        m_nextCount++;
-        if (1 == m_nextCount) {
-            qCDebug(dsrApp) << "Starting check timer for recording status";
-            m_checkTimer = new QTimer();
-            connect(m_checkTimer, &QTimer::timeout, this, [=] {
-                // 说明录屏还在进行中
-                if (m_count < m_nextCount) {
-                    qCDebug(dsrApp) << "Recording in progress, updating count";
-                    m_count = m_nextCount;
-                }
-                // 说明录屏已经停止了
-                else {
-                    qCDebug(dsrApp) << "Recording stopped, calling onStop";
-                    onStop();
-                }
+        // 首次进入录屏状态时，安装服务监听器以便主进程崩溃时及时收尾。
+        // 主进程正常停止会主动通过 DBus 调用 onStop，无需 watcher 介入。
+        if (nullptr == m_serviceWatcher) {
+            qCDebug(dsrApp) << "Installing QDBusServiceWatcher for main recorder process";
+            m_serviceWatcher = new QDBusServiceWatcher(
+                "com.deepin.ScreenRecorder",
+                QDBusConnection::sessionBus(),
+                QDBusServiceWatcher::WatchForUnregistration,
+                this);
+            connect(m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered,
+                    this, [this](const QString &) {
+                qCInfo(dsrApp) << "main recorder service unregistered, stopping plugin";
+                onStop();
             });
-            m_checkTimer->start(2000);
         }
     }
     qCDebug(dsrApp) << "onRecording method finished.";

--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.h
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.h
@@ -89,13 +89,13 @@ private:
     QPointer<DBusService> m_dBusService;
     bool m_bshow;
 
-    int m_nextCount = 0;
-    int m_count = 0;
     /**
-     * @brief 此定时器的作用为每隔1秒检查下截图录屏是否还在运行中。
-     * 避免截图录屏崩溃后导致本插件还在执行
+     * @brief 监听主进程 com.deepin.ScreenRecorder 服务名的注销事件。
+     * 主进程崩溃时 dbus-daemon 会自动注销该服务名，watcher 立刻触发——
+     * 用以替换原先基于心跳定时器的崩溃探测，避免同步 D-Bus 调用拖慢
+     * 显示定时器。
      */
-    QTimer *m_checkTimer;
+    QDBusServiceWatcher *m_serviceWatcher;
 };
 
 #endif // RECORDTIME_H


### PR DESCRIPTION
…tcher

The dock plugin previously detected main-process death by counting incoming onRecording() heartbeats from the recorder's emitRecording() loop and starting a 2s checkTimer to compare m_count vs m_nextCount. Any transient stall in the main process (audio capture blocked, IO backpressure, scheduler starvation on low-end machines) silenced the heartbeat and made the plugin falsely conclude the recorder had stopped — triggering onStop() -> clear() and destroying the timer widget, so the next heartbeat would re-create it from zero and the displayed time visibly restarted.

Switch to event-driven liveness: install a QDBusServiceWatcher on "com.deepin.ScreenRecorder" with WatchForUnregistration. dbus-daemon auto-unregisters the bus name only when the owning process actually exits, so a busy-but-alive recorder no longer trips the watchdog. Normal stop still arrives via the explicit DBus onStop() call; the watcher only covers crash cleanup.

Also guard onStop() against a null m_timeWidget — a stop-then-crash sequence can fire the watcher after clear() has already nulled it.

将托盘插件的"主程序存活检测"从基于心跳计数的轮询定时器改为
QDBusServiceWatcher 事件订阅。原方案在主程序因音频卡顿等原因
暂停心跳时会误判为崩溃，触发 onStop -> clear 销毁计时控件，
下一次心跳到来时重新初始化导致显示时间从零重启。改用 watcher
监听 bus name 注销事件后，仅主程序真实退出时才触发清理；同时
为 onStop 增加 m_timeWidget 空指针保护以应对 stop 后再触发的
边缘时序。

Log: 修复录屏过程中主程序短暂卡顿导致任务栏插件计时清零重启的问题

PMS: BUG-330567

Influence: 修复后主程序在音频抓取等场景下短暂卡顿不再触发插件误判停止，
任务栏录制时间显示连续不重置；主程序真实崩溃时仍能由 watcher 及时清理。