### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-screen-recorder.desktop
+++ b/deepin-screen-recorder.desktop
@@ -13,6 +13,7 @@ Type=Application
 X-Deepin-ManualID=deepin-screen-recorder
 X-Deepin-Vendor=deepin
 X-Deepin-TurboType=dtkwidget
+X-Deepin-Singleton=true
 NotShowIn=DeepinTablet
 
 # Translations:


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

New Features:
- Mark the screen recorder desktop entry as a singleton application via the X-Deepin-Singleton flag.