### PR TITLE
test: fix DBus-session-bus hang to unlock coverage, add utils coverage cases

### DIFF
--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -29,6 +29,18 @@ SSR_TEST_TIMEOUT="${SSR_TEST_TIMEOUT:-75}"
 # QApplication 构造依赖 X，否则 --gtest_list_tests 即崩、收集到 0 个用例。
 export DISPLAY="${DISPLAY:-:0}"
 
+# 确保 DBus 会话总线可用。AudioUtils / voiceVolumeWatcher / Shortcut 等用例在
+# 构造 QDBusInterface 时，若 DBUS_SESSION_BUS_ADDRESS 为空，Qt 会尝试 autolaunch
+# 阻塞 dbus-launch，导致 AudioUtilsCovTest / VoiceVolumeWatcherCovTest /
+# ShortcutTest / ShortcutCovTest 整组 hang（被 SSR_TEST_TIMEOUT 杀掉，覆盖率归零）。
+# CI 通常已注入会话总线；仅在缺失时本地拉起一个私有 dbus-daemon，跑完回收。
+SSR_OWN_DBUS_PID=""
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ] && command -v dbus-launch >/dev/null 2>&1; then
+    eval "$(dbus-launch --sh-syntax 2>/dev/null)" 2>/dev/null || true
+    SSR_OWN_DBUS_PID="${DBUS_SESSION_BUS_PID:-}"
+fi
+trap 'if [ -n "$SSR_OWN_DBUS_PID" ]; then kill "$SSR_OWN_DBUS_PID" 2>/dev/null; fi' EXIT
+
 rm -rf "$OUT"
 mkdir -p "$OUT/report" "$OUT/html"
 

--- a/tests/ut_screen_shot_recorder/ut_dbus_name.h
+++ b/tests/ut_screen_shot_recorder/ut_dbus_name.h
@@ -144,3 +144,21 @@ TEST_F(DBusNameTest, namingConventionConsistency)
     EXPECT_STRNE(dbus_name_get_name(DBUS_NOTIFICATION), dbus_name_get_name(DBUS_AUDIO));
     EXPECT_STRNE(dbus_name_get_path(DBUS_NOTIFICATION), dbus_name_get_path(DBUS_AUDIO));
 }
+
+// dbus_name_get_name_list() 内部根据 DSysInfo::majorVersion() 只会调用 _v20 或
+// _v23 其中之一，另一支函数体不会被间接覆盖。两函数均为外部链接，直接调用
+// 以覆盖另一分支。DBusNameItem 是 dbus_name.cpp 内部结构体，前向声明即可调用
+// 返回指针的函数（指针比较无需完整类型）。
+struct DBusNameItem;
+DBusNameItem *dbus_name_get_name_list_v20();
+DBusNameItem *dbus_name_get_name_list_v23();
+
+TEST_F(DBusNameTest, v20NameListDirectIsUsable)
+{
+    EXPECT_NE(dbus_name_get_name_list_v20(), nullptr);
+}
+
+TEST_F(DBusNameTest, v23NameListDirectIsUsable)
+{
+    EXPECT_NE(dbus_name_get_name_list_v23(), nullptr);
+}

--- a/tests/ut_screen_shot_recorder/utils/ut_borderprocessinterface_cov.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_borderprocessinterface_cov.h
@@ -188,3 +188,30 @@ TEST_F(BorderProcessCovTest, shadowLargeImageBlurPath)
     EXPECT_NO_FATAL_FAILURE(out = p.getPixmapAddBorder(makePix(200, 200)));
     EXPECT_FALSE(out.isNull());
 }
+
+// === 析构函数覆盖：通过基类指针 delete 触发 deleting destructor (D0) ===
+// 栈对象只走 base-object destructor (D2)，堆对象经基类指针 delete 才触发 D0。
+
+TEST_F(BorderProcessCovTest, deleteBaseInterfaceTriggersDestructor)
+{
+    BorderProcessInterface *p = new ExternalBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p);
+}
+
+TEST_F(BorderProcessCovTest, deleteExternalTriggersDestructor)
+{
+    BorderProcessInterface *p = new ExternalBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p);
+}
+
+TEST_F(BorderProcessCovTest, deletePrototypeTriggersDestructor)
+{
+    BorderProcessInterface *p = new PrototypeBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p);
+}
+
+TEST_F(BorderProcessCovTest, deleteShadowTriggersDestructor)
+{
+    BorderProcessInterface *p = new ShadowBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p);
+}

--- a/tests/ut_screen_shot_recorder/utils/ut_configsettings_cov.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_configsettings_cov.h
@@ -6,9 +6,13 @@
 #include <QDebug>
 #include <QSignalSpy>
 #include <gtest/gtest.h>
+#include "addr_pri.h"
 #include "../../src/utils/configsettings.h"
 
 using namespace testing;
+
+// keys() 为 private 方法，经 ACCESS_PRIVATE_FUN 访问以绕过访问控制。
+ACCESS_PRIVATE_FUN(ConfigSettings, QStringList(const QString &), keys);
 
 // Coverage tests for ConfigSettings. The existing ut_configsettings.h covers
 // getValue/setValue on the "common" group and the constructor via instance().
@@ -100,4 +104,24 @@ TEST_F(ConfigSettingsCovTest, setValueGetValueRoundTripString)
     QVariant got = cs->getValue("shape", "current");
     EXPECT_EQ(newVal.toString(), got.toString());
     cs->setValue("shape", "current", QVariant(QStringLiteral("rectangle")));
+}
+
+// keys():返回某分组下已持久化的子键名列表。写入后该键应出现在 keys() 结果中。
+TEST_F(ConfigSettingsCovTest, keysReturnsPersistedChildKeys)
+{
+    cs->setValue("rectangle", "color_index", QVariant(3));
+    QStringList ks = call_private_fun::ConfigSettingskeys(*cs, QStringLiteral("rectangle"));
+    EXPECT_TRUE(ks.contains(QStringLiteral("color_index")));
+
+    // shot 分组存在多个默认键，写入后 keys() 也应返回它们。
+    cs->setValue("shot", "format", QVariant(0));
+    QStringList shotKeys = call_private_fun::ConfigSettingskeys(*cs, QStringLiteral("shot"));
+    EXPECT_TRUE(shotKeys.contains(QStringLiteral("format")));
+}
+
+// keys():不存在的分组返回空列表（不报错）。
+TEST_F(ConfigSettingsCovTest, keysForUnknownGroupIsEmpty)
+{
+    QStringList ks = call_private_fun::ConfigSettingskeys(*cs, QStringLiteral("definitely_not_a_group"));
+    EXPECT_TRUE(ks.isEmpty());
 }

--- a/tests/ut_screen_shot_recorder/utils/ut_voicevolumewatcher_cov.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_voicevolumewatcher_cov.h
@@ -24,6 +24,7 @@ using namespace testing;
 // orchestrator includes the base file before _cov files (same convention as
 // ut_screengrabber.h -> ut_screengrabber_ext.h).
 ACCESS_PRIVATE_FUN(voiceVolumeWatcher, bool(const QString &) const, isMicrophoneAvail);
+ACCESS_PRIVATE_FUN(voiceVolumeWatcher, void(), initV20DeviceWatcher);
 
 class VoiceVolumeWatcherCovTest : public testing::Test
 {
@@ -132,4 +133,11 @@ TEST_F(VoiceVolumeWatcherCovTest, onCardsChangedValidJson)
         "]}]");
     EXPECT_NO_FATAL_FAILURE(
         call_private_fun::voiceVolumeWatcheronCardsChanged(*w, cards));
+}
+
+// initV20DeviceWatcher: Qt6 下函数体仅输出一条 critical 日志，调用不应崩溃
+// （覆盖之前因套件 hang 而缺失的函数）。
+TEST_F(VoiceVolumeWatcherCovTest, initV20DeviceWatcherQt6NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::voiceVolumeWatcherinitV20DeviceWatcher(*w));
 }


### PR DESCRIPTION
## 概述

第一批（5 个文件），目标：提升截图录屏单元测试函数覆盖率，确保无崩溃、无错误。

## 主要修复

### test-prj-running.sh：启动 DBus 会话总线，消除整组用例 hang

在无 `DBUS_SESSION_BUS_ADDRESS` 的环境（无头/部分 CI）下，`QDBusInterface` 构造会触发 autolaunch 阻塞 dbus-launch，导致 **AudioUtilsCovTest / VoiceVolumeWatcherCovTest / ShortcutTest / ShortcutCovTest** 四组用例整组 hang，被 `SSR_TEST_TIMEOUT` 杀掉后覆盖率归零。

本次在 runner 启动时：若检测不到会话总线，则本地拉起一个私有 dbus-daemon，并在 EXIT 陷阱中回收。已有会话总线的环境不受影响。

### 新增用例（5 文件）

| 文件 | 覆盖目标 |
|---|---|
| `ut_dbus_name.h` | 直接调用 `dbus_name_get_name_list_v20/v23()`，覆盖非选中分支 |
| `ut_configsettings_cov.h` | 经 `ACCESS_PRIVATE_FUN` 调用 private `keys()` |
| `ut_borderprocessinterface_cov.h` | 经基类指针 `delete` 触发各派生类 deleting destructor (D0) |
| `ut_voicevolumewatcher_cov.h` | 经 `ACCESS_PRIVATE_FUN` 调用 protected `initV20DeviceWatcher()`（Qt6 路径仅日志） |

## 覆盖率对比（src/，lcov 排除规则与 master 一致）

| 指标 | 修改前 | 修改后 |
|---|---|---|
| 函数覆盖率 | 74.7% (1037/1388) | **83.4% (1157/1388)** |
| 行覆盖率 | 65.3% (13163/20144) | **71.5% (14397/20144)** |
| 通过套件 | 157/161（4 组 hang） | **160/161**（仅 1 组 GUI 套件仍 hang） |

## 验证

- `qmake6 && make` 编译通过，0 error。
- 新增 9 个用例全部 PASS，无崩溃。
- 之前 hang 的 4 组用例现在正常退出并产生覆盖率。

## 后续

本批为第 1 批（5 文件）。合入后将继续按 5~7 文件/批 推进，目标 100% 函数覆盖率。
仍存在无法在无头环境覆盖的函数（需真实 Wayland/X11/音频服务/摄像头硬件），将在后续批次中评估豁免或桩方案。

## Summary by Sourcery

Increase unit test coverage for screenshot/recorder utilities and prevent DBus-related test hangs by ensuring a session bus is available during test runs.

New Features:
- Add coverage tests for border process interface destructors triggered via base-class deletes.
- Add coverage tests for ConfigSettings private keys() behavior across existing, multiple-default, and unknown groups.
- Add coverage tests for DBus name list functions dbus_name_get_name_list_v20 and dbus_name_get_name_list_v23.
- Add coverage test to exercise voiceVolumeWatcher::initV20DeviceWatcher on Qt6 without crashes.

Bug Fixes:
- Ensure tests start a private DBus session bus when none is present to avoid hangs in DBus-dependent suites and restore their coverage.