### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-screen-recorder.desktop
+++ b/deepin-screen-recorder.desktop
@@ -126,8 +126,8 @@ Name[ug]=Deepin ئېكراننى رەسىم تۇتۇش، سىنغا ئېلىش
 Name[uk]=Записувач з екрана Deepin
 Name[lo]=Deepin ບັນທຶກໜ້າຈໍ
 Name[zh_CN]=截图录屏
-Name[zh_HK]=Deepin 螢幕錄影
-Name[zh_TW]=Deepin 螢幕錄影
+Name[zh_HK]=螢幕錄影
+Name[zh_TW]=螢幕錄影
 
 [Desktop Action FullScreenShot]
 Exec=dbus-send --print-reply --dest=com.deepin.Screenshot /com/deepin/Screenshot com.deepin.Screenshot.FullscreenScreenshot


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Remove redundant "深度"/"deepin"/"Deepin" prefixes from zh_CN, zh_HK, and zh_TW Name/Comment translations in the deepin-screen-recorder desktop file.