### PR TITLE
Fix(mount): X11 button ungrab in scroll screenshot save flow

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,4 @@
-// Copyright (C) 2020 ~ 2021 Uniontech Software Technology Co.,Ltd.
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -508,7 +507,7 @@ void Utils::disableXGrabButton()
         return;
     }
 #endif
-    XUngrabButton(QX11Info::display(), true, AnyModifier, DefaultRootWindow(QX11Info::display()));
+    XUngrabButton(QX11Info::display(), AnyButton, AnyModifier, DefaultRootWindow(QX11Info::display()));
     qCDebug(dsrApp) << "XUngrabButton called.";
 }
 


### PR DESCRIPTION
--Change `XUngrabButton` from using `true` to `AnyButton` so the function releases
  all grabbed mouse buttons instead of only Button1. This fixes right-click
  interaction when the save dialog opens during scroll screenshot mode.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-369603.html

## Summary by Sourcery

Bug Fixes:
- Fix right-click interaction by ungrabbing AnyButton instead of only Button1 in the save dialog flow during scroll screenshots.