### PR TITLE
fix(shot): skip save2Clipboard in Treeland mode to improve pin screen…

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -4195,7 +4195,12 @@ void MainWindow::saveScreenShot()
         }
     }
     const bool r = saveAction(m_resultPixmap);
-    save2Clipboard(m_resultPixmap);
+    // Treeland 下跳过 save2Clipboard，避免耗时阻塞
+    if (!Utils::isTreelandMode) {
+        save2Clipboard(m_resultPixmap);
+    } else {
+        qCWarning(dsrApp) << "贴图 Treeland 模式，跳过 save2Clipboard";
+    }
     // 如果是自定义截图，发送保存路径信号
     if (m_saveIndex == SaveAction::CustomScreenSave && !m_saveFileName.isEmpty()) {
         emit screenshotSaved(m_saveFileName);


### PR DESCRIPTION
…shot response

- Add isTreelandMode check in saveScreenShot() to skip save2Clipboard()
- save2Clipboard() has a long blocking loop waiting for clipboard daemon signal, which takes ~1s for large screenshots and is unnecessary for pin screenshots
- Add [PIN_TIMING] performance logs to trace screenshot pipeline

Log: Treeland合成器下贴图功能响应优化，跳过不必要的剪贴板保存操作

PMS: bug-365417

Influence: Treeland合成器下贴图功能响应速度提升

## Summary by Sourcery

Skip unnecessary clipboard saving during screenshot pinning in Treeland mode to improve responsiveness and add timing logs for this path.

Bug Fixes:
- Avoid blocking save2Clipboard calls when running in Treeland mode during screenshot save.

Enhancements:
- Add PIN_TIMING logging around Treeland pin screenshot handling to trace performance.