### PR TITLE
chore: Update version to 6.6.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+deepin-screen-recorder (6.6.38) unstable; urgency=medium
+
+  * chore: Update version to 6.6.38
+  * fix: resolve remaining 41 unit test crashes via guards and test fixes
+  * fix: add null guards to prevent segfaults in non-X11/headless envs
+  * test: remove invalid ut_utils.h test suite
+  * test: strip invalid TEST_F cases from 7 legacy test headers
+  * ci: upgrade actions/checkout to v7 with unsafe PR checkout Upgrade actions/checkout from v3 to v7 and enable allow-unsafe-pr-checkout option for pull request builds.
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * [skip CI] Translate deepin-screen-recorder.ts in it
+  * Fix(mount): X11 button ungrab in scroll screenshot save flow
+  * test: raise ut src line coverage to 75% via per-test isolation + wayland/hw exclusion
+  * test: raise src unit coverage to 68.7% via resize sweep + event_monitor fix
+  * test: raise src unit-test line coverage from 60% to ~67%
+  * test: expand unit tests to lift src/ coverage from ~58% to ~60%
+  * test: add unit tests to boost src line coverage to ~53%
+  * test: port ut_screen_shot_recorder to Qt6; guard test-only prod tweaks
+  * [skip CI] Translate deepin-screen-recorder.ts in es
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:18:45 +0800
+
 deepin-screen-recorder (6.6.37) unstable; urgency=medium
 
   * fix(shot): skip save2Clipboard in Treeland mode to improve pin screenshot response


### PR DESCRIPTION
- update version to 6.6.38

log: update version to 6.6.38

## Summary by Sourcery

Chores:
- Update packaging metadata to reflect version 6.6.38.