### PR TITLE
fix(scrollshot): improve Wayland scroll capture reliability

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -1353,6 +1353,15 @@ void MainWindow::initScrollShot()
     }
     //定时2s后滚动截图的提示消失
     m_tipShowtimer = new QTimer(this);
+    m_waylandManualScrollTimer = new QTimer(this);
+    m_waylandManualScrollTimer->setSingleShot(true);
+    connect(m_waylandManualScrollTimer, &QTimer::timeout, this, [this] {
+        if (!m_scrollShot || status::scrollshot != m_functionType || m_isErrorWithScrollShot) {
+            return;
+        }
+        scrollShotGrabPixmap(m_waylandManualScrollPreviewPostion, m_waylandManualScrollDirection,
+                             m_waylandManualScrollMouseTime);
+    });
     connect(m_tipShowtimer, &QTimer::timeout, this, [ = ]() {
         m_tipShowtimer->stop();
         m_scrollShotTip->hide();
@@ -1489,6 +1498,18 @@ void MainWindow::handleManualScrollShot(int mouseTime, int direction)
     m_scrollShotTip->hide();
     m_isAdjustArea = false;
     update();
+    if (Utils::isWaylandMode) {
+        m_waylandManualScrollPreviewPostion = m_previewPostion;
+        m_waylandManualScrollDirection = direction;
+        m_waylandManualScrollMouseTime = mouseTime;
+        if (m_waylandManualScrollTimer) {
+            m_waylandManualScrollTimer->start(320);
+        } else {
+            scrollShotGrabPixmap(m_previewPostion, direction, mouseTime);
+        }
+        return;
+    }
+
     static int num = 1;
     ++num;
     if (num % 3 == 0) {
@@ -1523,7 +1544,7 @@ void MainWindow::showAdjustArea()
 }
 #ifdef OCR_SCROLL_FLAGE_ON
 //滚动截图模式，抓取当前捕捉区域的图片，传递给滚动截图处理类进行图片的拼接
-void MainWindow::scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, int mouseTime)
+void MainWindow::scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, qint64 mouseTime)
 {
 
 //不同的平台延时时间不同
@@ -2117,23 +2138,29 @@ void MainWindow::wheelEvent(QWheelEvent *event)
     int y = this->cursor().pos().y();
 
     //将当前捕捉区域画为一个矩形
-    QRect recordRect {
-        static_cast<int>(recordX * m_pixelRatio),
-        static_cast<int>(recordY * m_pixelRatio),
-        static_cast<int>(recordWidth * m_pixelRatio),
-        static_cast<int>(recordHeight * m_pixelRatio)
-    };
+    QRect recordRect(recordX, recordY, recordWidth, recordHeight);
     //当前鼠标的点
     QPoint mouseMovePoint(x, y);
     //判断当鼠标位置是否在捕捉区域内部,不在捕捉区域内则暂停自动滚动
     if (!recordRect.contains(mouseMovePoint))
         return;
     if (m_scrollShot) {
-        int time = int (QDateTime::currentDateTime().toTime_t());
-        float len = (event->delta() > 15.0) ? -15.0 : 15.0; // 获取滚轮方向
-        int direction = (fabs(double(len) - 15.0) <= EPSILON) ? 5 : 4; // 获取滚轮方向
-        scrollShotMouseScrollEvent(time, direction, x, y);
+        if (m_isErrorWithScrollShot)
+            return;
+
+        qint64 time = QDateTime::currentMSecsSinceEpoch();
+        float len = (event->delta() > 0) ? -5.0 : 5.0; // 获取滚轮方向
+        int direction = (fabs(double(len) - 5.0) <= EPSILON) ? 5 : 4; // 获取滚轮方向
+        m_scrollShotType = ScrollShotType::ManualScroll;
+        if (m_scrollShotStatus == 0) {
+            scrollShotMouseScrollEvent(time, direction, x, y);
+        }
         m_scrollShot->sigalWheelScrolling(len);
+        QTimer::singleShot(200, this, [ = ] {
+            if (m_scrollShot && status::scrollshot == m_functionType && !m_isErrorWithScrollShot) {
+                scrollShotMouseScrollEvent(QDateTime::currentMSecsSinceEpoch(), direction, x, y);
+            }
+        });
         qDebug() << __FUNCTION__ << __LINE__;
     }
 #endif
@@ -5204,15 +5231,10 @@ void MainWindow::scrollShotMouseMoveEvent(int x, int y)
  * @param x 当前的x坐标
  * @param y 当前的y坐标
  */
-void MainWindow::scrollShotMouseScrollEvent(int mouseTime, int direction, int x, int y)
+void MainWindow::scrollShotMouseScrollEvent(qint64 mouseTime, int direction, int x, int y)
 {
 #ifdef OCR_SCROLL_FLAGE_ON
-    QRect recordRect {
-        static_cast<int>(recordX * m_pixelRatio),
-        static_cast<int>(recordY * m_pixelRatio),
-        static_cast<int>(recordWidth * m_pixelRatio),
-        static_cast<int>(recordHeight * m_pixelRatio)
-    };
+    QRect recordRect(recordX, recordY, recordWidth, recordHeight);
     //当前鼠标滚动的点
     QPoint mouseScrollPoint(x, y);
     //判断鼠标滚动的位置是否是在捕捉区域内部，不在捕捉区域内部不进行处理

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -516,7 +516,7 @@ public slots:
      * @param x 当前的x坐标
      * @param y 当前的y坐标
      */
-    void scrollShotMouseScrollEvent(int mouseTime, int direction, int x, int y);
+    void scrollShotMouseScrollEvent(qint64 mouseTime, int direction, int x, int y);
 
     /**
      * @brief 监听是否正在进行自动滚动
@@ -699,7 +699,7 @@ protected:
      * @param direction 滚动的方向
      */
 #ifdef OCR_SCROLL_FLAGE_ON
-    void scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, int mosueTime = 0);
+    void scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, qint64 mouseTime = 0);
 #endif
     /**
      * @brief 判断工具栏是否在在捕捉区域内部
@@ -911,6 +911,10 @@ private:
       * @brief 滚动截图提示显示时间的定时器
       */
     QTimer *m_tipShowtimer = nullptr;
+    QTimer *m_waylandManualScrollTimer = nullptr;
+    PreviewWidget::PostionStatus m_waylandManualScrollPreviewPostion = PreviewWidget::PostionStatus::RIGHT;
+    int m_waylandManualScrollDirection = 0;
+    qint64 m_waylandManualScrollMouseTime = 0;
 
     ButtonFeedback *buttonFeedback = nullptr;
     /**

--- a/src/utils/pixmergethread.cpp
+++ b/src/utils/pixmergethread.cpp
@@ -13,7 +13,7 @@ const int PixMergeThread::TEMPLATE_HEIGHT = 50;
 
 PixMergeThread::PixMergeThread(QObject *parent) : QThread(parent)
 {
-    m_lastTime = int(QDateTime::currentDateTime().toTime_t());
+    m_lastTime = QDateTime::currentMSecsSinceEpoch();
 }
 
 PixMergeThread::~PixMergeThread()
@@ -123,7 +123,7 @@ void PixMergeThread::run()
 void PixMergeThread::setScrollModel(bool isManualScrollMode)
 {
     m_isManualScrollModel = isManualScrollMode;
-    //m_lastTime = QDateTime::currentDateTime().toTime_t();
+    //m_lastTime = QDateTime::currentMSecsSinceEpoch();
 }
 
 void PixMergeThread::clearCurImg()
@@ -132,9 +132,9 @@ void PixMergeThread::clearCurImg()
 }
 
 //计算时间差
-void PixMergeThread::calculateTimeDiff(int time)
+void PixMergeThread::calculateTimeDiff(qint64 time)
 {
-    m_curTimeDiff = (time - m_lastTime) * 100;
+    m_curTimeDiff = time - m_lastTime;
     qDebug() << "time:" << time << "m_lastTime" << m_lastTime << "m_curTimeDiff" << m_curTimeDiff;
     m_lastTime = time;
 }
@@ -346,6 +346,10 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
     /*查找最大值及位置*/
     cv::Point minLoc, maxLoc;
     minMaxLoc(res, &minVal, &maxVal, &minLoc, &maxLoc);
+    if (!m_isManualScrollModel && m_MeragerCount == 1 && maxVal >= thresholdv && maxLoc.y == 0) {
+        qDebug() << "2 自动滚动首帧未产生位移，等待下一次滚动";
+        return false;
+    }
     /*图像拼接*/
     cv::Mat temp1, result;
     if (maxVal >= thresholdv && maxLoc.y > 0) { //只有度量值大于阈值才认为是匹配
@@ -359,14 +363,7 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
             QRect rect = getScrollChangeRectArea(curImg, image);
             if (m_isManualScrollModel == false) { //自动滚动时异常处理
                 if (m_MeragerCount == 1) {
-                    if (rect.width() < 0 || rect.height() < 0) {
-                        qDebug() << "1 拼接失败了";
-                        emit merageError(Failed);
-                    } else {
-                        m_headHeight = -1;
-                        qDebug() << "1 无效区域，点击调整捕捉区域";
-                        emit invalidAreaError(InvalidArea, rect); //无效区域，点击调整捕捉区域
-                    }
+                    qDebug() << "1 自动滚动首帧位移过小，等待下一次滚动";
                 } else {
                     qDebug() << "======1==拼接到重复图片，拼接到低了=====";
                     emit merageError(ReachBottom);

--- a/src/utils/pixmergethread.h
+++ b/src/utils/pixmergethread.h
@@ -48,7 +48,7 @@ public:
     void setScrollModel(bool isManualScrollMode); //设置是否为手动模式
 
     void clearCurImg();
-    void calculateTimeDiff(int time); //计算时间差
+    void calculateTimeDiff(qint64 time); //计算时间差
     bool isOneWay(); //是否单向
     void setIsLastImg(bool isLastImg); //设置最后一张图片标记
 protected:
@@ -84,8 +84,8 @@ private:
     //bool m_successfullySplicedDwon = false;//向下拼接成功
     bool m_isManualScrollModel = false;//是否手动模式
     int m_bottomHeight = -1;// 长图底部固定区域高度
-    int m_curTimeDiff = 0; //当前时间差
-    int m_lastTime = 0;    //上一次的时间
+    qint64 m_curTimeDiff = 0; //当前时间差
+    qint64 m_lastTime = 0; //上一次的时间
     int m_upCount = 0;
     int m_downCount = 0;
     bool m_isLastPixmap = false; // 是否是最后一张

--- a/src/utils/waylandscrollmonitor.cpp
+++ b/src/utils/waylandscrollmonitor.cpp
@@ -5,7 +5,7 @@
 
 #include "waylandscrollmonitor.h"
 
-#define SCROLL_DOWN 15.0
+#define SCROLL_DOWN 5.0
 
 WaylandScrollMonitor::WaylandScrollMonitor(QObject *parent) : QObject(parent)
     , m_connection(nullptr)
@@ -114,7 +114,7 @@ void WaylandScrollMonitor::releaseWaylandScrollThread()
 void WaylandScrollMonitor::doWaylandAutoScroll()
 {
     if (m_fakeinput != nullptr) {
-        // Qt::Vertical 垂直滚动，15.0 代表向下滚动
+        // Qt::Vertical 垂直滚动，正值代表向下滚动
         m_fakeinput->requestPointerAxisForCapture(Qt::Vertical, SCROLL_DOWN);
     }
 }


### PR DESCRIPTION
Delay Wayland manual capture until scroll content settles. 延迟 Wayland 手动滚动抓图，等待滚动内容稳定。

Use millisecond timestamps and smaller fake scroll steps. 使用毫秒级时间戳并降低模拟滚动步长。

Log: 修复 Wayland 滚动截图失败问题
Bug: https://pms.uniontech.com/bug-view-352409.html
Influence: 提升 Wayland 下手动和自动滚动截图稳定性，减少无效区域误报。