### PR TITLE
Fix(mount): X11 button ungrab in scroll screenshot save flow

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -299,7 +299,7 @@ void Utils::disableXGrabButton()
 {
     if (Utils::isWaylandMode == true)
         return;
-    XUngrabButton(QX11Info::display(), true, AnyModifier, DefaultRootWindow(QX11Info::display()));
+    XUngrabButton(QX11Info::display(), AnyButton, AnyModifier, DefaultRootWindow(QX11Info::display()));
 
 }
 


### PR DESCRIPTION
--Change `XUngrabButton` from using `true` to `AnyButton` so the function releases
  all grabbed mouse buttons instead of only Button1. This fixes right-click
  interaction when the save dialog opens during scroll screenshot mode.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-369195.html

## Summary by Sourcery

Bug Fixes:
- Fix incorrect ungrab behavior that only released Button1 by ungrabbing AnyButton on X11, restoring right-click interaction in the save dialog.