### PR TITLE
feat(record): add Treeland override to disable prelaunch splash

### DIFF
--- a/assets/treeland/org.deepin.dde.treeland/org.deepin.dde.treeland.app/deepin-screen-recorder/90-disable-splash.json
+++ b/assets/treeland/org.deepin.dde.treeland/org.deepin.dde.treeland.app/deepin-screen-recorder/90-disable-splash.json
@@ -1,0 +1,17 @@
+{
+  "magic": "dsg.config.override",
+  "version": "1.0",
+  "contents": {
+    "enablePrelaunchSplash": {
+      "value": false,
+      "serial": 1,
+      "flags": ["global"],
+      "name": "Enable Prelaunch Splash",
+      "name[zh_CN]": "启用预启动闪屏",
+      "description": "Whether to show prelaunch splash for this app",
+      "description[zh_CN]": "是否为此应用显示预启动闪屏",
+      "permissions": "readwrite",
+      "visibility": "public"
+    }
+  }
+}

--- a/src/src.pro
+++ b/src/src.pro
@@ -441,4 +441,14 @@ dbus_service.path = $$PREFIX/share/dbus-1/services
 manual_dir.files = $$PWD/../assets/deepin-screen-recorder
 manual_dir.path = $$PREFIX/share/deepin-manual/manual-assets/application/
 
+# Treeland override: disable prelaunch splash
+equals(QT_MAJOR_VERSION, 6) {
+    CONFIG += dtk_install_dconfig
+    treeland_splash.files = $$PWD/../assets/treeland/org.deepin.dde.treeland/org.deepin.dde.treeland.app/deepin-screen-recorder/90-disable-splash.json
+    treeland_splash.base = $$PWD/../assets/treeland/org.deepin.dde.treeland/org.deepin.dde.treeland.app
+    treeland_splash.appid = org.deepin.dde.treeland
+    treeland_splash.meta_name = org.deepin.dde.treeland.app
+    DCONFIG_OVERRIDE_FILES += treeland_splash
+}
+
 INSTALLS += target icon desktop translations dbus_service manual_dir


### PR DESCRIPTION
- Add DConfig override JSON to disable prelaunch splash for deepin-screen-recorder
- Use DTK6 dtk_install_dconfig mechanism with DCONFIG_OVERRIDE_FILES
- Only enabled under Qt6 build to ensure Qt5 compatibility

新增 Treeland DConfig override JSON 文件，将 deepin-screen-recorder 的 enablePrelaunchSplash 设为 false，通过 DTK6 的 dtk_install_dconfig 机制安装，仅在 Qt6 构建环境下生效。

Log: 新增Treeland合成器下截图录屏应用预启动闪屏禁用配置

PMS: TASK-389563

Influence: 截图录屏应用在Treeland合成器下启动时不再显示预启动闪屏