### PR TITLE
fix: add null guards to prevent segfaults in non-X11/headless envs

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -224,6 +224,12 @@ void Utils::passInputEvent(int wid)
         return;
     }
 #endif
+    // 非 X11 平台（如 offscreen/纯 Wayland）下 QX11Info::display() 返回 nullptr，
+    // 直接传给 X11 调用会段错误，需提前返回。
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "passInputEvent: no X11 connection, skipping.";
+        return;
+    }
 
     XRectangle *reponseArea = new XRectangle;
     reponseArea->x = 0;
@@ -286,6 +292,10 @@ void Utils::getInputEvent(const int wid, const short x, const short y, const uns
         return;
     }
 #endif
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "getInputEvent: no X11 connection, skipping.";
+        return;
+    }
     XRectangle *reponseArea = new XRectangle;
     reponseArea->x = x;
     reponseArea->y = y;
@@ -319,6 +329,10 @@ void Utils::cancelInputEvent(const int wid, const short x, const short y, const 
         return;
     }
 #endif
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "cancelInputEvent: no X11 connection, skipping.";
+        return;
+    }
     XRectangle *reponseArea = new XRectangle;
     reponseArea->x = x;
     reponseArea->y = y;
@@ -344,6 +358,10 @@ void Utils::cancelInputEvent1(
         return;
     }
 #endif
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "cancelInputEvent1: no X11 connection, skipping.";
+        return;
+    }
     XRectangle *reponseArea = new XRectangle;
     reponseArea->x = x;
     reponseArea->y = y;
@@ -451,6 +469,10 @@ void Utils::enableXGrabButton()
         return;
     }
 #endif
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "enableXGrabButton: no X11 connection, skipping.";
+        return;
+    }
     // extern int XGrabButton(
     //     Display *      /* display */,
     //     unsigned int  /* button */,
@@ -507,6 +529,10 @@ void Utils::disableXGrabButton()
         return;
     }
 #endif
+    if (!QX11Info::display()) {
+        qCWarning(dsrApp) << "disableXGrabButton: no X11 connection, skipping.";
+        return;
+    }
     XUngrabButton(QX11Info::display(), AnyButton, AnyModifier, DefaultRootWindow(QX11Info::display()));
     qCDebug(dsrApp) << "XUngrabButton called.";
 }

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -210,6 +210,13 @@ QPixmap ScreenGrabber::grabPrimaryScreenFallback(bool &ok, const QRect &rect, co
  */
 QPixmap ScreenGrabber::grabSingleScreen(bool &ok, const QRect &rect, QScreen *screen, const qreal devicePixelRatio)
 {
+    // screen 由调用方传入，可能为 nullptr（例如无头环境或屏幕查找失败），
+    // 直接访问会段错误，需提前返回空图并标记失败。
+    if (!screen) {
+        qCWarning(dsrApp) << "grabSingleScreen: screen is null, returning empty pixmap.";
+        ok = false;
+        return {};
+    }
     qCDebug(dsrApp) << "Grabbing single screen:" << screen->name() << " for rect:" << rect;
     Q_UNUSED(ok)
     

--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -2604,7 +2604,10 @@ void ShapesWidget::updateCursorShape()
             setCursorValue = BaseUtils::setCursorShape(m_currentType);
         }
         // 避免相同的光标样式重复设置
-        if (*qApp->overrideCursor() != setCursorValue) {
+        // qApp->overrideCursor() 在未设置任何 override cursor 时返回 nullptr，
+        // 直接解引用会段错误，需先判空。
+        const QCursor *currentOverride = qApp->overrideCursor();
+        if (currentOverride == nullptr || *currentOverride != setCursorValue) {
             qApp->changeOverrideCursor(setCursorValue);
         }
     }


### PR DESCRIPTION
Add nullptr checks before dereferencing QCursor override, QScreen parameter, and QX11Info::display() to avoid crashes on offscreen or pure Wayland platforms uncovered by unit tests.

为 QCursor override、QScreen 入参以及 QX11Info::display() 添加 空指针守卫，修复 offscreen/纯 Wayland 等环境下的段错误（由单元
测试触发并定位）。

Log: 修复非X11环境下的多处空指针崩溃
Influence: 修复 shapeswidget 的 override cursor 空指针解引用、 screengrabber 的 screen 空指针解引用，以及 utils.cpp 中 6 处 X11 调用未判 display() 为空导致的段错误；不影响正常 X11 环境运行。

## Summary by Sourcery

Add null checks around X11 display access, screen parameters, and application override cursor usage to prevent crashes in non-X11 or headless environments.

Bug Fixes:
- Guard all X11 utility functions that use QX11Info::display() to skip execution when no X11 connection is available, avoiding segfaults on offscreen or Wayland platforms.
- Prevent ScreenGrabber from dereferencing a null QScreen pointer by returning an empty pixmap and marking failure when no screen is provided.
- Avoid dereferencing a null override cursor in ShapesWidget by checking for a current override cursor before comparing and updating it.