### PR TITLE
fix(ut): fix record_time coverage wiped when worktree path contains "tests"

### DIFF
--- a/tests/ut_dde_dock_plugins/ut_record_time/build_run_ut.sh
+++ b/tests/ut_dde_dock_plugins/ut_record_time/build_run_ut.sh
@@ -21,7 +21,7 @@ executable=ut_record_time #可执行程序的文件名
 
 #下面是覆盖率目录操作，一种正向操作，一种逆向操作
 extract_info="*/dde-dock-plugins/*" #针对当前目录进行覆盖率操作
-remove_info="*tests* *build-ut*" #排除当前目录进行覆盖率操作
+remove_info="*/ut_record_time/* *build-ut*"  # 精确匹配测试目录，避免误删路径含 tests 的源码
 
 build_dir=$workdir
 result_coverage_dir=$build_dir/html


### PR DESCRIPTION
Change lcov remove glob from "*tests*" to "*/ut_record_time/*" so it only matches the test dir, not source files whose path contains "tests".

将 lcov 的 remove 通配符从 "*tests*" 改为 "*/ut_record_time/*"， 仅匹配测试目录，避免误删路径中含 "tests" 的源文件。

Log: 修复 record_time 覆盖率在 tests 路径下被清空的 bug
Influence: 解决 multica 等 worktree 路径含 "tests" 时 record_time
   coverage.info 变空、导致主脚本 lcov 合并失败、最终函数覆盖率
   误报为 69.8% 的问题。

## Summary by Sourcery

Bug Fixes:
- Prevent record_time coverage data from being cleared when project or worktree paths include the substring "tests" by narrowing the lcov removal glob to the specific ut_record_time test directory.