### PR TITLE
fix(treeland): Print fullscreen capture latency and reliability

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -21,6 +21,7 @@
 #include "utils/configsettings.h"
 #include "utils/shortcut.h"
 #include "utils/screengrabber.h"
+#include "utils/treelandfullscreengrabber.h"
 #include "utils/log.h"
 #include "camera_process.h"
 #include "widgets/tooltips.h"
@@ -2256,6 +2257,12 @@ void MainWindow::initLaunchMode(const QString &launchMode)
 void MainWindow::fullScreenshot()
 {
     qCDebug(dsrApp) << "fullScreenshot";
+    // Treeland: legacy shotFullScreen copies an empty m_backgroundPixmap.
+    // Grab outputs noninteractively via ext-image-copy-capture instead.
+    if (Utils::isTreelandMode && !Utils::isWaylandMode) {
+        fullScreenshotTreeland();
+        return;
+    }
     // DDesktopServices::playSystemSoundEffect(DDesktopServices::SEE_Screenshot);
     this->initAttributes();
     this->initLaunchMode("screenShot");
@@ -2295,8 +2302,8 @@ void MainWindow::fullScreenshot()
     qCDebug(dsrApp) << "fullScreenshot sendNotify";
     save2Clipboard(m_resultPixmap);
 
-    if (Utils::isWaylandMode) {
-        qCDebug(dsrApp) << "fullScreenshot Utils::isWaylandMode";
+    if (Utils::isWaylandMode || Utils::isTreelandMode) {
+        qCDebug(dsrApp) << "fullScreenshot immediate exit (wayland/treeland)";
         exitApp();
     } else {
         qCDebug(dsrApp) << "fullScreenshot Utils::isWaylandMode false";
@@ -2840,7 +2847,10 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
             qCDebug(dsrApp) << "Whether the data passed to the clipboard is empty? " << t_imageData->imageData().isNull();
         }
 
-        if (hasClipboardDaemon) {
+        // Treeland: dataComing handshake never completes here, so the
+        // size-based wait (e.g. 6s at 1440p) always burns the full timeout and
+        // delays notify when clipboard runs first. Pin path already skips clipboard.
+        if (hasClipboardDaemon && !Utils::isTreelandMode) {
             if (!Utils::isWaylandMode) {
                 this->hide();  // 隐藏主界面
             }
@@ -2867,6 +2877,8 @@ void MainWindow::save2Clipboard(const QPixmap &pix)
                 }
                 QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
             }
+        } else if (Utils::isTreelandMode) {
+            qCInfo(dsrApp) << "Treeland: skip clipboard-daemon wait (notify must not block)";
         }
     }
     qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "已保存到剪贴板！";
@@ -4485,7 +4497,9 @@ void MainWindow::sendNotify(SaveAction saveAction, QString saveFilePath, const b
     notification.callWithArgumentList(QDBus::AutoDetect, "Notify", arg);  // timeout
 
     qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "send notify finished!";
-    if (Utils::isWaylandMode) {
+    // Treeland sets isWaylandMode=false (TreeLand special-case) but must still
+    // exit immediately — delayed exit leaves the process holding m_singleInstance.
+    if (Utils::isWaylandMode || Utils::isTreelandMode) {
         exitApp();
     } else {
         QTimer::singleShot(10, [=] { exitApp(); });
@@ -8007,9 +8021,63 @@ void MainWindow::setupConnections()
             this, &MainWindow::onFinishClicked);
 }
 
+
+void MainWindow::fullScreenshotTreeland()
+{
+    qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "treeland fullscreen capture start";
+    m_functionType = status::shot;
+    m_needSaveScreenshot = true;
+    m_treelandNonInteractiveFullscreen = true;
+    if (auto *manager = TreelandCaptureManager::instance()) {
+        disconnect(manager, &TreelandCaptureManager::activeChanged,
+                   this, &MainWindow::initializeCapture);
+    }
+
+    TreelandFullScreenGrabber grabber;
+    QImage image = grabber.grab();
+    if (image.isNull()) {
+        qCWarning(dsrApp) << "treeland fullscreen grab null, retrying once";
+        image = grabber.grab();
+    }
+    if (image.isNull()) {
+        qCWarning(dsrApp) << "treeland fullscreen capture failed, refusing to save an empty image";
+        DBusNotify shotFailedNotify;
+        shotFailedNotify.Notify(Utils::appName,
+                                0,
+                                "deepin-screen-recorder",
+                                QString(),
+                                tr("Screenshot failed."),
+                                QStringList(),
+                                QVariantMap(),
+                                5000);
+        _exit(1);
+    }
+
+    m_resultPixmap = QPixmap::fromImage(image);
+    const QScreen *primaryScreen = QGuiApplication::primaryScreen();
+    if (primaryScreen && primaryScreen->virtualGeometry().width() > 0) {
+        m_resultPixmap.setDevicePixelRatio(qreal(image.width())
+                                           / primaryScreen->virtualGeometry().width());
+    }
+
+    TempFile::instance()->setFullScreenPixmap(m_resultPixmap);
+    const bool saved = saveAction(m_resultPixmap);
+    // Clipboard best-effort; Treeland skips the daemon wait. Notify right after.
+    save2Clipboard(m_resultPixmap);
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 50);
+    qCInfo(dsrApp) << __FUNCTION__ << __LINE__ << "fullscreen save done:" << saved
+                   << "size:" << image.size();
+    sendNotify(m_saveIndex, m_saveFileName, saved);
+}
+
 void MainWindow::initializeCapture()
 {
 #ifndef ENABLE_UNIT_TEST
+    // Noninteractive fullscreen (Print) must not drive the Treeland selector.
+    if (m_treelandNonInteractiveFullscreen) {
+        return;
+    }
+
     auto manager = TreelandCaptureManager::instance();
     auto captureContext = manager->ensureContext();
 
@@ -8023,6 +8091,9 @@ void MainWindow::initializeCapture()
         qCWarning(dsrApp) << "Window handle not available, cannot initialize capture";
         // 如果窗口句柄还未创建，延迟初始化
         // 等待窗口创建完成后再初始化
+        if (m_treelandNonInteractiveFullscreen) {
+            return;
+        }
         QTimer::singleShot(100, this, &MainWindow::initializeCapture);
         return;
     }

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -1449,6 +1449,11 @@ private:
      * @brief Initializes screen capture
      */
     void initializeCapture();
+
+    /**
+     * @brief Treeland noninteractive fullscreen via ext-image-copy-capture
+     */
+    void fullScreenshotTreeland();
     
     /**
      * @brief Handles when capture is finished
@@ -1468,6 +1473,7 @@ private:
     std::function<void(bool)> m_recordingStateCallback;
     // treeland：抑制一次 handleCaptureFinish 的完成动作（用于中途切换时仅重置后端选区）
     bool m_suppressTreelandFinishOnce = false;
+    bool m_treelandNonInteractiveFullscreen = false;
     // treeland：记录上一次截图模式的选区，用于从录屏切回截图时恢复
     QRect m_lastTreelandShotRegion;
     bool m_hasLastTreelandShotRegion = false;

--- a/src/src.pro
+++ b/src/src.pro
@@ -216,6 +216,7 @@ HEADERS += main_window.h \
     widgets/tooltips.h \
     widgets/filter.h \
     utils/screengrabber.h \
+    utils/treelandfullscreengrabber.h \
     RecorderRegionShow.h \
     recordertablet.h \
     dbusinterface/ocrinterface.h \
@@ -312,6 +313,7 @@ SOURCES += main.cpp \
     widgets/tooltips.cpp \
     widgets/filter.cpp \
     utils/screengrabber.cpp \
+    utils/treelandfullscreengrabber.cpp \
     RecorderRegionShow.cpp \
     recordertablet.cpp \
     dbusinterface/ocrinterface.cpp \

--- a/src/utils/treelandfullscreengrabber.cpp
+++ b/src/utils/treelandfullscreengrabber.cpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "treelandfullscreengrabber.h"
+#include "log.h"
+
+#include "../protocols/ext-image-copy-capture/qwayland-ext-image-copy-capture-v1.h"
+#include "../protocols/ext-image-copy-capture/qwayland-ext-image-capture-source-v1.h"
+
+#include <private/qwaylandclientextension_p.h>
+#include <private/qwaylandshmbackingstore_p.h>
+#include <private/qguiapplication_p.h>
+#include <private/qwaylanddisplay_p.h>
+#include <private/qwaylandintegration_p.h>
+
+#include <QEventLoop>
+#include <QGuiApplication>
+#include <QPainter>
+#include <QScreen>
+#include <QTimer>
+#include <qpa/qplatformnativeinterface.h>
+
+#include <wayland-client.h>
+
+namespace {
+
+QtWaylandClient::QWaylandDisplay *waylandDisplay()
+{
+    auto *integration = dynamic_cast<QtWaylandClient::QWaylandIntegration *>(
+        QGuiApplicationPrivate::platformIntegration());
+    return integration ? integration->display() : nullptr;
+}
+
+class OutputSourceManager
+    : public QWaylandClientExtensionTemplate<OutputSourceManager>,
+      public QtWayland::ext_output_image_capture_source_manager_v1
+{
+    Q_OBJECT
+public:
+    OutputSourceManager() : QWaylandClientExtensionTemplate<OutputSourceManager>(1) { }
+};
+
+class CopyCaptureManager
+    : public QWaylandClientExtensionTemplate<CopyCaptureManager>,
+      public QtWayland::ext_image_copy_capture_manager_v1
+{
+    Q_OBJECT
+public:
+    CopyCaptureManager() : QWaylandClientExtensionTemplate<CopyCaptureManager>(1) { }
+};
+
+class CaptureSession : public QObject, public QtWayland::ext_image_copy_capture_session_v1
+{
+    Q_OBJECT
+public:
+    CaptureSession(struct ::ext_image_copy_capture_session_v1 *object, QObject *parent = nullptr)
+        : QObject(parent), QtWayland::ext_image_copy_capture_session_v1(object)
+    {
+    }
+    ~CaptureSession() override
+    {
+        if (isInitialized())
+            destroy();
+    }
+
+    QSize bufferSize;
+    QList<uint32_t> shmFormats;
+
+Q_SIGNALS:
+    void done();
+    void stopped();
+
+protected:
+    void ext_image_copy_capture_session_v1_buffer_size(uint32_t width, uint32_t height) override
+    {
+        bufferSize = QSize(static_cast<int>(width), static_cast<int>(height));
+    }
+    void ext_image_copy_capture_session_v1_shm_format(uint32_t format) override
+    {
+        shmFormats.append(format);
+    }
+    void ext_image_copy_capture_session_v1_dmabuf_device(wl_array *) override { }
+    void ext_image_copy_capture_session_v1_dmabuf_format(uint32_t, wl_array *) override { }
+    void ext_image_copy_capture_session_v1_done() override { Q_EMIT done(); }
+    void ext_image_copy_capture_session_v1_stopped() override { Q_EMIT stopped(); }
+};
+
+class CaptureFrame : public QObject, public QtWayland::ext_image_copy_capture_frame_v1
+{
+    Q_OBJECT
+public:
+    CaptureFrame(struct ::ext_image_copy_capture_frame_v1 *object, QObject *parent = nullptr)
+        : QObject(parent), QtWayland::ext_image_copy_capture_frame_v1(object)
+    {
+    }
+    ~CaptureFrame() override
+    {
+        if (isInitialized())
+            destroy();
+    }
+
+Q_SIGNALS:
+    void ready();
+    void failed(uint32_t reason);
+
+protected:
+    void ext_image_copy_capture_frame_v1_transform(uint32_t) override { }
+    void ext_image_copy_capture_frame_v1_damage(int32_t, int32_t, int32_t, int32_t) override { }
+    void ext_image_copy_capture_frame_v1_presentation_time(uint32_t, uint32_t, uint32_t) override { }
+    void ext_image_copy_capture_frame_v1_ready() override { Q_EMIT ready(); }
+    void ext_image_copy_capture_frame_v1_failed(uint32_t reason) override { Q_EMIT failed(reason); }
+};
+
+// Map an advertised wl_shm format to a wl_shm_format QWaylandShmBuffer can
+// allocate and QImage can read directly.
+bool isSupportedShmFormat(uint32_t format)
+{
+    switch (format) {
+    case WL_SHM_FORMAT_ARGB8888:
+    case WL_SHM_FORMAT_XRGB8888:
+    case WL_SHM_FORMAT_ABGR8888:
+    case WL_SHM_FORMAT_XBGR8888:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace
+
+class TreelandFullScreenGrabber::Private
+{
+public:
+    OutputSourceManager sourceManager;
+    CopyCaptureManager captureManager;
+};
+
+TreelandFullScreenGrabber::TreelandFullScreenGrabber(QObject *parent)
+    : QObject(parent)
+    , d(new Private)
+{
+}
+
+TreelandFullScreenGrabber::~TreelandFullScreenGrabber()
+{
+    delete d;
+}
+
+QImage TreelandFullScreenGrabber::grab(int timeoutMs)
+{
+    const QList<QScreen *> screens = QGuiApplication::screens();
+    if (screens.isEmpty()) {
+        qCWarning(dsrApp) << "TreelandFullScreenGrabber: no screens";
+        return QImage();
+    }
+
+    // Wait for both protocol globals to bind.
+    if (!d->sourceManager.isActive() || !d->captureManager.isActive()) {
+        QEventLoop loop;
+        QTimer deadline;
+        deadline.setSingleShot(true);
+        connect(&deadline, &QTimer::timeout, &loop, &QEventLoop::quit);
+        auto checkActive = [&] {
+            if (d->sourceManager.isActive() && d->captureManager.isActive())
+                loop.quit();
+        };
+        connect(&d->sourceManager, &OutputSourceManager::activeChanged, &loop, checkActive);
+        connect(&d->captureManager, &CopyCaptureManager::activeChanged, &loop, checkActive);
+        deadline.start(timeoutMs);
+        QTimer::singleShot(0, &loop, checkActive);
+        loop.exec();
+        if (!d->sourceManager.isActive() || !d->captureManager.isActive()) {
+            qCWarning(dsrApp) << "TreelandFullScreenGrabber: ext-image-copy-capture globals"
+                              << "not available (source:" << d->sourceManager.isActive()
+                              << "capture:" << d->captureManager.isActive() << ")";
+            return QImage();
+        }
+    }
+
+    if (screens.size() == 1)
+        return grabOutput(screens.first(), timeoutMs);
+
+    // Composite multiple outputs onto a canvas covering the virtual desktop.
+    const QRect virtualRect = screens.first()->virtualGeometry();
+    const qreal ratio = qreal(QGuiApplication::primaryScreen()->devicePixelRatio());
+    QImage canvas(virtualRect.size() * ratio, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::black);
+    QPainter painter(&canvas);
+    bool any = false;
+    for (QScreen *screen : screens) {
+        const QImage img = grabOutput(screen, timeoutMs);
+        if (img.isNull()) {
+            qCWarning(dsrApp) << "TreelandFullScreenGrabber: failed to grab" << screen->name();
+            continue;
+        }
+        any = true;
+        const QRect logical = screen->geometry().translated(-virtualRect.topLeft());
+        painter.drawImage(QRectF(logical.topLeft() * ratio, logical.size() * ratio), img);
+    }
+    painter.end();
+    return any ? canvas : QImage();
+}
+
+QImage TreelandFullScreenGrabber::grabOutput(QScreen *screen, int timeoutMs)
+{
+    auto *nativeInterface = QGuiApplication::platformNativeInterface();
+    auto *output = static_cast<wl_output *>(nativeInterface->nativeResourceForScreen("output", screen));
+    if (!output) {
+        qCWarning(dsrApp) << "TreelandFullScreenGrabber: no wl_output for" << screen->name();
+        return QImage();
+    }
+
+    auto *source = d->sourceManager.create_source(output);
+    CaptureSession session(d->captureManager.create_session(source, 0));
+    // The source can be destroyed as soon as the session holds it.
+    ext_image_capture_source_v1_destroy(source);
+    if (auto *display = waylandDisplay())
+        wl_display_flush(display->wl_display());
+
+    QImage result;
+    QEventLoop loop;
+    QTimer deadline;
+    deadline.setSingleShot(true);
+    connect(&deadline, &QTimer::timeout, &loop, [&loop] {
+        qCWarning(dsrApp) << "TreelandFullScreenGrabber: timed out waiting for frame";
+        loop.quit();
+    });
+
+    QtWaylandClient::QWaylandShmBuffer *buffer = nullptr;
+    CaptureFrame *frame = nullptr;
+
+    connect(&session, &CaptureSession::stopped, &loop, &QEventLoop::quit);
+    connect(&session, &CaptureSession::done, &loop, [&] {
+        if (frame)
+            return; // constraint updates after the first done are ignored
+        if (session.bufferSize.isEmpty()) {
+            qCWarning(dsrApp) << "TreelandFullScreenGrabber: empty buffer size";
+            loop.quit();
+            return;
+        }
+        uint32_t shmFormat = 0;
+        bool found = false;
+        for (uint32_t format : session.shmFormats) {
+            if (isSupportedShmFormat(format)) {
+                shmFormat = format;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            qCWarning(dsrApp) << "TreelandFullScreenGrabber: no supported SHM format in"
+                              << session.shmFormats;
+            loop.quit();
+            return;
+        }
+
+        buffer = new QtWaylandClient::QWaylandShmBuffer(
+            waylandDisplay(),
+            session.bufferSize,
+            QtWaylandClient::QWaylandShm::formatFrom(static_cast<::wl_shm_format>(shmFormat)));
+        frame = new CaptureFrame(session.create_frame(), &session);
+        connect(frame, &CaptureFrame::failed, &loop, [&loop](uint32_t reason) {
+            qCWarning(dsrApp) << "TreelandFullScreenGrabber: frame failed, reason" << reason;
+            loop.quit();
+        });
+        connect(frame, &CaptureFrame::ready, &loop, [&] {
+            result = buffer->image()->copy();
+            loop.quit();
+        });
+        frame->attach_buffer(buffer->buffer());
+        // Protocol: first capture in a session must damage the whole buffer.
+        frame->damage_buffer(0, 0, session.bufferSize.width(), session.bufferSize.height());
+        frame->capture();
+        if (auto *display = waylandDisplay())
+            wl_display_flush(display->wl_display());
+    });
+
+    deadline.start(timeoutMs);
+    loop.exec();
+
+    // `frame` is parented to `session`; only the buffer needs manual cleanup.
+    delete buffer;
+
+    if (result.isNull())
+        qCWarning(dsrApp) << "TreelandFullScreenGrabber: grab failed for" << screen->name();
+    else
+        qCInfo(dsrApp) << "TreelandFullScreenGrabber: grabbed" << screen->name() << result.size();
+    return result;
+}
+
+#include "treelandfullscreengrabber.moc"

--- a/src/utils/treelandfullscreengrabber.h
+++ b/src/utils/treelandfullscreengrabber.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TREELANDFULLSCREENGRABBER_H
+#define TREELANDFULLSCREENGRABBER_H
+
+#include <QImage>
+#include <QObject>
+
+class QScreen;
+
+/**
+ * @brief Non-interactive full-screen grab for Treeland.
+ *
+ * The treeland_capture_unstable_v1 selector always waits for user input, so
+ * the fullscreen (Print key / D-Bus FullscreenScreenshot) path grabs each
+ * output through ext-image-copy-capture-v1 with an
+ * ext_output_image_capture_source_manager_v1 source instead. Frames are
+ * requested in SHM buffers because screenshot consumers need CPU-readable
+ * pixels (the DMA-BUF path used for recording is tiled).
+ */
+class TreelandFullScreenGrabber : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TreelandFullScreenGrabber(QObject *parent = nullptr);
+    ~TreelandFullScreenGrabber() override;
+
+    /**
+     * @brief Grab every screen and composite them into one image.
+     * @return Image in output pixels, or a null image on failure/timeout.
+     */
+    QImage grab(int timeoutMs = 15000);
+
+private:
+    QImage grabOutput(QScreen *screen, int timeoutMs);
+
+    class Private;
+    Private *d;
+};
+
+#endif // TREELANDFULLSCREENGRABBER_H


### PR DESCRIPTION
## Summary

On Treeland, **Print** / `FullscreenScreenshot` was unreliable and felt slow:

1. **~6s delay between file save and “Saved to …” toast**  
   `save2Clipboard()` busy-waits for `dde-clipboard-daemon` `dataComing` with a size-based timeout (**6s at 2560×1440**). On Treeland that handshake never completes, so the wait always burns the full timeout when clipboard runs around notify.

2. **Second Print often does nothing**  
   TreeLand is intentionally *not* `isWaylandMode`, so `sendNotify` / `fullScreenshot` used `QTimer::singleShot(10, exitApp)` and left the process in `app->exec()`, holding `m_singleInstance`.

3. **Empty / failed fullscreen grabs**  
   Legacy `shotFullScreen()` copies an unfilled `m_backgroundPixmap` on Treeland. This PR grabs each output noninteractively via **ext-image-copy-capture-v1** (SHM), with full `damage_buffer`, display flush, 15s timeout, and one retry. Interactive `initializeCapture` is skipped for this path.

## Changes

- `TreelandFullScreenGrabber` + `fullScreenshotTreeland()` for noninteractive fullscreen
- Skip clipboard-daemon wait when `Utils::isTreelandMode`
- Immediate `exitApp()` when `isTreelandMode` (same as Wayland)
- Flag `m_treelandNonInteractiveFullscreen` to stop selector init spam

## Test plan

- [ ] Treeland: press **Print** — Desktop JPEG appears and toast follows promptly (sub-second class, not multi-second stall)
- [ ] Rapid double **Print** — two captures (or no silent long no-op while a zombie process holds the bus name)
- [ ] Interactive region screenshot (Ctrl+Alt+A / dock) still works
- [ ] X11 / non-Treeland paths unchanged (clipboard wait still used when not Treeland)

## Notes

Verified live on Arch DDE + Treeland 0.8.15: compositor frame delivery ~20–40ms; delay was client-side. Pin-screenshots already skips blocking clipboard on Treeland; this aligns fullscreen with that approach.