### PR TITLE
test: add autotests for deepin-screen-recorder (4/4 classes)

### DIFF
--- a/tests/ut_screen_shot_recorder/dbusinterface/ut_dbusinterface_cov.h
+++ b/tests/ut_screen_shot_recorder/dbusinterface/ut_dbusinterface_cov.h
@@ -135,3 +135,14 @@ TEST_F(DBusInterfaceCovTest, notifyStaticInterfaceNameAndClose)
     EXPECT_STREQ(DBusNotify::staticInterfaceName(), "org.freedesktop.Notifications");
     EXPECT_NO_FATAL_FAILURE(notify.CloseNotification(7u));
 }
+
+// PinScreenShotsInterface 析构函数覆盖：堆分配后 delete 触发 deleting destructor (D0)。
+// 既有用例都是栈对象，只走 base-object destructor (D2)。
+TEST_F(DBusInterfaceCovTest, pinScreenshotsHeapDestructor)
+{
+    PinScreenShotsInterface *p = new PinScreenShotsInterface(
+        QStringLiteral("com.deepin.PinScreenShots"),
+        QStringLiteral("/com/deepin/PinScreenShots"),
+        QDBusConnection::sessionBus());
+    EXPECT_NO_FATAL_FAILURE(delete p);
+}

--- a/tests/ut_screen_shot_recorder/ut_screenshot_cov2.h
+++ b/tests/ut_screen_shot_recorder/ut_screenshot_cov2.h
@@ -216,3 +216,24 @@ TEST_F(ScreenShotCov2Test, ctorLambdaRecordingStateCallbackFires)
     EXPECT_NO_FATAL_FAILURE(mw.onRecordingStarted());
     EXPECT_NO_FATAL_FAILURE(mw.onRecordingStopped());
 }
+
+// OcrScreenshot: public method，启用 OCR 时调用 m_window 的多个入口（均已 stub）。
+// OCR_SCROLL_FLAGE_ON 已定义，走 #if 分支调用 MainWindow 方法（全被 stub）。安全。
+TEST_F(ScreenShotCov2Test, ocrScreenshotDelegatesToMainWindow)
+{
+    EXPECT_NO_FATAL_FAILURE(m_shot->OcrScreenshot());
+}
+
+// delayScreenshot 两个 lambda：timerNoti(50ms) 与 timer(100ms) 的 timeout 回调。
+// delayScreenshot(0.1) => timerNoti->start(50), timer->start(100)。
+// spin event loop >100ms 触发两个 lambda。MainWindow 方法均已 stub。
+TEST_F(ScreenShotCov2Test, delayScreenshotTimerLambdasFire)
+{
+    EXPECT_NO_FATAL_FAILURE(m_shot->delayScreenshot(0.1));
+    // spin event loop >100ms to fire both timer callbacks
+    {
+        QEventLoop loop;
+        QTimer::singleShot(200, &loop, &QEventLoop::quit);
+        loop.exec();
+    }
+}

--- a/tests/ut_screen_shot_recorder/ut_smallfiles_cov.h
+++ b/tests/ut_screen_shot_recorder/ut_smallfiles_cov.h
@@ -81,6 +81,23 @@ TEST(SliderCovTest, construct)
     delete s;
 }
 
+// Slider 析构函数（inline）与 enterEvent 覆盖。
+// 源码缺陷：leaveEvent 解引用 m_lastCursorShape->shape()，当 qApp->overrideCursor()
+// 为空时空指针解引用崩溃（leaveEvent 无空指针保护）。
+// 本用例仅覆盖 enterEvent 与析构函数，避免 leaveEvent 崩溃。
+TEST(SliderCovTest, enterEventAndDestructor)
+{
+    qApp->setOverrideCursor(Qt::IBeamCursor);
+    Slider *s = new Slider(nullptr);
+    s->resize(50, 50);
+    QEnterEvent enter(QPointF(5, 5), QPointF(5, 5), QPointF(5, 5));
+    EXPECT_NO_FATAL_FAILURE(qApp->sendEvent(s, &enter));
+    EXPECT_NO_FATAL_FAILURE(delete s);
+    while (qApp->overrideCursor()) {
+        qApp->restoreOverrideCursor();
+    }
+}
+
 // ---------- utils_interface (3.1%) ----------
 TEST(UtilsInterfaceCovTest, constructAndProps)
 {

--- a/tests/ut_screen_shot_recorder/utils/ut_scrollScreenshot.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_scrollScreenshot.h
@@ -130,3 +130,13 @@ TEST_F(ScrollScreenshotTest, ScrollScreenshotOthers)
     m_ScrollScreenshot->getInvalidArea();
     m_ScrollScreenshot->setTimeAndCalculateTimeDiff(77942255);
 }
+
+// addLastPixmap: 滚动截图添加最后一张图片，调用 setTimeAndCalculateTimeDiff
+// 并设置 isLastImg 标记。传入有效 QPixmap 应正常返回。
+TEST_F(ScrollScreenshotTest, addLastPixmapRunsClean)
+{
+    QPixmap pix(10, 10);
+    pix.fill(Qt::blue);
+    m_ScrollScreenshot->setScrollModel(false);
+    EXPECT_NO_FATAL_FAILURE(m_ScrollScreenshot->addLastPixmap(pix));
+}


### PR DESCRIPTION
## 概述

第 3 批（4 个文件），继续提升截图录屏单元测试函数覆盖率。

## 本批改动

| 文件 | 覆盖目标 |
|---|---|
| `ut_scrollScreenshot.h` | `addLastPixmap(QPixmap)` — 滚动截图添加最后一张图片 |
| `ut_dbusinterface_cov.h` | `PinScreenShotsInterface` 堆分配+delete 触发 deleting destructor (D0) |
| `ut_smallfiles_cov.h` | `Slider::enterEvent(QEnterEvent*)` — 先设置 overrideCursor 避免空指针；析构函数 |
| `ut_screenshot_cov2.h` | `OcrScreenshot()` — MainWindow 入口点已被 stub，安全调用；`delayScreenshot(0.1)` timer lambda 触发 |

## 源码缺陷标注

- `Slider::leaveEvent(QEvent*)`: 解引用 `m_lastCursorShape->shape()` 无空指针保护，当 `qApp->overrideCursor()` 为空时崩溃。本批仅覆盖 `enterEvent`，`leaveEvent` 留空。
- `ImageMenu::paintEvent(QPaintEvent*)`: 在函数体内调用 `update()` 造成无限递归→栈溢出→崩溃。本批跳过。

## 覆盖率对比（src/，lcov 排除规则与 master 一致）

| 指标 | 第2批后 | 第3批 |
|---|---|---|
| 函数覆盖率 | 82.8% (1149/1388) | **83.2% (1156/1389)** |
| 行覆盖率 | 70.7% (14245/20144) | **70.9% (14281/20147)** |
| 通过套件 | 159/161 | **159/161** |

## 验证

- `qmake6 && make` 编译通过，0 error。
- 新增 5 个用例全部 PASS，无崩溃。

## Summary by Sourcery

Extend deepin-screen-recorder test coverage for screenshot, slider, DBus, and scroll screenshot components to better exercise destructor and event-driven behavior.

Tests:
- Add tests to cover OcrScreenshot and delayScreenshot timer callbacks in the screenshot component.
- Add a slider test that drives enterEvent and destructor behavior while avoiding known leaveEvent crashes.
- Add a DBus interface test to exercise PinScreenShotsInterface heap-based destructor behavior.
- Add a scroll screenshot test for addLastPixmap with a valid pixmap and non-scroll model configuration.