### PR TITLE
fix(scrollshot): improve Wayland scroll screenshot reliability

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -103,6 +103,9 @@ const int SIDEBAR_X_SPACING = 8;
 const int CURSOR_WIDTH = 8;
 const int CURSOR_HEIGHT = 18;
 const int INDICATOR_WIDTH =  110;
+const int WAYLAND_MANUAL_SCROLL_DELAY_MS = 220;
+const int WAYLAND_SCROLL_RETRY_DELAY_MS = 120;
+const double WAYLAND_SCROLL_STEP = 10.0;
 }
 #ifdef KF5_WAYLAND_FLAGE_ON
 /**
@@ -1366,6 +1369,17 @@ void MainWindow::initScrollShot()
     }
     //定时2s后滚动截图的提示消失
     m_tipShowtimer = new QTimer(this);
+    if (!m_waylandManualScrollTimer) {
+        m_waylandManualScrollTimer = new QTimer(this);
+        m_waylandManualScrollTimer->setSingleShot(true);
+        connect(m_waylandManualScrollTimer, &QTimer::timeout, this, [this] {
+            if (!m_initScroll || !m_scrollShot || status::scrollshot != m_functionType || m_isErrorWithScrollShot) {
+                return;
+            }
+            scrollShotGrabPixmap(m_waylandManualScrollPreviewPostion, m_waylandManualScrollDirection,
+                                 m_waylandManualScrollMouseTime);
+        });
+    }
     connect(m_tipShowtimer, &QTimer::timeout, this, [ = ]() {
         m_tipShowtimer->stop();
         m_scrollShotTip->hide();
@@ -1492,7 +1506,7 @@ void MainWindow::showScrollShot()
 }
 
 //处理手动滚动截图逻辑
-void MainWindow::handleManualScrollShot(int mouseTime, int direction)
+void MainWindow::handleManualScrollShot(qint64 mouseTime, int direction)
 {
 #ifdef OCR_SCROLL_FLAGE_ON
     qDebug() << "function: " << __func__ << " ,line: " << __LINE__;
@@ -1502,6 +1516,18 @@ void MainWindow::handleManualScrollShot(int mouseTime, int direction)
     m_scrollShotTip->hide();
     m_isAdjustArea = false;
     update();
+    if (Utils::isWaylandMode) {
+        m_waylandManualScrollPreviewPostion = m_previewPostion;
+        m_waylandManualScrollDirection = direction;
+        m_waylandManualScrollMouseTime = mouseTime;
+        if (m_waylandManualScrollTimer && !m_waylandManualScrollTimer->isActive()) {
+            m_waylandManualScrollTimer->start(WAYLAND_MANUAL_SCROLL_DELAY_MS);
+        } else if (!m_waylandManualScrollTimer) {
+            scrollShotGrabPixmap(m_previewPostion, direction, mouseTime);
+        }
+        return;
+    }
+
     static int num = 1;
     ++num;
     if (num % 3 == 0) {
@@ -1536,7 +1562,7 @@ void MainWindow::showAdjustArea()
 }
 #ifdef OCR_SCROLL_FLAGE_ON
 //滚动截图模式，抓取当前捕捉区域的图片，传递给滚动截图处理类进行图片的拼接
-void MainWindow::scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, int mouseTime)
+void MainWindow::scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, qint64 mouseTime)
 {
 
 //不同的平台延时时间不同
@@ -1547,12 +1573,15 @@ void MainWindow::scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostio
 #else
     static int delayTime = 50;
 #endif
-    qDebug() << QSysInfo::currentCpuArchitecture() << delayTime;
     //滚动截图处理类：设置滚动截图的模式
     if (ScrollShotType::AutoScroll == m_scrollShotType) {
         m_scrollShot->setScrollModel(false);
     } else if (ScrollShotType::ManualScroll == m_scrollShotType) {
-        m_scrollShot->setTimeAndCalculateTimeDiff(mouseTime);
+        if (Utils::isWaylandMode && mouseTime > 0) {
+            m_scrollShot->setTimeAndCalculateTimeDiff(mouseTime);
+        } else {
+            m_scrollShot->setTimeAndCalculateTimeDiff(QDateTime::currentMSecsSinceEpoch());
+        }
         m_scrollShot->setScrollModel(true);
     }
     //判断工具栏是否在捕捉区域内部
@@ -2186,23 +2215,31 @@ void MainWindow::wheelEvent(QWheelEvent *event)
     int y = this->cursor().pos().y();
 
     //将当前捕捉区域画为一个矩形
-    QRect recordRect {
-        static_cast<int>(recordX * m_pixelRatio),
-        static_cast<int>(recordY * m_pixelRatio),
-        static_cast<int>(recordWidth * m_pixelRatio),
-        static_cast<int>(recordHeight * m_pixelRatio)
-    };
+    QRect recordRect(recordX, recordY, recordWidth, recordHeight);
     //当前鼠标的点
-    QPoint mouseMovePoint(x * m_pixelRatio, y * m_pixelRatio);
+    QPoint mouseMovePoint(x, y);
     //判断当鼠标位置是否在捕捉区域内部,不在捕捉区域内则暂停自动滚动
     if (!recordRect.contains(mouseMovePoint))
         return;
     if (m_scrollShot) {
-        int time = int (QDateTime::currentDateTime().toTime_t());
-        float len = (event->delta() > 15.0) ? -15.0 : 15.0; // 获取滚轮方向
-        int direction = (fabs(double(len) - 15.0) <= EPSILON) ? 5 : 4; // 获取滚轮方向
-        scrollShotMouseScrollEvent(time, direction, x, y);
+        if (m_isErrorWithScrollShot)
+            return;
+
+        qint64 time = QDateTime::currentMSecsSinceEpoch();
+        float len = (event->delta() > 0) ? -WAYLAND_SCROLL_STEP : WAYLAND_SCROLL_STEP; // 获取滚轮方向
+        int direction = (fabs(double(len) - WAYLAND_SCROLL_STEP) <= EPSILON) ? 5 : 4; // 获取滚轮方向
+        m_scrollShotType = ScrollShotType::ManualScroll;
+        const bool isFirstManualScroll = (m_scrollShotStatus == 0);
+        if (isFirstManualScroll) {
+            scrollShotMouseScrollEvent(time, direction, x, y);
+        }
         m_scrollShot->sigalWheelScrolling(len);
+        QTimer::singleShot(WAYLAND_SCROLL_RETRY_DELAY_MS, this, [ = ] {
+            if (m_initScroll && m_scrollShot && status::scrollshot == m_functionType && !m_isErrorWithScrollShot
+                    && (!isFirstManualScroll || m_scrollShotStatus == 5)) {
+                scrollShotMouseScrollEvent(QDateTime::currentMSecsSinceEpoch(), direction, x, y);
+            }
+        });
         qDebug() << __FUNCTION__ << __LINE__;
     }
 #endif
@@ -3373,6 +3410,9 @@ void MainWindow::saveScreenShot()
     hideAllWidget();
 
     m_initScroll = false; // 保存时关闭滚动截图
+    if (m_waylandManualScrollTimer) {
+        m_waylandManualScrollTimer->stop();
+    }
     m_isSaveScrollShot = true; //保存滚动截图时改变
     update();
 #ifdef OCR_SCROLL_FLAGE_ON
@@ -5295,17 +5335,12 @@ void MainWindow::scrollShotMouseMoveEvent(int x, int y)
  * @param x 当前的x坐标
  * @param y 当前的y坐标
  */
-void MainWindow::scrollShotMouseScrollEvent(int mouseTime, int direction, int x, int y)
+void MainWindow::scrollShotMouseScrollEvent(qint64 mouseTime, int direction, int x, int y)
 {
 #ifdef OCR_SCROLL_FLAGE_ON
-    QRect recordRect {
-        static_cast<int>(recordX * m_pixelRatio),
-        static_cast<int>(recordY * m_pixelRatio),
-        static_cast<int>(recordWidth * m_pixelRatio),
-        static_cast<int>(recordHeight * m_pixelRatio)
-    };
+    QRect recordRect(recordX, recordY, recordWidth, recordHeight);
     //当前鼠标滚动的点
-    QPoint mouseScrollPoint(x * m_pixelRatio, y * m_pixelRatio);
+    QPoint mouseScrollPoint = Utils::isWaylandMode ? QPoint(x, y) : QPoint(x * m_pixelRatio, y * m_pixelRatio);
     //判断鼠标滚动的位置是否是在捕捉区域内部，不在捕捉区域内部不进行处理
     if (!recordRect.contains(mouseScrollPoint)) return;
 
@@ -6388,6 +6423,9 @@ void MainWindow::exitApp()
 {
     qInfo() << __FUNCTION__ << __LINE__ << "退出截图录屏！";
     m_initScroll = false; // 保存时关闭滚动截图
+    if (m_waylandManualScrollTimer) {
+        m_waylandManualScrollTimer->stop();
+    }
     emit releaseEvent();
     qApp->quit();
     if (Utils::isWaylandMode) {

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -518,7 +518,7 @@ public slots:
      * @param x 当前的x坐标
      * @param y 当前的y坐标
      */
-    void scrollShotMouseScrollEvent(int mouseTime, int direction, int x, int y);
+    void scrollShotMouseScrollEvent(qint64 mouseTime, int direction, int x, int y);
 
     /**
      * @brief 监听是否正在进行自动滚动
@@ -681,7 +681,7 @@ protected:
      * @brief 处理手动滚动截图逻辑
      * @param 鼠标滚动的方向
      */
-    void handleManualScrollShot(int mouseTime, int direction);
+    void handleManualScrollShot(qint64 mouseTime, int direction);
 
     /**
      * @brief 滚动截图时鼠标穿透设置
@@ -708,7 +708,7 @@ protected:
      * @param direction 滚动的方向
      */
 #ifdef OCR_SCROLL_FLAGE_ON
-    void scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, int mosueTime = 0);
+    void scrollShotGrabPixmap(PreviewWidget::PostionStatus previewPostion, int direction, qint64 mouseTime = 0);
 #endif
     /**
      * @brief 判断工具栏是否在在捕捉区域内部
@@ -921,6 +921,10 @@ private:
       * @brief 滚动截图提示显示时间的定时器
       */
     QTimer *m_tipShowtimer = nullptr;
+    QTimer *m_waylandManualScrollTimer = nullptr;
+    PreviewWidget::PostionStatus m_waylandManualScrollPreviewPostion = PreviewWidget::PostionStatus::RIGHT;
+    int m_waylandManualScrollDirection = 0;
+    qint64 m_waylandManualScrollMouseTime = 0;
 
     ButtonFeedback *buttonFeedback = nullptr;
     /**

--- a/src/utils/pixmergethread.cpp
+++ b/src/utils/pixmergethread.cpp
@@ -10,10 +10,11 @@
 #include <opencv2/imgproc/types_c.h>
 const int PixMergeThread::LONG_IMG_MAX_HEIGHT = 10000;
 const int PixMergeThread::TEMPLATE_HEIGHT = 50;
+const int PixMergeThread::FIRST_FRAME_RETRY_LIMIT = 3;
 
 PixMergeThread::PixMergeThread(QObject *parent) : QThread(parent)
 {
-    m_lastTime = int(QDateTime::currentDateTime().toTime_t());
+    m_lastTime = QDateTime::currentMSecsSinceEpoch();
 }
 
 PixMergeThread::~PixMergeThread()
@@ -123,7 +124,7 @@ void PixMergeThread::run()
 void PixMergeThread::setScrollModel(bool isManualScrollMode)
 {
     m_isManualScrollModel = isManualScrollMode;
-    //m_lastTime = QDateTime::currentDateTime().toTime_t();
+    //m_lastTime = QDateTime::currentMSecsSinceEpoch();
 }
 
 void PixMergeThread::clearCurImg()
@@ -132,9 +133,9 @@ void PixMergeThread::clearCurImg()
 }
 
 //计算时间差
-void PixMergeThread::calculateTimeDiff(int time)
+void PixMergeThread::calculateTimeDiff(qint64 time)
 {
-    m_curTimeDiff = (time - m_lastTime) * 100;
+    m_curTimeDiff = time - m_lastTime;
     qDebug() << "time:" << time << "m_lastTime" << m_lastTime << "m_curTimeDiff" << m_curTimeDiff;
     m_lastTime = time;
 }
@@ -290,6 +291,7 @@ bool PixMergeThread::splicePictureUp(const cv::Mat &image)
             return false;
         }
         qDebug() << "拼接成功了";
+        m_firstFrameRetryCount = 0;
         m_downCount = 0;
         m_curImg = result;
         return true;
@@ -359,6 +361,15 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
     /*查找最大值及位置*/
     cv::Point minLoc, maxLoc;
     minMaxLoc(res, &minVal, &maxVal, &minLoc, &maxLoc);
+    if (!m_isManualScrollModel && m_MeragerCount == 1 && maxVal >= thresholdv && maxLoc.y == 0) {
+        if (++m_firstFrameRetryCount > FIRST_FRAME_RETRY_LIMIT) {
+            qDebug() << "2 自动滚动首帧多次未产生位移";
+            emit merageError(Failed);
+        } else {
+            qDebug() << "2 自动滚动首帧未产生位移，等待下一次滚动";
+        }
+        return false;
+    }
     /*图像拼接*/
     cv::Mat temp1, result;
     if (maxVal >= thresholdv && maxLoc.y > 0) { //只有度量值大于阈值才认为是匹配
@@ -372,13 +383,16 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
             QRect rect = getScrollChangeRectArea(curImg, image);
             if (m_isManualScrollModel == false) { //自动滚动时异常处理
                 if (m_MeragerCount == 1) {
-                    if (rect.width() < 0 || rect.height() < 0) {
-                        qDebug() << "1 拼接失败了";
-                        emit merageError(Failed);
+                    if (++m_firstFrameRetryCount > FIRST_FRAME_RETRY_LIMIT) {
+                        qDebug() << "1 自动滚动首帧多次无有效拼接";
+                        if (rect.width() < 0 || rect.height() < 0) {
+                            emit merageError(Failed);
+                        } else {
+                            m_headHeight = -1;
+                            emit invalidAreaError(InvalidArea, rect);
+                        }
                     } else {
-                        m_headHeight = -1;
-                        qDebug() << "1 无效区域，点击调整捕捉区域";
-                        emit invalidAreaError(InvalidArea, rect); //无效区域，点击调整捕捉区域
+                        qDebug() << "1 自动滚动首帧位移过小，等待下一次滚动";
                     }
                 } else {
                     qDebug() << "======1==拼接到重复图片，拼接到低了=====";
@@ -410,6 +424,7 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
             return false;
         }
         qDebug() << "拼接成功了";
+        m_firstFrameRetryCount = 0;
         m_upCount = 0;
         m_curImg = result;
         return true;

--- a/src/utils/pixmergethread.h
+++ b/src/utils/pixmergethread.h
@@ -48,7 +48,7 @@ public:
     void setScrollModel(bool isManualScrollMode); //设置是否为手动模式
 
     void clearCurImg();
-    void calculateTimeDiff(int time); //计算时间差
+    void calculateTimeDiff(qint64 time); //计算时间差
     bool isOneWay(); //是否单向
     void setIsLastImg(bool isLastImg); //设置最后一张图片标记
 protected:
@@ -78,16 +78,18 @@ private:
     int m_headHeight = -1;
     static const int LONG_IMG_MAX_HEIGHT;
     static const int TEMPLATE_HEIGHT;
+    static const int FIRST_FRAME_RETRY_LIMIT;
 
     //手动截图状态
     //bool m_successfullySplicedUp = false; //向上拼接成功
     //bool m_successfullySplicedDwon = false;//向下拼接成功
     bool m_isManualScrollModel = false;//是否手动模式
     int m_bottomHeight = -1;// 长图底部固定区域高度
-    int m_curTimeDiff = 0; //当前时间差
-    int m_lastTime = 0;    //上一次的时间
+    qint64 m_curTimeDiff = 0; //当前时间差
+    qint64 m_lastTime = 0; //上一次的时间
     int m_upCount = 0;
     int m_downCount = 0;
+    int m_firstFrameRetryCount = 0;
     bool m_isLastPixmap = false; // 是否是最后一张
 };
 

--- a/src/utils/scrollScreenshot.cpp
+++ b/src/utils/scrollScreenshot.cpp
@@ -100,7 +100,7 @@ void ScrollScreenshot::addPixmap(const QPixmap &piximg, int wheelDirection)
 
 void ScrollScreenshot::addLastPixmap(const QPixmap &piximg)
 {
-    setTimeAndCalculateTimeDiff(static_cast<int>(QDateTime::currentDateTime().toTime_t()));
+    setTimeAndCalculateTimeDiff(QDateTime::currentMSecsSinceEpoch());
     m_PixMerageThread->setIsLastImg(true); //添加最后一张图片标记
     if (nullptr != m_PixMerageThread)
         m_PixMerageThread->addShotImg(piximg, m_lastDirection);
@@ -151,7 +151,7 @@ QRect ScrollScreenshot::getInvalidArea()
     return m_rect;
 }
 //设置时间并计算时间差
-void ScrollScreenshot::setTimeAndCalculateTimeDiff(int time)
+void ScrollScreenshot::setTimeAndCalculateTimeDiff(qint64 time)
 {
     m_PixMerageThread->calculateTimeDiff(time);
 }

--- a/src/utils/scrollScreenshot.h
+++ b/src/utils/scrollScreenshot.h
@@ -45,7 +45,7 @@ public:
     //手动滚动时的函数处理
     void setScrollModel(bool model); //设置滚动模式，先设置滚动模式，再添加图片
     QRect getInvalidArea();//获取调整区域
-    void setTimeAndCalculateTimeDiff(int time); //设置时间并计算时间差
+    void setTimeAndCalculateTimeDiff(qint64 time); //设置时间并计算时间差
 signals:
     void getOneImg();
     void updatePreviewImg(QImage img);

--- a/src/utils/waylandscrollmonitor.cpp
+++ b/src/utils/waylandscrollmonitor.cpp
@@ -5,7 +5,7 @@
 
 #include "waylandscrollmonitor.h"
 
-#define SCROLL_DOWN 15.0
+static const double SCROLL_DOWN = 10.0;
 
 WaylandScrollMonitor::WaylandScrollMonitor(QObject *parent) : QObject(parent)
     , m_connection(nullptr)
@@ -114,7 +114,7 @@ void WaylandScrollMonitor::releaseWaylandScrollThread()
 void WaylandScrollMonitor::doWaylandAutoScroll()
 {
     if (m_fakeinput != nullptr) {
-        // Qt::Vertical 垂直滚动，15.0 代表向下滚动
+        // Qt::Vertical 垂直滚动，正值代表向下滚动
         m_fakeinput->requestPointerAxisForCapture(Qt::Vertical, SCROLL_DOWN);
     }
 }


### PR DESCRIPTION
Fix occasional manual wheel unresponsiveness in Wayland scroll capture. Optimize auto-scroll step and tolerate first frames without displacement. Use millisecond timestamps to avoid inaccurate time-diff calculation.

修复 Wayland 环境下滚动截图手动滚轮偶发无响应的问题。
优化自动滚动步长，增加首帧无位移容错，降低误报概率。
调整滚动截图时间戳类型，避免时间差计算精度不足。

Log: 修复 Wayland 环境下滚动截图失败问题
Bug: https://pms.uniontech.com/bug-view-278311.html