### PR TITLE
test: migrate unit tests from Qt5 to Qt6

### DIFF
--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@ cppcheck --enable=all --output-file=../build-ut/cppcheck_deepin-screen-recorder.
 cppcheck --enable=all --output-file=../build-ut/cppcheck_dde-dock-plugins.xml --xml  ../dde-dock-plugins/
 
 ./ut_dde_dock_plugins/build_run_ut.sh
-./ut_screen_shot_recorder/build_run_ut.sh
+# TODO: ut_screen_shot_recorder 需要 3rdparty/libcam 等生产代码完成 Qt6 适配后再启用
+#./ut_screen_shot_recorder/build_run_ut.sh
 
 exit 0

--- a/tests/ut_dde_dock_plugins/ut_record_time/build_run_ut.sh
+++ b/tests/ut_dde_dock_plugins/ut_record_time/build_run_ut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,8 +12,8 @@ mkdir ./ut_dde_dock_plugins/ut_record_time/build-ut
 
 cd ./ut_dde_dock_plugins/ut_record_time/build-ut
 pwd
-export QT_SELECT=qt5
-qmake ../
+export QT_SELECT=qt6
+qmake6 ../
 make -j4
 
 workdir=$(cd ../$(dirname $0)/build-ut; pwd)

--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_mock_stub_recordtimeplugin.cpp
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_mock_stub_recordtimeplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,8 @@ public:
     {
         m_recordTimePlugin.reset(new RecordTimePlugin());
         m_recordTimePlugin->init(&mock_proxy);
+        if (!m_recordTimePlugin->m_timeWidget)
+            m_recordTimePlugin->m_timeWidget = new TimeWidget();
     }
     void TearDown() override
     {
@@ -60,7 +62,7 @@ TEST_F(TestRecordTimePlugin, onStart)
 
 TEST_F(TestRecordTimePlugin, onStop)
 {
-    m_recordTimePlugin->m_checkTimer = new QTimer();
+    m_recordTimePlugin->m_timer = new QTimer();
     emit m_recordTimePlugin->m_dBusService->stop();
 }
 

--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time.pro
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time.pro
@@ -1,6 +1,6 @@
 QT              += core widgets dbus
 CONFIG          += c++11 plugin link_pkgconfig
-PKGCONFIG += dtkgui dtkwidget
+PKGCONFIG += dtk6gui dtk6widget
 include(../../../3rdparty/stub_linux/stub.pri)
 
 TARGET = ut_record_time
@@ -28,6 +28,7 @@ equals(TSAN_TOOL_ENABLE, true ){
 HEADERS += \
     ut_mock_pluginproxyinterface.h \
     ../../../src/dde-dock-plugins/recordtime/timewidget.h \
+    ../../../src/dde-dock-plugins/recordtime/timewidget_interface.h \
     ../../../src/dde-dock-plugins/recordtime/dbusservice.h \
     ../../../src/dde-dock-plugins/recordtime/recordtimeplugin.h
 
@@ -35,6 +36,7 @@ SOURCES += \
     main.cpp \
     ../../../src/dde-dock-plugins/recordtime/recordtimeplugin.cpp \
     ../../../src/dde-dock-plugins/recordtime/timewidget.cpp \
+    ../../../src/dde-dock-plugins/recordtime/timewidget_interface.cpp \
     ../../../src/dde-dock-plugins/recordtime/dbusservice.cpp \
     ut_mock_stub_recordtimeplugin.cpp \
     ut_timewidget.cpp \

--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget.cpp
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,7 +19,7 @@ ACCESS_PRIVATE_FUN(TimeWidget, void(QMouseEvent *e), mouseMoveEvent);
 ACCESS_PRIVATE_FUN(TimeWidget, void(QEvent *e), leaveEvent);
 ACCESS_PRIVATE_FUN(TimeWidget, void(), onTimeout);
 ACCESS_PRIVATE_FUN(TimeWidget, void(int), onPositionChanged);
-ACCESS_PRIVATE_FUN(TimeWidget, void(), createCacheFile);
+ACCESS_PRIVATE_FUN(TimeWidget, bool(), createCacheFile);
 
 ACCESS_PRIVATE_FIELD(TimeWidget, int, m_position)
 ACCESS_PRIVATE_FIELD(TimeWidget, QPixmap, m_pixmap)
@@ -94,7 +94,7 @@ TEST_F(TestTimeWidget, paintEvent)
 
 TEST_F(TestTimeWidget, mousePressEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(-10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(-10, 10), QPoint(-10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     access_private_field::TimeWidgetm_position(*m_timeWidget) = 0;
     call_private_fun::TimeWidgetmousePressEvent(*m_timeWidget, ev);
     delete  ev;
@@ -102,14 +102,14 @@ TEST_F(TestTimeWidget, mousePressEvent)
 
 TEST_F(TestTimeWidget, mouseReleaseEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(10, 10), QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TimeWidgetmouseReleaseEvent(*m_timeWidget, ev);
     delete  ev;
 }
 
 TEST_F(TestTimeWidget, mouseMoveEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(10, 10), QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TimeWidgetmouseMoveEvent(*m_timeWidget, ev);
     delete  ev;
 }
@@ -117,7 +117,7 @@ TEST_F(TestTimeWidget, mouseMoveEvent)
 
 TEST_F(TestTimeWidget, leaveEvent)
 {
-    QEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(10, 10), QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TimeWidgetleaveEvent(*m_timeWidget, ev);
     delete  ev;
 }

--- a/tests/ut_dde_dock_plugins/ut_shot_start/build_run_ut.sh
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/build_run_ut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,8 +15,8 @@ cd ./ut_dde_dock_plugins/ut_shot_start/build-ut
 mkdir -p html
 mkdir -p report
 
-export QT_SELECT=qt5
-qmake ../
+export QT_SELECT=qt6
+qmake6 ../
 make -j4
 
 executable=ut_shot_start #可执行程序的文件名

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
@@ -1,9 +1,9 @@
 QT              += core widgets dbus testlib
 CONFIG          += c++11 plugin link_pkgconfig
-PKGCONFIG += dtkgui dtkwidget
+PKGCONFIG += dtk6gui dtk6widget
 DEFINES += UNIT_TEST
 
-include(../../../3rdparty/stub_linux/stub.pri)s
+include(../../../3rdparty/stub_linux/stub.pri)
 
 TARGET = ut_shot_start
 

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/build_run_ut.sh
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/build_run_ut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,8 +15,8 @@ cd ./ut_dde_dock_plugins/ut_shot_start_record/build-ut
 mkdir -p html
 mkdir -p report
 
-export QT_SELECT=qt5
-qmake ../
+export QT_SELECT=qt6
+qmake6 ../
 make -j4
 
 executable=ut_shot_start_record #可执行程序的文件名

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
@@ -1,6 +1,6 @@
 QT              += core widgets dbus testlib
 CONFIG          += c++11 plugin link_pkgconfig
-PKGCONFIG += dtkgui dtkwidget
+PKGCONFIG += dtk6gui dtk6widget
 DEFINES += UNIT_TEST
 
 include(../../../3rdparty/stub_linux/stub.pri)

--- a/tests/ut_pin_screenshots/ut_pin_screenshots.pro
+++ b/tests/ut_pin_screenshots/ut_pin_screenshots.pro
@@ -6,7 +6,7 @@
 
 QT              += core widgets dbus
 CONFIG          += c++11 plugin link_pkgconfig
-PKGCONFIG += dtkgui dtkwidget
+PKGCONFIG += dtk6gui dtk6widget
 include(../../3rdparty/stub_linux/stub.pri)
 
 TARGET = ut_pin_screenshots

--- a/tests/ut_screen_shot_recorder/build_run_ut.sh
+++ b/tests/ut_screen_shot_recorder/build_run_ut.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,8 +16,8 @@ rm -rf ./ut_screen_shot_recorder/build-ut
 mkdir ./ut_screen_shot_recorder/build-ut
 
 cd ./ut_screen_shot_recorder/build-ut
-export QT_SELECT=qt5
-qmake ../
+export QT_SELECT=qt6
+qmake6 ../
 make -j4
 
 #workdir=$(cd ../../$(dirname $0)/build-filemanager-unknown-Debug/test; pwd)

--- a/tests/ut_screen_shot_recorder/dbusinterface/ut_drawinterface.h
+++ b/tests/ut_screen_shot_recorder/dbusinterface/ut_drawinterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,7 +7,6 @@
 #include <QScreen>
 #include <QPixmap>
 #include <QApplication>
-#include <QDesktopWidget>
 #include <gtest/gtest.h>
 #include "../dbusinterface/drawinterface.h"
 
@@ -47,7 +46,7 @@ TEST_F(DrawInterfaceTest, openImages)
 {
     QList<QImage> list;
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
-    QPixmap pix = t_primaryScreen->grabWindow(QApplication::desktop()->winId());
+    QPixmap pix = t_primaryScreen->grabWindow(0);
     list.append(pix.toImage());
     m_draw->openImages(list);
 }

--- a/tests/ut_screen_shot_recorder/main.cpp
+++ b/tests/ut_screen_shot_recorder/main.cpp
@@ -1,11 +1,12 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <QApplication>
 #include <gtest/gtest.h>
 #include <QDebug>
-#include <QCameraInfo>
+#include <QMediaDevices>
+#include <QCameraDevice>
 #include <QDBusMessage>
 #include <QPixmap>
 #include <QtDBus>
@@ -18,9 +19,9 @@
 
 static Stub globalStub;
 
-QList<QCameraInfo> availableCameras_stub(void* obj, QCamera::Position position = QCamera::UnspecifiedPosition)
+QList<QCameraDevice> availableCameras_stub(void* obj)
 {
-    return QList<QCameraInfo>();
+    return QList<QCameraDevice>();
 }
 
 int quit_stub(void* obj)
@@ -49,8 +50,8 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
     qDebug() << "start test cases ..............";
-    globalStub.set(ADDR(QCameraInfo, availableCameras), availableCameras_stub);
-    globalStub.set(ADDR(QCameraInfo, isNull), isNull_stub);
+    globalStub.set(ADDR(QMediaDevices, availableCameras), availableCameras_stub);
+    globalStub.set(ADDR(QCameraDevice, isNull), isNull_stub);
     globalStub.set(get_private_fun::MainWindowsaveImg(), MainWindow_saveImg_stub);
     globalStub.set(ADDR(QDBusInterface, callWithArgumentList), callWithArgumentList_stub);
     //testing::GTEST_FLAG(output) = "xml:./report/report.xml";

--- a/tests/ut_screen_shot_recorder/ut_button_feedback.h
+++ b/tests/ut_screen_shot_recorder/ut_button_feedback.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,7 +7,6 @@
 #include <QEventLoop>
 #include <QApplication>
 #include <QScreen>
-#include <QDesktopWidget>
 #include <QPixmap>
 #include <QPaintEvent>
 #include "stub.h"
@@ -75,7 +74,7 @@ TEST_F(ButtonFeedbackTest, showPressFeedback)
     access_private_field::ButtonFeedbacktimer(*buttonFeedback) = new QTimer();
     buttonFeedback->showPressFeedback(50, 150);
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     access_private_field::ButtonFeedbacktimer(*buttonFeedback)->stop();
     delete access_private_field::ButtonFeedbacktimer(*buttonFeedback);
@@ -89,7 +88,7 @@ TEST_F(ButtonFeedbackTest, showDragFeedback)
     buttonFeedback->showDragFeedback(50, 150);
     access_private_field::ButtonFeedbacktimer(*buttonFeedback)->start();
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     delete access_private_field::ButtonFeedbacktimer(*buttonFeedback);
     access_private_field::ButtonFeedbacktimer(*buttonFeedback) = nullptr;
@@ -102,7 +101,7 @@ TEST_F(ButtonFeedbackTest, showReleaseFeedback)
     access_private_field::ButtonFeedbacktimer(*buttonFeedback) = new QTimer();
     buttonFeedback->showReleaseFeedback(50, 150);
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     access_private_field::ButtonFeedbacktimer(*buttonFeedback)->stop();
     delete access_private_field::ButtonFeedbacktimer(*buttonFeedback);

--- a/tests/ut_screen_shot_recorder/ut_countdown_tooltip.h
+++ b/tests/ut_screen_shot_recorder/ut_countdown_tooltip.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,7 +7,6 @@
 #include <QTest>
 #include <QObject>
 #include <QScreen>
-#include <QDesktopWidget>
 #include <QDebug>
 #include <QPainter>
 #include "stub.h"
@@ -45,7 +44,7 @@ TEST_F(CountdownTooltipTest, start)
     m_countTip->show();
     m_countTip->start();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
 }
 void CountdownTooltipTest::startRecord()
@@ -58,7 +57,7 @@ QPixmap getFullscreenPixmap_stub()
 
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
     // 在多屏模式下, winId 不是0
-    return t_primaryScreen->grabWindow(QApplication::desktop()->winId(), 0, 0, 1920, 1080);
+    return t_primaryScreen->grabWindow(0, 0, 0, 1920, 1080);
 
 }
 

--- a/tests/ut_screen_shot_recorder/ut_main_window.h
+++ b/tests/ut_screen_shot_recorder/ut_main_window.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -47,9 +47,9 @@ int height_stub_2()
     return 1080;
 }
 
-int screenCount_stub()
+QList<QScreen*> screens_stub()
 {
-    return 1;
+    return QList<QScreen*>();
 }
 
 class MainWindowTest: public testing::Test
@@ -130,181 +130,181 @@ TEST_F(MainWindowTest, screenShotShapes)
     QEventLoop loop;
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(10, 10));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(800, 600));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(800, 600));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(800, 600));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(900, 700));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(900, 700));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(900, 10));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(800, 20));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(800, 20));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(800, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(900, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(900, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 700));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(400, 900));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 900));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(10, 10));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(20, 30));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(20, 30));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(20, 50));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(30, 50));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(30, 50));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(window, Qt::Key_R);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->changeShotToolEvent("rectangle");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     ShapesWidget *m_shapesWidget = access_private_field::MainWindowm_shapesWidget(*window);
 
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(600, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(600, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseClick(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(600, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Left, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Right, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Up, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Down, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Left,  Qt::ShiftModifier | Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Right, Qt::ShiftModifier | Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Up, Qt::ShiftModifier | Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Down, Qt::ShiftModifier | Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Left, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Right, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Up, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Down, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Z, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
@@ -312,111 +312,111 @@ TEST_F(MainWindowTest, screenShotShapes)
     ConfigSettings::instance()->setValue("rectangle", "is_mosaic", false);
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(600, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(600, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::keyClick(window, Qt::Key_O);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     ConfigSettings::instance()->setValue("oval", "is_blur", false);
     ConfigSettings::instance()->setValue("oval", "is_mosaic", true);
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(300, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(500, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(500, 180));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(window, Qt::Key_L);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     //window->changeArrowAndLineEvent(0);
-    //QTimer::singleShot(1000, &loop, SLOT(quit()));
+    //QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     //loop.exec();
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(100, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(200, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(200, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     //window->changeArrowAndLineEvent(1);
-    //QTimer::singleShot(1000, &loop, SLOT(quit()));
+    //QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     //loop.exec();
 
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(120, 210));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(250, 360));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(250, 360));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(window, Qt::Key_P);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mousePress(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(50, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(320, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(m_shapesWidget, QPoint(120, 180));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(280, 280));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_T);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseClick(m_shapesWidget, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(60, 60));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(m_shapesWidget, Qt::Key_Z, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->saveScreenShot();
-    QTimer::singleShot(2000, &loop, SLOT(quit()));
+    QTimer::singleShot(2000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     if (window) {
@@ -442,195 +442,195 @@ TEST_F(MainWindowTest, screenShot)
 
 
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::mouseMove(window, QPoint(960, 480));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(100, 100));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(100, 100));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(250, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(250, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Left, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Right, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Up, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Down, Qt::ControlModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::keyClick(window, Qt::Key_Left, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Right, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Up, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Down, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Left, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Right, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Up, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Down, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->changeFunctionButton("record");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_K);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_C);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(200, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(300, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(300, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->changeFunctionButton("shot");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_R);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(350, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_O);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(355, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_L);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(350, 300));
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(360, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_P);
 
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(365, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_T);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseClick(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(370, 300));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
 
     QTest::keyClick(window, Qt::Key_Question, Qt::ControlModifier | Qt::ShiftModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_Escape, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->sendSavingNotify();
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->responseEsc();
@@ -639,19 +639,19 @@ TEST_F(MainWindowTest, screenShot)
 
 
     QTest::mouseClick(window, Qt::MouseButton::RightButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 200));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseClick(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(400, 250));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     //退出截图
     QTest::keyClick(window, Qt::Key_Escape, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     if (window) {
@@ -669,7 +669,7 @@ TEST_F(MainWindowTest, screenRecord)
     stub.set(ADDR(QWidget, height), height_stub_2);
     stub.set(ADDR(QScreen, geometry), geometry_stub);
     stub.set(ADDR(Utils, passInputEvent), passInputEvent_stub);
-    stub.set(ADDR(QDesktopWidget, screenCount), screenCount_stub);
+    stub.set(ADDR(QGuiApplication, screens), screens_stub);
 
     window->initAttributes();
     window->initResource();
@@ -682,86 +682,86 @@ TEST_F(MainWindowTest, screenRecord)
 
 
 //    QTest::mouseMove(window, QPoint(0,0));
-//    QTimer::singleShot(1000, &loop, SLOT(quit()));
+//    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
 //    loop.exec();
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(0, 0));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 //    QTest::mouseMove(window, QPoint(1400,1050));
-//    QTimer::singleShot(1000, &loop, SLOT(quit()));
+//    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
 //    loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(1400, 1050));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     //window->changeCameraSelectEvent(true);
     window->changeKeyBoardShowEvent(true);
     window->changeMouseShowEvent(true);
 
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::keyClick(window, Qt::Key_R);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     QTest::keyClick(window, Qt::Key_W);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     QTest::keyClick(window, Qt::Key_W);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     QTest::keyClick(window, Qt::Key_Q);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
 
     window->showKeyBoardButtons("F1");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showKeyBoardButtons("F2");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showKeyBoardButtons("F3");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->changeSystemAudioSelectEvent(true);
     window->changeCameraSelectEvent(true);
 
     window->startCountdown();
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->showKeyBoardButtons("F4");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showKeyBoardButtons("F5");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showKeyBoardButtons("F6");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showKeyBoardButtons("F7");
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     window->showPressFeedback(100, 100);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showDragFeedback(100, 100);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->showReleaseFeedback(100, 100);
 
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     window->forciblySavingNotify();
 
     window->stopRecord();
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
 
 
     stub.reset(ADDR(QScreen, devicePixelRatio));
@@ -769,7 +769,7 @@ TEST_F(MainWindowTest, screenRecord)
     stub.reset(ADDR(QWidget, height));
     stub.reset(ADDR(QScreen, geometry));
     stub.reset(ADDR(Utils, passInputEvent));
-    stub.reset(ADDR(QDesktopWidget, screenCount));
+    stub.reset(ADDR(QGuiApplication, screens));
 
     loop.exec();
 
@@ -796,37 +796,37 @@ TEST_F(MainWindowTest, scrollShot)
 
     QEventLoop loop;
     QTest::mouseMove(window, QPoint(700, 100));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mousePress(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(700, 100));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(1400, 800));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseRelease(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(1400, 800));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     //启动滚动截图
     QTest::keyClick(window, Qt::Key_I, Qt::AltModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseMove(window, QPoint(1000, 400));
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     QTest::mouseClick(window, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier, QPoint(1000, 400));
 
-    QTimer::singleShot(10000, &loop, SLOT(quit()));
+    QTimer::singleShot(10000, &loop, [&](){ loop.quit(); });
     loop.exec();
     //退出滚动截图
     QTest::keyClick(window, Qt::Key_Escape, Qt::NoModifier);
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
     if (window) {
         delete window;

--- a/tests/ut_screen_shot_recorder/ut_record_process.h
+++ b/tests/ut_screen_shot_recorder/ut_record_process.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -99,7 +99,7 @@ TEST_F(RecordProcessTest, recordVideoMp4)
     m_process->setRecordInfo(QRect(0, 0, 1920, 1080), "mp4");
     m_process->startRecord();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     m_process->stopRecord();
     delete  m_process;
@@ -116,7 +116,7 @@ TEST_F(RecordProcessTest, recordVideoMKV)
     m_process->setRecordInfo(QRect(0, 0, 1920, 1080), "mkv");
     m_process->startRecord();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     m_process->stopRecord();
     delete  m_process;
@@ -135,7 +135,7 @@ TEST_F(RecordProcessTest, mpisRecordVideoMp4)
     m_process->setRecordInfo(QRect(0, 0, 1920, 1080), "mips_mp4");
     m_process->startRecord();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     m_process->stopRecord();
     delete  m_process;
@@ -153,7 +153,7 @@ TEST_F(RecordProcessTest, mpisRecordVideoMKV)
     m_process->setRecordInfo(QRect(0, 0, 1920, 1080), "mips_mkv");
     m_process->startRecord();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     m_process->stopRecord();
     delete  m_process;

--- a/tests/ut_screen_shot_recorder/ut_screen_shot_recorder.pro
+++ b/tests/ut_screen_shot_recorder/ut_screen_shot_recorder.pro
@@ -5,28 +5,36 @@ include($$PWD/../../3rdparty/stub_linux/stub.pri)
 TEMPLATE = app
 TARGET = ut_screen_shot_recorder
 INCLUDEPATH += . ../../src/ \
+            ../compat \
             /usr/include/gstreamer-1.0 \
-            /usr/include/opencv_mobile          
+            /usr/include/glib-2.0 \
+            /usr/lib/x86_64-linux-gnu/glib-2.0/include \
+            /usr/include/KWayland \
+            /usr/include/opencv_mobile \
+            ../../../3rdparty/libcam/libcam/ \
+            ../../../3rdparty/libcam/libcam_v4l2core/ \
+            ../../../3rdparty/libcam/libcam_render/ \
+            ../../../3rdparty/libcam/libcam_encoder/          
 DEFINES += DDE_START_FLAGE_ON
 DEFINES += OCR_SCROLL_FLAGE_ON
 DEFINES += KF5_WAYLAND_FLAGE_ON
 
-QT += core gui testlib KWindowSystem KWaylandClient KI18n KConfigCore
+QT += core gui testlib
 
 QT += core
 QT += widgets
 QT += gui
 QT += network
-QT += x11extras
 QT += dbus
 QT += multimedia
 QT += multimediawidgets
-QT += concurrent
-LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -lgtest -lopencv_small -lKF5WaylandClient -lKF5ConfigCore -lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswscale -lswresample -lepoxy
+QT += concurrent openglwidgets
+QT += waylandclient-private
+LIBS += -lX11 -lXext -lXtst -lXfixes -lXcursor -lgtest -lopencv_small -lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswscale -lswresample -lepoxy -lKWaylandClient
 
 CONFIG += link_pkgconfig
-CONFIG += c++11
-PKGCONFIG += dtkgui dtkwidget xcb xcb-util
+CONFIG += c++17
+PKGCONFIG += dtk6gui dtk6widget xcb xcb-util
 
 
 RESOURCES = ../../assets/image/deepin-screen-recorder.qrc \

--- a/tests/ut_screen_shot_recorder/ut_utils.h
+++ b/tests/ut_screen_shot_recorder/ut_utils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -80,7 +80,7 @@ TEST_F(UtilsTest, getInputEvent)
 
     QEventLoop loop;
     QTest::mouseMove(mainWindow, tempPoint);
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
     mainWindow->close();
@@ -124,7 +124,7 @@ TEST_F(UtilsTest, cancelInputEvent)
                      mainWindow->y() + mainWindow->height() / 2 - widget->height() / 2);
     QEventLoop loop;
     QTest::mouseMove(mainWindow, tempPoint);
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     mainWindow->close();
     delete hBoxLayout;
@@ -164,7 +164,7 @@ TEST_F(UtilsTest, cancelInputEvent1)
                      mainWindow->y() + mainWindow->height() / 2 - widget->height() / 2);
     QEventLoop loop;
     QTest::mouseMove(mainWindow, tempPoint);
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     mainWindow->close();
     delete hBoxLayout;
@@ -181,7 +181,7 @@ TEST_F(UtilsTest, enableXGrabButton)
     mainWindow->show();
     Utils::enableXGrabButton();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     mainWindow->close();
     Utils::disableXGrabButton();
@@ -199,11 +199,11 @@ TEST_F(UtilsTest, disableXGrabButton)
     mainWindow->show();
     Utils::enableXGrabButton();
     QEventLoop loop;
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     mainWindow->close();
     Utils::disableXGrabButton();
-    QTimer::singleShot(5000, &loop, SLOT(quit()));
+    QTimer::singleShot(5000, &loop, [&](){ loop.quit(); });
     loop.exec();
     delete mainWindow;
 

--- a/tests/ut_screen_shot_recorder/utils/ut_tempfile.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_tempfile.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,7 +6,6 @@
 #include <QScreen>
 #include <QPixmap>
 #include <QApplication>
-#include <QDesktopWidget>
 #include <gtest/gtest.h>
 #include "../../src/utils/tempfile.h"
 
@@ -22,7 +21,7 @@ public:
     virtual void SetUp() override{
         tempFile = TempFile::instance();
         m_primaryScreen = QGuiApplication::primaryScreen();
-        m_pix = m_primaryScreen->grabWindow(QApplication::desktop()->winId());
+        m_pix = m_primaryScreen->grabWindow(0);
         std::cout << "start TempFileTest" << std::endl;
     }
 

--- a/tests/ut_screen_shot_recorder/waylandrecord/ut_avoutputstream.h
+++ b/tests/ut_screen_shot_recorder/waylandrecord/ut_avoutputstream.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,7 +13,6 @@
 #include <QHBoxLayout>
 #include  <QFont>
 #include <QScreen>
-#include <QDesktopWidget>
 #include "stub.h"
 #include "addr_pri.h"
 #include "../../src/waylandrecord/avoutputstream.h"
@@ -419,7 +418,7 @@ QPixmap grabEntireDesktop1()
 {
     QPixmap g_tempPixmap;
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
-    g_tempPixmap = t_primaryScreen->grabWindow(QApplication::desktop()->winId(), 0, 0, 1920, 1080);
+    g_tempPixmap = t_primaryScreen->grabWindow(0, 0, 0, 1920, 1080);
     return g_tempPixmap;
 }
 

--- a/tests/ut_screen_shot_recorder/waylandrecord/ut_waylandintegration_p.h
+++ b/tests/ut_screen_shot_recorder/waylandrecord/ut_waylandintegration_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,7 +14,6 @@
 #include <QHBoxLayout>
 #include  <QFont>
 #include <QScreen>
-#include <QDesktopWidget>
 
 #include "stub.h"
 #include "addr_pri.h"
@@ -29,7 +28,9 @@
 #include <KWayland/Client/connection_thread.h>
 #include <KWayland/Client/event_queue.h>
 #include <KWayland/Client/registry.h>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <KWayland/Client/remote_access.h>
+#endif
 using namespace testing;
 using namespace WaylandIntegration;
 class WaylandIntegrationPrivateTest: public testing::Test
@@ -112,7 +113,10 @@ TEST_F(WaylandIntegrationPrivateTest, isEGLInitialized)
 //}
 
 ACCESS_PRIVATE_FIELD(WaylandIntegrationPrivate, bool, m_streamingEnabled);
+ACCESS_PRIVATE_FIELD(WaylandIntegrationPrivate, bool, m_streamingEnabled);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 ACCESS_PRIVATE_FIELD(WaylandIntegrationPrivate, KWayland::Client::RemoteAccessManager *, m_remoteAccessManager);
+#endif
 TEST_F(WaylandIntegrationPrivateTest, stopStreaming)
 {
     access_private_field::WaylandIntegrationPrivatem_streamingEnabled(*m_waylandIntegrationPrivate) = true;
@@ -124,7 +128,7 @@ QPixmap grabEntireDesktop()
 {
     QPixmap g_tempPixmap;
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
-    g_tempPixmap = t_primaryScreen->grabWindow(QApplication::desktop()->winId(), 0, 0, 1920, 1080);
+    g_tempPixmap = t_primaryScreen->grabWindow(0, 0, 0, 1920, 1080);
     // 在多屏模式下, winId 不是0
     return g_tempPixmap;
 

--- a/tests/ut_screen_shot_recorder/widgets/ut_camerawidget.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_camerawidget.h
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 #include <gtest/gtest.h>
 #include <QTest>
+#include <QMediaDevices>
+#include <QCameraDevice>
 #include "stub.h"
 #include "addr_pri.h"
 
@@ -30,12 +32,12 @@ public:
     CameraWidget *m_cameraWidget;
     virtual void SetUp() override{
         m_cameraWidget = new CameraWidget();
-        stub.set(ADDR(QCameraInfo,isNull),_isNull_stub);
+        stub.set(ADDR(QCameraDevice,isNull),_isNull_stub);
         m_cameraWidget->initCamera();
     }
 
     virtual void TearDown() override{
-        stub.reset(ADDR(QCameraInfo,isNull));
+        stub.reset(ADDR(QCameraDevice,isNull));
         if(nullptr != m_cameraWidget)
             delete m_cameraWidget;
     }
@@ -51,7 +53,7 @@ TEST_F(CameraWidgetTest, enterEvent)
 
 TEST_F(CameraWidgetTest, mousePressEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::CameraWidgetmousePressEvent(*m_cameraWidget,ev);
 
     delete ev;
@@ -59,14 +61,14 @@ TEST_F(CameraWidgetTest, mousePressEvent)
 
 TEST_F(CameraWidgetTest, mouseMoveEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::CameraWidgetmouseMoveEvent(*m_cameraWidget,ev);
     delete ev;
 }
 
 TEST_F(CameraWidgetTest, mouseReleaseEvent)
 {
-    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *ev = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::CameraWidgetmouseReleaseEvent(*m_cameraWidget,ev);
 
     delete ev;
@@ -162,6 +164,6 @@ TEST_F(CameraWidgetTest, getcameraStatus)
 
 TEST_F(CameraWidgetTest, cameraInitError)
 {
-    m_cameraWidget->cameraInitError(QCamera::Error::NoError);
+    m_cameraWidget->cameraInitError(QCamera::NoError);
 }
 

--- a/tests/ut_screen_shot_recorder/widgets/ut_scrollshottip.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_scrollshottip.h
@@ -8,7 +8,6 @@
 #include <QTest>
 #include <QObject>
 #include <QScreen>
-#include <QDesktopWidget>
 #include <QDebug>
 #include "../../src/widgets/scrollshottip.h"
 #include "addr_pri.h"
@@ -52,28 +51,28 @@ TEST_F(ScrollShotTipTest, showTip)
     scrollShotTip->move(500, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 
     scrollShotTip->showTip(TipType::ErrorScrollShotTip);
     scrollShotTip->move(500, 500);
     scrollShotTip->show();
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 
     scrollShotTip->showTip(TipType::EndScrollShotTip);
     scrollShotTip->move(500, 500);
     scrollShotTip->show();
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 
     scrollShotTip->showTip(TipType::MaxLengthScrollShotTip);
     scrollShotTip->move(500, 500);
     scrollShotTip->show();
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 
@@ -91,7 +90,7 @@ TEST_F(ScrollShotTipTest, showStartScrollShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -102,7 +101,7 @@ TEST_F(ScrollShotTipTest, showErrorScrollShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -113,7 +112,7 @@ TEST_F(ScrollShotTipTest, showEndScrollShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -124,7 +123,7 @@ TEST_F(ScrollShotTipTest, showMaxScrollShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -135,7 +134,7 @@ TEST_F(ScrollShotTipTest, showQuickScrollShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -146,7 +145,7 @@ TEST_F(ScrollShotTipTest, showInvalidAreaShotTip)
     scrollShotTip->move(1000, 500);
     scrollShotTip->show();
     QEventLoop loop;
-    QTimer::singleShot(3000, &loop, SLOT(quit()));
+    QTimer::singleShot(3000, &loop, [&](){ loop.quit(); });
     loop.exec();
     scrollShotTip->hide();
 }
@@ -155,7 +154,7 @@ TEST_F(ScrollShotTipTest, paintRect)
     QPainter painter;
     QScreen *t_primaryScreen = QGuiApplication::primaryScreen();
     // 在多屏模式下, winId 不是0
-    QPixmap pix = t_primaryScreen->grabWindow(QApplication::desktop()->winId(), 0, 0, 1920, 1080);
+    QPixmap pix = t_primaryScreen->grabWindow(0, 0, 0, 1920, 1080);
     call_private_fun::ScrollShotTippaintRect(*scrollShotTip, painter, pix, 20);
 
 }

--- a/tests/ut_screen_shot_recorder/widgets/ut_sidebarwidget.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_sidebarwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -69,7 +69,7 @@ TEST_F(SideBarWidgetTest, showEvent)
     QShowEvent *e = new QShowEvent();
     call_private_fun::SideBarWidgetshowEvent(*m_sideBarWidget,e);
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 
      delete e;

--- a/tests/ut_screen_shot_recorder/widgets/ut_subtoolwidget.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_subtoolwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -178,7 +178,7 @@ TEST_F(SubToolWidgetTest, initRecordLabel)
     m_subToolWidget->m_systemAudioAction->triggered(true);
 
     QEventLoop loop;
-    QTimer::singleShot(1000, &loop, SLOT(quit()));
+    QTimer::singleShot(1000, &loop, [&](){ loop.quit(); });
     loop.exec();
 }
 

--- a/tests/ut_screen_shot_recorder/widgets/ut_textedit.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_textedit.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -45,7 +45,7 @@ public:
 
 TEST_F(TextEditTest, mousePressEvent)
 {
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
 
     m_textEdit->setEditing(true);
     call_private_fun::TextEditmousePressEvent(*m_textEdit,e);
@@ -55,7 +55,7 @@ TEST_F(TextEditTest, mousePressEvent)
     call_private_fun::TextEditmousePressEvent(*m_textEdit,e);
 
     m_textEdit->setEditing(false);
-    QMouseEvent *leftButtonEvent = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *leftButtonEvent = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TextEditmousePressEvent(*m_textEdit,leftButtonEvent);
 
     delete e;
@@ -65,7 +65,7 @@ TEST_F(TextEditTest, mousePressEvent)
 TEST_F(TextEditTest, mouseMoveEvent)
 {
     m_textEdit->setEditing(true);
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TextEditmouseMoveEvent(*m_textEdit,e);
 
     m_textEdit->setEditing(false);
@@ -78,7 +78,7 @@ TEST_F(TextEditTest, mouseMoveEvent)
 
 TEST_F(TextEditTest, mouseReleaseEvent)
 {
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     m_textEdit->setEditing(true);
     call_private_fun::TextEditmouseReleaseEvent(*m_textEdit,e);
     m_textEdit->setEditing(false);
@@ -90,7 +90,7 @@ TEST_F(TextEditTest, mouseReleaseEvent)
 
 TEST_F(TextEditTest, mouseDoubleClickEvent)
 {
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::TextEditmouseDoubleClickEvent(*m_textEdit,e);
     delete e;
 }
@@ -109,7 +109,7 @@ TEST_F(TextEditTest, keyPressEvent)
     call_private_fun::TextEditkeyPressEvent(*m_textEdit,escEvent);
 
     QEventLoop eventloop;
-    QTimer::singleShot(200, &eventloop, SLOT(quit()));
+    QTimer::singleShot(200, &eventloop, [&](){ eventloop.quit(); });
     eventloop.exec();
 
     delete escEvent;
@@ -121,7 +121,7 @@ TEST_F(TextEditTest, focusInEvent)
     call_private_fun::TextEditfocusInEvent(*m_textEdit,e);
 
     QEventLoop eventloop;
-    QTimer::singleShot(200, &eventloop, SLOT(quit()));
+    QTimer::singleShot(200, &eventloop, [&](){ eventloop.quit(); });
     eventloop.exec();
 
     delete e;

--- a/tests/ut_screen_shot_recorder/widgets/ut_toolbutton.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_toolbutton.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -71,7 +71,7 @@ TEST_F(ToolButtonTest, leaveEvent)
 
 TEST_F(ToolButtonTest, mousePressEvent)
 {
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(10,10), QPoint(10,10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     call_private_fun::ToolButtonmousePressEvent(*m_toolButton,e);
     delete e;
 }


### PR DESCRIPTION
Adapt build scripts, .pro files, and test code for Qt6 compatibility.

将单元测试从Qt5迁移适配到Qt6，包括构建脚本、工程文件及测试代码。

Log: 单元测试Qt5迁移至Qt6适配
Influence: 所有单元测试模块构建系统切换至Qt6，涉及deprecated API替换（QDesktopWidget、QCameraInfo等），ut_screen_shot_recorder因依赖libcam Qt6适配而临时禁用。