### PR TITLE
fix(utils): avoid command string concatenation in lookup

### DIFF
--- a/src/utils/baseutils.cpp
+++ b/src/utils/baseutils.cpp
@@ -157,14 +157,8 @@ bool BaseUtils::isValidFormat(QString suffix)
 
 bool BaseUtils::isCommandExist(QString command)
 {
-    QProcess *proc = new QProcess;
-    if (!proc) {
-        return false;
-    }
-    QString cm = QString("which %1\n").arg(command);
-    proc->start(cm);
-    proc->waitForFinished(1000);
-    int ret = proc->exitCode() == 0;
-    delete proc;
-    return ret;
+    QProcess proc;
+    proc.start(QStringLiteral("which"), QStringList() << command);
+    proc.waitForFinished(1000);
+    return proc.exitCode() == 0;
 }


### PR DESCRIPTION
Use QProcess arguments instead of building a command string.

使用QProcess参数列表替代命令字符串拼接。

Log: 修复命令查找逻辑中的字符串拼接风险
Task：https://pms.uniontech.com/task-view-390623.html Influence: 仅影响dman命令存在性检查逻辑，F1帮助快捷键行为保持不变。