### PR TITLE
feat: allow adjusting screenshot selection area in annotation mode

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -5075,6 +5075,52 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
     if (Utils::isTreelandMode)
         return DWidget::eventFilter(obj,event);
 
+    // 标注态下拦截 ShapesWidget 上的边缘命中鼠标事件，用于调整框选区域；
+    // 内部命中或正在绘制图形时放行给 ShapesWidget 处理标注（D2①）。
+    if (m_isShapesWidgetExist && obj == m_shapesWidget
+            && status::shot == m_functionType
+            && recordButtonStatus == RECORD_BUTTON_NORMAL) {
+        QEvent::Type t = event->type();
+        if (t == QEvent::MouseButtonPress || t == QEvent::MouseMove
+                || t == QEvent::MouseButtonRelease) {
+            QMouseEvent *swEvent = static_cast<QMouseEvent *>(event);
+            // 将 ShapesWidget 局部坐标转换为 MainWindow 坐标
+            QPoint mainPos = m_shapesWidget->mapToParent(swEvent->pos());
+            int action = getActionAt(mainPos);
+            bool routing = false;
+            if (t == QEvent::MouseButtonPress) {
+                routing = (action != ACTION_MOVE
+                           && swEvent->button() == Qt::LeftButton
+                           && !m_shapesWidget->isPressed());
+            } else if (t == QEvent::MouseButtonRelease) {
+                routing = (isPressMouseLeftButton
+                           && swEvent->button() == Qt::LeftButton);
+            } else { // MouseMove
+                routing = isPressMouseLeftButton
+                          || (action != ACTION_MOVE
+                              && !m_shapesWidget->isPressed());
+            }
+            if (routing) {
+                QMouseEvent mappedEvent(t, QPointF(mainPos), swEvent->button(),
+                                        swEvent->buttons(), swEvent->modifiers());
+                bool localRepaint = false;
+                if (t == QEvent::MouseButtonPress) {
+                    mousePressEF(&mappedEvent, localRepaint);
+                } else if (t == QEvent::MouseMove) {
+                    mouseMoveEF(&mappedEvent, localRepaint);
+                } else {
+                    mouseReleaseEF(&mappedEvent, localRepaint);
+                }
+                if (localRepaint) {
+                    update();
+                }
+                return true;
+            }
+            return false; // 内部命中或正在绘制：放行给 ShapesWidget
+        }
+        return false; // 非鼠标事件：放行给 ShapesWidget
+    }
+
     bool needRepaint = false;
 
 #undef KeyPress
@@ -5197,12 +5243,7 @@ int MainWindow::mousePressEF(QMouseEvent *mouseEvent, bool &needRepaint)
                 isFirstPressButton = true;
             } else {
                 // qCDebug(dsrApp) << ">>>>>>>>>> isFirstPressButton 2" << isFirstPressButton;
-                dragAction = getAction(mouseEvent);
-
-                dragRecordX = recordX;
-                dragRecordY = recordY;
-                dragRecordWidth = recordWidth;
-                dragRecordHeight = recordHeight;
+                beginSelectionDrag(mouseEvent);
 
                 if (recordButtonStatus == RECORD_BUTTON_NORMAL) {
                     // hideRecordButton();
@@ -5234,6 +5275,18 @@ int MainWindow::mousePressEF(QMouseEvent *mouseEvent, bool &needRepaint)
                     connect(m_menuController, &MenuController::closeAction, this, &MainWindow::exitApp);
                 }
                 m_menuController->showMenu(QPoint(mapToGlobal(mouseEvent->pos())));
+            }
+        }
+    } else if (m_isShapesWidgetExist && status::shot == m_functionType
+               && recordButtonStatus == RECORD_BUTTON_NORMAL) {
+        // 进入标注编辑后，鼠标命中框选边缘时开始拖拽调整框选区域（D2①）
+        if (mouseEvent->button() == Qt::LeftButton) {
+            dragStartX = mouseEvent->x();
+            dragStartY = mouseEvent->y();
+            beginSelectionDrag(mouseEvent);
+            if (dragAction != ACTION_MOVE) {
+                isPressMouseLeftButton = true;
+                isReleaseMouseLeftButton = false;
             }
         }
     }
@@ -5334,6 +5387,15 @@ int MainWindow::mouseReleaseEF(QMouseEvent *mouseEvent, bool &needRepaint)
 
             needRepaint = true;
         }
+    } else if (m_isShapesWidgetExist && status::shot == m_functionType
+               && recordButtonStatus == RECORD_BUTTON_NORMAL
+               && isPressMouseLeftButton) {
+        // 进入标注编辑后，框选拖拽释放：约束最小尺寸/边界并同步 ShapesWidget 几何
+        finishSelectionDrag();
+        updateShapesWidgetGeometry();
+        isPressMouseLeftButton = false;
+        isReleaseMouseLeftButton = true;
+        needRepaint = true;
     }
     return 1;
 }
@@ -5436,32 +5498,7 @@ int MainWindow::mouseMoveEF(QMouseEvent *mouseEvent, bool &needRepaint)
                 }
             } else if (isPressMouseLeftButton) {
                 if (recordButtonStatus == RECORD_BUTTON_NORMAL && dragRecordX >= 0 && dragRecordY >= 0) {
-                    if (dragAction == ACTION_MOVE) {
-                        recordX = std::max(
-                            std::min(dragRecordX + mouseEvent->x() - dragStartX, m_backgroundRect.width() - recordWidth), 0);
-                        recordY = std::max(
-                            std::min(dragRecordY + mouseEvent->y() - dragStartY, m_backgroundRect.height() - recordHeight), 0);
-                    } else if (dragAction == ACTION_RESIZE_TOP_LEFT) {
-                        resizeTop(mouseEvent);
-                        resizeLeft(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_TOP_RIGHT) {
-                        resizeTop(mouseEvent);
-                        resizeRight(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_BOTTOM_LEFT) {
-                        resizeBottom(mouseEvent);
-                        resizeLeft(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_BOTTOM_RIGHT) {
-                        resizeBottom(mouseEvent);
-                        resizeRight(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_TOP) {
-                        resizeTop(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_BOTTOM) {
-                        resizeBottom(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_LEFT) {
-                        resizeLeft(mouseEvent);
-                    } else if (dragAction == ACTION_RESIZE_RIGHT) {
-                        resizeRight(mouseEvent);
-                    }
+                    doSelectionDrag(mouseEvent);
 
                     needRepaint = true;
                 }
@@ -5629,8 +5666,34 @@ int MainWindow::mouseMoveEF(QMouseEvent *mouseEvent, bool &needRepaint)
         t_rect.setWidth(recordWidth);
         t_rect.setHeight(recordHeight);
 
-        if (!t_rect.contains(mouseEvent->x(), mouseEvent->y())) {
-            qApp->setOverrideCursor(Qt::ArrowCursor);
+        if (status::shot == m_functionType && recordButtonStatus == RECORD_BUTTON_NORMAL) {
+            // 进入标注编辑后，边缘命中时调整框选区域并显示手柄（D2①）
+            if (isPressMouseLeftButton) {
+                doSelectionDrag(mouseEvent);
+                updateShapesWidgetGeometry();
+                needRepaint = true;
+            }
+            updateCursor(mouseEvent);
+            int action = getAction(mouseEvent);
+            bool drawPoint = action != ACTION_MOVE;
+            if (drawPoint != drawDragPoint) {
+                drawDragPoint = drawPoint;
+                needRepaint = true;
+            }
+            if (m_toolBar && m_toolBar->isVisible()) {
+                updateToolBarPos();
+            }
+            if (!t_rect.contains(mouseEvent->x(), mouseEvent->y()) && !isPressMouseLeftButton) {
+                qApp->setOverrideCursor(Qt::ArrowCursor);
+                if (drawDragPoint) {
+                    drawDragPoint = false;
+                    needRepaint = true;
+                }
+            }
+        } else {
+            if (!t_rect.contains(mouseEvent->x(), mouseEvent->y())) {
+                qApp->setOverrideCursor(Qt::ArrowCursor);
+            }
         }
     }
     if (m_shotflag == 0) {
@@ -5656,43 +5719,51 @@ int MainWindow::keyPressEF(QKeyEvent *keyEvent, bool &needRepaint)
                 m_shapesWidget->setShiftKeyPressed(m_isShiftPressed);
             }
 
-            if (keyEvent->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
-                if (keyEvent->key() == Qt::Key_Left) {
-                    m_shapesWidget->microAdjust("Ctrl+Shift+Left");
-                } else if (keyEvent->key() == Qt::Key_Right) {
-                    m_shapesWidget->microAdjust("Ctrl+Shift+Right");
-                } else if (keyEvent->key() == Qt::Key_Up) {
-                    m_shapesWidget->microAdjust("Ctrl+Shift+Up");
-                } else if (keyEvent->key() == Qt::Key_Down) {
-                    m_shapesWidget->microAdjust("Ctrl+Shift+Down");
-                }
-            } else if (qApp->keyboardModifiers() & Qt::ControlModifier) {
-                if (keyEvent->key() == Qt::Key_Left) {
-                    m_shapesWidget->microAdjust("Ctrl+Left");
-                } else if (keyEvent->key() == Qt::Key_Right) {
-                    m_shapesWidget->microAdjust("Ctrl+Right");
-                } else if (keyEvent->key() == Qt::Key_Up) {
-                    m_shapesWidget->microAdjust("Ctrl+Up");
-                } else if (keyEvent->key() == Qt::Key_Down) {
-                    m_shapesWidget->microAdjust("Ctrl+Down");
-                } else if (keyEvent->key() == Qt::Key_C) {
-                    //                        ConfigSettings::instance()->setValue("save", "save_op",
-                    //                        SaveAction::SaveToClipboard);
-                    // m_copyToClipboard = true;
-                    // saveScreenShot();
-                } else if (keyEvent->key() == Qt::Key_S) {
-                    //                        expressSaveScreenshot();
-                    saveScreenShot();
+            if (m_shapesWidget->selectedIndex() == -1) {
+                // 无选中图形：方向键/Ctrl/Shift+Ctrl 调整框选区域（D3①）
+                if (adjustSelectionByKey(keyEvent, needRepaint)) {
+                    updateShapesWidgetGeometry();
                 }
             } else {
-                if (keyEvent->key() == Qt::Key_Left) {
-                    m_shapesWidget->microAdjust("Left");
-                } else if (keyEvent->key() == Qt::Key_Right) {
-                    m_shapesWidget->microAdjust("Right");
-                } else if (keyEvent->key() == Qt::Key_Up) {
-                    m_shapesWidget->microAdjust("Up");
-                } else if (keyEvent->key() == Qt::Key_Down) {
-                    m_shapesWidget->microAdjust("Down");
+                // 有选中图形：维持 microAdjust 微调图形（原逻辑不变）
+                if (keyEvent->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
+                    if (keyEvent->key() == Qt::Key_Left) {
+                        m_shapesWidget->microAdjust("Ctrl+Shift+Left");
+                    } else if (keyEvent->key() == Qt::Key_Right) {
+                        m_shapesWidget->microAdjust("Ctrl+Shift+Right");
+                    } else if (keyEvent->key() == Qt::Key_Up) {
+                        m_shapesWidget->microAdjust("Ctrl+Shift+Up");
+                    } else if (keyEvent->key() == Qt::Key_Down) {
+                        m_shapesWidget->microAdjust("Ctrl+Shift+Down");
+                    }
+                } else if (qApp->keyboardModifiers() & Qt::ControlModifier) {
+                    if (keyEvent->key() == Qt::Key_Left) {
+                        m_shapesWidget->microAdjust("Ctrl+Left");
+                    } else if (keyEvent->key() == Qt::Key_Right) {
+                        m_shapesWidget->microAdjust("Ctrl+Right");
+                    } else if (keyEvent->key() == Qt::Key_Up) {
+                        m_shapesWidget->microAdjust("Ctrl+Up");
+                    } else if (keyEvent->key() == Qt::Key_Down) {
+                        m_shapesWidget->microAdjust("Ctrl+Down");
+                    } else if (keyEvent->key() == Qt::Key_C) {
+                        //                        ConfigSettings::instance()->setValue("save", "save_op",
+                        //                        SaveAction::SaveToClipboard);
+                        // m_copyToClipboard = true;
+                        // saveScreenShot();
+                    } else if (keyEvent->key() == Qt::Key_S) {
+                        //                        expressSaveScreenshot();
+                        saveScreenShot();
+                    }
+                } else {
+                    if (keyEvent->key() == Qt::Key_Left) {
+                        m_shapesWidget->microAdjust("Left");
+                    } else if (keyEvent->key() == Qt::Key_Right) {
+                        m_shapesWidget->microAdjust("Right");
+                    } else if (keyEvent->key() == Qt::Key_Up) {
+                        m_shapesWidget->microAdjust("Up");
+                    } else if (keyEvent->key() == Qt::Key_Down) {
+                        m_shapesWidget->microAdjust("Down");
+                    }
                 }
             }
 
@@ -5701,134 +5772,15 @@ int MainWindow::keyPressEF(QKeyEvent *keyEvent, bool &needRepaint)
             } else {
                 qCDebug(dsrApp) << "ShapeWidget Exist keyEvent:" << keyEvent->key();
             }
+            if (needRepaint) {
+                update();
+            }
             return 0;
         }
 
         if (m_shotStatus == ShotMouseStatus::Normal) {
-            // 是否按住 shift+ctrl
-            if (keyEvent->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
-                if (keyEvent->key() == Qt::Key_Left) {
-                    if (recordWidth > RECORD_MIN_SHOT_SIZE) {
-                        recordX = std::max(0, recordX + 1);
-                        recordWidth = std::max(std::min(recordWidth - 1, m_backgroundRect.width()), RECORD_MIN_SHOT_SIZE);
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    }
-
-                } else if (keyEvent->key() == Qt::Key_Right) {
-                    if (recordWidth > RECORD_MIN_SHOT_SIZE) {
-                        recordWidth = std::max(std::min(recordWidth - 1, m_backgroundRect.width()), RECORD_MIN_SHOT_SIZE);
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    }
-                } else if (keyEvent->key() == Qt::Key_Up) {
-                    if (recordHeight > RECORD_MIN_SHOT_SIZE) {
-                        recordY = std::max(0, recordY + 1);
-
-                        recordHeight = std::max(std::min(recordHeight - 1, m_backgroundRect.height()), RECORD_MIN_SHOT_SIZE);
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    }
-                } else if (keyEvent->key() == Qt::Key_Down) {
-                    if (recordHeight > RECORD_MIN_SHOT_SIZE) {
-                        recordHeight = std::max(std::min(recordHeight - 1, m_backgroundRect.height()), RECORD_MIN_SHOT_SIZE);
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    }
-                }
-            }
-            // 是否只按住 ctrl
-            else if ((qApp->keyboardModifiers() == Qt::ControlModifier)) {
-                if (keyEvent->key() == Qt::Key_S) {
-                    //                        expressSaveScreenshot();
-                    saveScreenShot();
-                }
-
-                if (keyEvent->key() == Qt::Key_C) {
-                    //                        ConfigSettings::instance()->setValue("save", "save_op",
-                    //                        SaveAction::SaveToClipboard);
-                    // m_copyToClipboard = true;
-                    //                        saveScreenshot();
-                    // saveScreenShot();
-                }
-                if (keyEvent->key() == Qt::Key_Left) {
-                    recordX = std::max(0, recordX - 1);
-                    recordWidth = std::min(recordWidth + 1, rootWindowRect.width());
-
-                    needRepaint = true;
-                    selectAreaName = tr("select-area");
-                } else if (keyEvent->key() == Qt::Key_Right) {
-                    if (recordX + recordWidth + 1 >= m_screenWidth) {
-                        recordX = std::max(0, recordX - 1);
-                    }
-                    recordWidth = std::min(recordWidth + 1, rootWindowRect.width());
-
-                    needRepaint = true;
-                    selectAreaName = tr("select-area");
-                } else if (keyEvent->key() == Qt::Key_Up) {
-                    recordY = std::max(0, recordY - 1);
-                    recordHeight = std::min(recordHeight + 1, rootWindowRect.height());
-
-                    needRepaint = true;
-                    selectAreaName = tr("select-area");
-                } else if (keyEvent->key() == Qt::Key_Down) {
-                    if (recordY + recordHeight + 1 >= m_screenHeight) {
-                        recordY = std::max(0, recordY - 1);
-                    }
-                    recordHeight = std::min(recordHeight + 1, rootWindowRect.height());
-
-                    needRepaint = true;
-                    selectAreaName = tr("select-area");
-                }
-            } else {
-                // 鼠标已经按下过但当前未按下时
-                if (!isPressMouseLeftButton && qApp->keyboardModifiers() == Qt::NoModifier) {
-                    if (keyEvent->key() == Qt::Key_Left || keyEvent->key() == Qt::Key_A) {
-                        recordX = std::max(0, recordX - 1);
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    } else if (keyEvent->key() == Qt::Key_Right || keyEvent->key() == Qt::Key_D) {
-                        recordX = std::min(m_backgroundRect.width() - recordWidth, recordX + 1);
-
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    } else if (keyEvent->key() == Qt::Key_Up || keyEvent->key() == Qt::Key_W) {
-                        recordY = std::max(0, recordY - 1);
-
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    } else if (keyEvent->key() == Qt::Key_Down || keyEvent->key() == Qt::Key_S) {
-                        recordY = std::min(m_backgroundRect.height() - recordHeight, recordY + 1);
-
-                        needRepaint = true;
-                        selectAreaName = tr("select-area");
-                    }
-                }
-            }
-
-            if (!m_needSaveScreenshot) {
-                m_sizeTips->updateTips(QPoint(recordX, recordY), QSize(recordWidth, recordHeight));
-                if (m_toolBar->isVisible()) {
-                    updateToolBarPos();
-                }
-                // if (m_recordButton->isVisible()) {
-                // updateRecordButtonPos();
-                // }
-
-                if (m_sideBar->isVisible()) {
-                    updateSideBarPos();
-                }
-
-                // if (m_shotButton->isVisible()) {
-                // updateShotButtonPos();
-                // }
-
-                if (m_cameraWidget && m_cameraWidget->isVisible()) {
-                    updateCameraWidgetPos();
-                }
-            }
+            adjustSelectionByKey(keyEvent, needRepaint);
         }
-
         if (needRepaint) {
             update();
         }
@@ -7297,11 +7249,10 @@ void MainWindow::resizeRight(QMouseEvent *mouseEvent)
     }
 }
 
-int MainWindow::getAction(QEvent *event)
+int MainWindow::getActionAt(const QPoint &pos) const
 {
-    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-    int cursorX = mouseEvent->x();
-    int cursorY = mouseEvent->y();
+    int cursorX = pos.x();
+    int cursorY = pos.y();
 
     if (cursorX > recordX - m_cursorBound && cursorX < recordX + m_cursorBound && cursorY > recordY - m_cursorBound &&
         cursorY < recordY + m_cursorBound) {
@@ -7334,6 +7285,236 @@ int MainWindow::getAction(QEvent *event)
     } else {
         return ACTION_MOVE;
     }
+}
+
+int MainWindow::getAction(QEvent *event)
+{
+    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    return getActionAt(QPoint(mouseEvent->x(), mouseEvent->y()));
+}
+
+void MainWindow::beginSelectionDrag(QMouseEvent *mouseEvent)
+{
+    dragAction = getAction(mouseEvent);
+    dragRecordX = recordX;
+    dragRecordY = recordY;
+    dragRecordWidth = recordWidth;
+    dragRecordHeight = recordHeight;
+}
+
+void MainWindow::doSelectionDrag(QMouseEvent *mouseEvent)
+{
+    if (dragAction == ACTION_MOVE) {
+        recordX = std::max(
+            std::min(dragRecordX + mouseEvent->x() - dragStartX, m_backgroundRect.width() - recordWidth), 0);
+        recordY = std::max(
+            std::min(dragRecordY + mouseEvent->y() - dragStartY, m_backgroundRect.height() - recordHeight), 0);
+    } else if (dragAction == ACTION_RESIZE_TOP_LEFT) {
+        resizeTop(mouseEvent);
+        resizeLeft(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_TOP_RIGHT) {
+        resizeTop(mouseEvent);
+        resizeRight(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_BOTTOM_LEFT) {
+        resizeBottom(mouseEvent);
+        resizeLeft(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_BOTTOM_RIGHT) {
+        resizeBottom(mouseEvent);
+        resizeRight(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_TOP) {
+        resizeTop(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_BOTTOM) {
+        resizeBottom(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_LEFT) {
+        resizeLeft(mouseEvent);
+    } else if (dragAction == ACTION_RESIZE_RIGHT) {
+        resizeRight(mouseEvent);
+    }
+}
+
+void MainWindow::finishSelectionDrag()
+{
+    // 约束最小尺寸与屏幕边界（截图走 RECORD_MIN_SHOT_SIZE / m_backgroundRect）
+    recordWidth = recordWidth < RECORD_MIN_SHOT_SIZE ? RECORD_MIN_SHOT_SIZE : recordWidth;
+    recordHeight = recordHeight < RECORD_MIN_SHOT_SIZE ? RECORD_MIN_SHOT_SIZE : recordHeight;
+
+    if (recordX + recordWidth > m_backgroundRect.width()) {
+        recordX = m_backgroundRect.width() - recordWidth;
+    }
+    if (recordY + recordHeight > m_backgroundRect.height()) {
+        recordY = m_backgroundRect.height() - recordHeight;
+    }
+    if (recordX < 0) recordX = 0;
+    if (recordY < 0) recordY = 0;
+
+    if (status::scrollshot != m_functionType) {
+        m_sizeTips->updateTips(QPoint(recordX, recordY), QSize(recordWidth, recordHeight));
+    }
+    updateToolBarPos();
+    if (status::shot == m_functionType && m_sideBar->isVisible()) {
+        updateSideBarPos();
+    }
+}
+
+void MainWindow::updateShapesWidgetGeometry()
+{
+    if (!m_shapesWidget) {
+        return;
+    }
+    // 记录旧原点（控件当前几何即旧框选位置）
+    QRect oldGeo = m_shapesWidget->geometry();
+    int oldX = oldGeo.x() - 2;
+    int oldY = oldGeo.y() - 2;
+
+    m_shapesWidget->setFixedSize(recordWidth - 4, recordHeight - 4);
+    m_shapesWidget->move(recordX + 2, recordY + 2);
+
+    QRect t_rect;
+    t_rect.setX(recordX);
+    t_rect.setY(recordY);
+    t_rect.setWidth(recordWidth);
+    t_rect.setHeight(recordHeight);
+    m_shapesWidget->setGlobalRect(t_rect);
+
+    // 原点位移时对图形做补偿平移，保持屏幕坐标不变（D4①）
+    int dx = recordX - oldX;
+    int dy = recordY - oldY;
+    if (dx != 0 || dy != 0) {
+        m_shapesWidget->translateShapes(QPointF(dx, dy));
+    }
+}
+
+bool MainWindow::adjustSelectionByKey(QKeyEvent *keyEvent, bool &needRepaint)
+{
+    // 返回 true 表示处理了方向键框选调整。
+    bool handledArrow = false;
+    // 是否按住 shift+ctrl
+    if (keyEvent->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
+        if (keyEvent->key() == Qt::Key_Left) {
+            if (recordWidth > RECORD_MIN_SHOT_SIZE) {
+                recordX = std::max(0, recordX + 1);
+                recordWidth = std::max(std::min(recordWidth - 1, m_backgroundRect.width()), RECORD_MIN_SHOT_SIZE);
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+            }
+            handledArrow = true;
+
+        } else if (keyEvent->key() == Qt::Key_Right) {
+            if (recordWidth > RECORD_MIN_SHOT_SIZE) {
+                recordWidth = std::max(std::min(recordWidth - 1, m_backgroundRect.width()), RECORD_MIN_SHOT_SIZE);
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+            }
+            handledArrow = true;
+        } else if (keyEvent->key() == Qt::Key_Up) {
+            if (recordHeight > RECORD_MIN_SHOT_SIZE) {
+                recordY = std::max(0, recordY + 1);
+
+                recordHeight = std::max(std::min(recordHeight - 1, m_backgroundRect.height()), RECORD_MIN_SHOT_SIZE);
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+            }
+            handledArrow = true;
+        } else if (keyEvent->key() == Qt::Key_Down) {
+            if (recordHeight > RECORD_MIN_SHOT_SIZE) {
+                recordHeight = std::max(std::min(recordHeight - 1, m_backgroundRect.height()), RECORD_MIN_SHOT_SIZE);
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+            }
+            handledArrow = true;
+        }
+    }
+    // 是否只按住 ctrl
+    else if ((qApp->keyboardModifiers() == Qt::ControlModifier)) {
+        if (keyEvent->key() == Qt::Key_S) {
+            //                        expressSaveScreenshot();
+            saveScreenShot();
+        }
+
+        if (keyEvent->key() == Qt::Key_C) {
+            //                        ConfigSettings::instance()->setValue("save", "save_op",
+            //                        SaveAction::SaveToClipboard);
+            // m_copyToClipboard = true;
+            //                        saveScreenshot();
+            // saveScreenShot();
+        }
+        if (keyEvent->key() == Qt::Key_Left) {
+            recordX = std::max(0, recordX - 1);
+            recordWidth = std::min(recordWidth + 1, rootWindowRect.width());
+
+            needRepaint = true;
+            selectAreaName = tr("select-area");
+            handledArrow = true;
+        } else if (keyEvent->key() == Qt::Key_Right) {
+            if (recordX + recordWidth + 1 >= m_screenWidth) {
+                recordX = std::max(0, recordX - 1);
+            }
+            recordWidth = std::min(recordWidth + 1, rootWindowRect.width());
+
+            needRepaint = true;
+            selectAreaName = tr("select-area");
+            handledArrow = true;
+        } else if (keyEvent->key() == Qt::Key_Up) {
+            recordY = std::max(0, recordY - 1);
+            recordHeight = std::min(recordHeight + 1, rootWindowRect.height());
+
+            needRepaint = true;
+            selectAreaName = tr("select-area");
+            handledArrow = true;
+        } else if (keyEvent->key() == Qt::Key_Down) {
+            if (recordY + recordHeight + 1 >= m_screenHeight) {
+                recordY = std::max(0, recordY - 1);
+            }
+            recordHeight = std::min(recordHeight + 1, rootWindowRect.height());
+
+            needRepaint = true;
+            selectAreaName = tr("select-area");
+            handledArrow = true;
+        }
+    } else {
+        // 鼠标已经按下过但当前未按下时
+        if (!isPressMouseLeftButton && qApp->keyboardModifiers() == Qt::NoModifier) {
+            if (keyEvent->key() == Qt::Key_Left || keyEvent->key() == Qt::Key_A) {
+                recordX = std::max(0, recordX - 1);
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+                handledArrow = true;
+            } else if (keyEvent->key() == Qt::Key_Right || keyEvent->key() == Qt::Key_D) {
+                recordX = std::min(m_backgroundRect.width() - recordWidth, recordX + 1);
+
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+                handledArrow = true;
+            } else if (keyEvent->key() == Qt::Key_Up || keyEvent->key() == Qt::Key_W) {
+                recordY = std::max(0, recordY - 1);
+
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+                handledArrow = true;
+            } else if (keyEvent->key() == Qt::Key_Down || keyEvent->key() == Qt::Key_S) {
+                recordY = std::min(m_backgroundRect.height() - recordHeight, recordY + 1);
+
+                needRepaint = true;
+                selectAreaName = tr("select-area");
+                handledArrow = true;
+            }
+        }
+    }
+
+    if (!m_needSaveScreenshot) {
+        m_sizeTips->updateTips(QPoint(recordX, recordY), QSize(recordWidth, recordHeight));
+        if (m_toolBar->isVisible()) {
+            updateToolBarPos();
+        }
+        if (m_sideBar->isVisible()) {
+            updateSideBarPos();
+        }
+        if (m_cameraWidget && m_cameraWidget->isVisible()) {
+            updateCameraWidgetPos();
+        }
+    }
+
+    return handledArrow;
 }
 
 void MainWindow::updateCursor(QEvent *event)
@@ -7738,6 +7919,8 @@ void MainWindow::initShapeWidget(QString type)
     } else {
         m_shapesWidget->setFixedSize(recordWidth - 4, recordHeight - 4);
         m_shapesWidget->move(recordX + 2, recordY + 2);
+        // 安装事件过滤器，使 MainWindow 能在标注态拦截 ShapesWidget 上的边缘命中鼠标事件（T1 依赖）
+        m_shapesWidget->installEventFilter(this);
     }
 
     QRect t_rect;

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -811,6 +811,34 @@ protected:
     void keyReleaseEvent(QKeyEvent *event) override;
 
     int getAction(QEvent *event);
+    /**
+     * @brief getActionAt: 给定 MainWindow 坐标判定框选边缘动作（八方向 + MOVE）
+     * @param pos MainWindow 局部坐标
+     * @return 与 getAction 相同的 ACTION_* 常量
+     */
+    int getActionAt(const QPoint &pos) const;
+    /**
+     * @brief updateShapesWidgetGeometry: 框选变更后同步 ShapesWidget 几何，并对图形做补偿平移
+     * 保持标注图形屏幕坐标不变（D4①），effect 图形按回滚点暂随控件移动
+     */
+    void updateShapesWidgetGeometry();
+    /**
+     * @brief beginSelectionDrag: 记录拖拽起始动作与基线框选几何
+     */
+    void beginSelectionDrag(QMouseEvent *mouseEvent);
+    /**
+     * @brief doSelectionDrag: 按 dragAction 应用框选移动/缩放（标注前与标注态共用）
+     */
+    void doSelectionDrag(QMouseEvent *mouseEvent);
+    /**
+     * @brief finishSelectionDrag: 拖拽结束约束最小尺寸/边界并刷新提示与工具栏
+     */
+    void finishSelectionDrag();
+    /**
+     * @brief adjustSelectionByKey: 键盘（方向键/Ctrl/Shift+Ctrl）调整框选区域
+     * @return 是否处理了该按键
+     */
+    bool adjustSelectionByKey(QKeyEvent *keyEvent, bool &needRepaint);
 
 
     /**

--- a/src/widgets/shapeswidget.cpp
+++ b/src/widgets/shapeswidget.cpp
@@ -2627,4 +2627,39 @@ void ShapesWidget::setGlobalRect(QRect rect)
     m_globalRect = rect;
 }
 
+void ShapesWidget::translateShapes(const QPointF &delta)
+{
+    // 控件原点移动 delta，图形局部坐标补偿 -delta 以保持屏幕坐标不变。
+    // effect（模糊/马赛克）按方案回滚点暂不平移，其取样刷新留待 T3 实测后纳入。
+    for (int i = 0; i < m_shapes.length(); ++i) {
+        Toolshape &shape = m_shapes[i];
+        if (shape.type == "effect") {
+            continue;
+        }
+        for (int j = 0; j < shape.mainPoints.length(); ++j) {
+            shape.mainPoints[j] -= delta;
+        }
+        for (int j = 0; j < shape.points.length(); ++j) {
+            shape.points[j] -= delta;
+        }
+    }
+
+    // 同步当前选中的图形副本
+    if (m_selectedOrder >= 0 && m_selectedOrder < m_shapes.length()
+            && m_shapes[m_selectedOrder].type != "effect") {
+        m_selectedShape.mainPoints = m_shapes[m_selectedOrder].mainPoints;
+        m_selectedShape.points = m_shapes[m_selectedOrder].points;
+    }
+
+    // 同步文本编辑控件几何，保持文字屏幕位置不变
+    QMap<int, TextEdit *>::iterator it = m_editMap.begin();
+    while (it != m_editMap.end()) {
+        TextEdit *edit = it.value();
+        edit->move(edit->pos() - delta.toPoint());
+        ++it;
+    }
+
+    update();
+}
+
 

--- a/src/widgets/shapeswidget.h
+++ b/src/widgets/shapeswidget.h
@@ -178,6 +178,23 @@ public slots:
     void setGlobalRect(QRect rect);
 
     /**
+     * @brief translateShapes: 平移全部标注图形坐标，保持其屏幕坐标不变
+     * @param delta 控件原点位移（recordX/Y 的变化量），图形局部坐标补偿 -delta
+     * @note effect（模糊/马赛克）图形按方案回滚点暂不平移，随控件移动
+     */
+    void translateShapes(const QPointF &delta);
+    /**
+     * @brief selectedIndex: 当前选中的标注图形索引
+     * @return m_selectedIndex，-1 表示无选中图形
+     */
+    int selectedIndex() const { return m_selectedIndex; }
+    /**
+     * @brief isPressed: 控件是否处于鼠标按下状态（正在绘制/拖拽图形）
+     * @return m_isPressed
+     */
+    bool isPressed() const { return m_isPressed; }
+
+    /**
      * @brief paintImage: 绘制图片
      * 将编辑的内容绘制到图片上
      */

--- a/tests/ut_screen_shot_recorder/ut_main_window_ef.h
+++ b/tests/ut_screen_shot_recorder/ut_main_window_ef.h
@@ -34,6 +34,12 @@ ACCESS_PRIVATE_FUN(MainWindow, int(QMouseEvent *, bool &), mouseMoveEF);
 ACCESS_PRIVATE_FUN(MainWindow, int(QKeyEvent *, bool &), keyPressEF);
 ACCESS_PRIVATE_FUN(MainWindow, int(QKeyEvent *, bool &), keyReleaseEF);
 ACCESS_PRIVATE_FUN(MainWindow, int(QWheelEvent *, bool &), wheelEF);
+ACCESS_PRIVATE_FUN(MainWindow, int(const QPoint &) const, getActionAt);
+ACCESS_PRIVATE_FUN(MainWindow, bool(QKeyEvent *, bool &), adjustSelectionByKey);
+ACCESS_PRIVATE_FIELD(MainWindow, int, m_cursorBound);
+ACCESS_PRIVATE_FIELD(MainWindow, QRect, m_backgroundRect);
+ACCESS_PRIVATE_FIELD(MainWindow, QRect, rootWindowRect);
+ACCESS_PRIVATE_FIELD(MainWindow, bool, m_needSaveScreenshot);
 
 class MainWindowEFTest : public Test
 {
@@ -153,4 +159,60 @@ TEST_F(MainWindowEFTest, wheelEFVertical)
         Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
     bool needRepaint = false;
     EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowwheelEF(*m_w, &wheelEvent, needRepaint));
+}
+
+// ===================== 框选区域调整（V-628）单测 =====================
+
+// getActionAt：八方向边缘命中与内部判定
+TEST_F(MainWindowEFTest, getActionAtEdgeAndInterior)
+{
+    access_private_field::MainWindowrecordX(*m_w) = 100;
+    access_private_field::MainWindowrecordY(*m_w) = 100;
+    access_private_field::MainWindowrecordWidth(*m_w) = 200;
+    access_private_field::MainWindowrecordHeight(*m_w) = 150;
+    access_private_field::MainWindowm_cursorBound(*m_w) = 20;
+    // ACTION_RESIZE_TOP_LEFT=1, ACTION_RESIZE_LEFT=7, ACTION_MOVE=0, ACTION_RESIZE_BOTTOM_RIGHT=4
+    EXPECT_EQ(call_private_fun::MainWindowgetActionAt(*m_w, QPoint(100, 100)), 1);
+    EXPECT_EQ(call_private_fun::MainWindowgetActionAt(*m_w, QPoint(95, 175)), 7);
+    EXPECT_EQ(call_private_fun::MainWindowgetActionAt(*m_w, QPoint(200, 175)), 0);
+    EXPECT_EQ(call_private_fun::MainWindowgetActionAt(*m_w, QPoint(295, 245)), 4);
+}
+
+// adjustSelectionByKey：无修饰方向键平移框选区域
+TEST_F(MainWindowEFTest, adjustSelectionByKeyArrowMovesSelection)
+{
+    access_private_field::MainWindowrecordX(*m_w) = 100;
+    access_private_field::MainWindowrecordY(*m_w) = 100;
+    access_private_field::MainWindowrecordWidth(*m_w) = 200;
+    access_private_field::MainWindowrecordHeight(*m_w) = 150;
+    access_private_field::MainWindowm_backgroundRect(*m_w) = QRect(0, 0, 1920, 1080);
+    access_private_field::MainWindowrootWindowRect(*m_w) = QRect(0, 0, 1920, 1080);
+    access_private_field::MainWindowm_needSaveScreenshot(*m_w) = false;
+
+    QKeyEvent keyEvent(QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier);
+    bool needRepaint = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowadjustSelectionByKey(*m_w, &keyEvent, needRepaint));
+    EXPECT_EQ(access_private_field::MainWindowrecordX(*m_w), 101);
+}
+
+// keyPressEF：标注态无选中图形时方向键调框选（D3①）
+TEST_F(MainWindowEFTest, keyPressEFAnnotNoSelectionAdjustsSelection)
+{
+    access_private_field::MainWindowrecordX(*m_w) = 100;
+    access_private_field::MainWindowrecordY(*m_w) = 100;
+    access_private_field::MainWindowrecordWidth(*m_w) = 200;
+    access_private_field::MainWindowrecordHeight(*m_w) = 150;
+    access_private_field::MainWindowm_backgroundRect(*m_w) = QRect(0, 0, 1920, 1080);
+    access_private_field::MainWindowrootWindowRect(*m_w) = QRect(0, 0, 1920, 1080);
+    access_private_field::MainWindowm_needSaveScreenshot(*m_w) = false;
+    access_private_field::MainWindowm_isShapesWidgetExist(*m_w) = true;
+
+    // 无选中图形（selectedIndex() == -1）
+    ShapesWidget *sw = new ShapesWidget(m_w);
+    access_private_field::MainWindowm_shapesWidget(*m_w) = sw;
+
+    QKeyEvent keyEvent(QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier);
+    bool needRepaint = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowkeyPressEF(*m_w, &keyEvent, needRepaint));
+    EXPECT_EQ(access_private_field::MainWindowrecordX(*m_w), 101);
 }

--- a/tests/ut_screen_shot_recorder/widgets/ut_shapeswidget_paint_cov.h
+++ b/tests/ut_screen_shot_recorder/widgets/ut_shapeswidget_paint_cov.h
@@ -110,3 +110,53 @@ TEST_F(ShapesWidgetPaintCovTest, paintEmpty)
 {
     EXPECT_NO_FATAL_FAILURE(paintOnce());
 }
+
+// ===================== translateShapes（V-628 T3）=====================
+
+TEST_F(ShapesWidgetPaintCovTest, translateShapesShiftsNonEffectShapes)
+{
+    Toolshape rect;
+    rect.type = "rectangle";
+    rect.mainPoints = { QPointF(10, 10), QPointF(10, 50), QPointF(50, 10), QPointF(50, 50) };
+    rect.points = { QPointF(20, 20), QPointF(30, 30) };
+
+    access_private_field::ShapesWidgetm_shapes(*m_w) = { rect };
+
+    m_w->translateShapes(QPointF(5, 7));
+
+    const Toolshapes &shapes = access_private_field::ShapesWidgetm_shapes(*m_w);
+    EXPECT_EQ(shapes[0].mainPoints[0], QPointF(5, 3));
+    EXPECT_EQ(shapes[0].mainPoints[3], QPointF(45, 43));
+    EXPECT_EQ(shapes[0].points[0], QPointF(15, 13));
+    EXPECT_EQ(shapes[0].points[1], QPointF(25, 23));
+}
+
+TEST_F(ShapesWidgetPaintCovTest, translateShapesSkipsEffectShapes)
+{
+    Toolshape eff;
+    eff.type = "effect";
+    eff.mainPoints = { QPointF(10, 10), QPointF(10, 50), QPointF(50, 10), QPointF(50, 50) };
+
+    access_private_field::ShapesWidgetm_shapes(*m_w) = { eff };
+
+    m_w->translateShapes(QPointF(5, 7));
+
+    const Toolshapes &shapes = access_private_field::ShapesWidgetm_shapes(*m_w);
+    EXPECT_EQ(shapes[0].mainPoints[0], QPointF(10, 10));
+    EXPECT_EQ(shapes[0].mainPoints[3], QPointF(50, 50));
+}
+
+TEST_F(ShapesWidgetPaintCovTest, translateShapesZeroDeltaNoChange)
+{
+    Toolshape rect;
+    rect.type = "rectangle";
+    rect.mainPoints = { QPointF(10, 10), QPointF(10, 50), QPointF(50, 10), QPointF(50, 50) };
+
+    access_private_field::ShapesWidgetm_shapes(*m_w) = { rect };
+
+    m_w->translateShapes(QPointF(0, 0));
+
+    const Toolshapes &shapes = access_private_field::ShapesWidgetm_shapes(*m_w);
+    EXPECT_EQ(shapes[0].mainPoints[0], QPointF(10, 10));
+    EXPECT_EQ(shapes[0].mainPoints[3], QPointF(50, 50));
+}


### PR DESCRIPTION
## Allow adjusting the screenshot selection area in annotation mode

After selecting a screenshot region, the user can still adjust the
selection area's size and position once annotation editing has begun,
matching the pre-annotation behavior (mouse handles + keyboard), under
the same min-size and screen-bound constraints.

### Changes
- **Mouse gate**: route shapes-widget mouse events to selection
  drag/resize when near the selection edge and not drawing; internal
  hits and in-progress drawing pass through to annotation.
- **Keyboard gate**: when no shape is selected, direction keys adjust
  the selection (Ctrl/Shift+Ctrl to scale); when a shape is selected
  they keep micro-adjusting that shape.
- **Shape translation**: translate non-effect annotation shapes with
  the selection widget geometry so annotations stay in place while
  the selection moves; effect shapes are skipped at the rollback point.
- **Tests**: add unit tests covering selection-adjust eight-direction
  hit, keyboard selection adjust, annotation-mode event routing, and
  shape translation (move / effect-skip / zero delta).

Base: `a62b2c0e` (master). Scope limited to the screenshot
selection-adjust path; recording and scroll-screenshot paths are
unchanged.

## Summary by Sourcery

Allow the screenshot selection rectangle to be adjusted while in annotation mode, with consistent mouse/keyboard behavior and synchronized annotation geometry.

Enhancements:
- Route ShapesWidget mouse events near the selection edge to selection drag/resize logic while letting interior hits and drawing events continue to the annotation tools.
- Unify selection drag/resize handling into reusable helpers and reuse it both before and during annotation mode, including cursor and handle updates.
- Enable keyboard-driven adjustment of the selection rectangle (move/scale with arrows and modifiers) when no annotation shape is selected, while preserving micro-adjust controls for selected shapes.
- Keep annotation shapes visually fixed when the selection rectangle moves by translating their coordinates relative to the selection widget, skipping effect shapes for now.

Tests:
- Add unit tests covering edge vs interior hit detection, keyboard-based selection adjustment in annotation mode, and translation behavior for annotation shapes including skipping effect shapes.