### PR TITLE
fix(shot): hide record button on toolbar under Treeland

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2139,7 +2139,7 @@ void MainWindow::initLaunchMode(const QString &launchMode)
 {
     qCDebug(dsrApp) << "initLaunchMode";
     m_functionType = status::shot;
-    if (launchMode == "screenRecord") {
+    if (launchMode == "screenRecord" && !Utils::isTreelandMode) {
         qCDebug(dsrApp) << "initLaunchMode screenRecord";
         m_sizeTips->setRecorderTipsInfo(true);
         m_sizeTips->updateTips(QPoint(recordX, recordY), QSize(recordWidth, recordHeight));

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -713,7 +713,7 @@ void SubToolWidget::initShotLabel()
     });
 
     //切换到录屏按钮
-    // TreeLand环境下现在已支持录屏功能
+    // TODO:treeland暂时屏蔽录屏功能
     m_recorderButton = new ToolButton();
     m_recorderButton->setCheckable(false);
     m_recorderButton->setIconSize(TOOL_ICON_SIZE);
@@ -721,6 +721,7 @@ void SubToolWidget::initShotLabel()
     Utils::setAccessibility(m_recorderButton, AC_SUBTOOLWIDGET_RECORDER_BUTTON);
         m_recorderButton->setFixedSize(TOOL_BUTTON_SIZE);
         installTipHint(m_recorderButton, tr("Record"));
+    if (!(Utils::isTreelandMode))
         btnList.append(m_recorderButton);
         connect(m_recorderButton, &ToolButton::clicked, this, [ = ] {
             m_pMainWindow->getToolBarPoint();


### PR DESCRIPTION
- Add isTreelandMode check before appending recorder button to toolbar layout in initShotLabel()
- Consistent with existing Treeland gating pattern for mosaic and scrollshot buttons

在截图工具栏初始化时增加 Treeland 环境判断，
当运行在 Treeland 合成器下时不将录屏按钮加入工具栏布局，
与模糊按钮和滚动截图按钮的屏蔽方式保持一致。

Log: Treeland合成器下截图工具栏不再显示录屏功能入口

PMS: TASK-389563

Influence: 截图工具栏在Treeland合成器下不再展示录屏切换按钮