### PR TITLE
fix: [record] allow recording across compositor switch and fix camera in 2D

### DIFF
--- a/src/RecorderRegionShow.cpp
+++ b/src/RecorderRegionShow.cpp
@@ -66,6 +66,14 @@ RecorderRegionShow::~RecorderRegionShow()
 void RecorderRegionShow::initCameraInfo(const CameraWidget::Position position, const QSize size)
 {
     qCDebug(dsrApp) << "Entry. Position:" << position << ", Size:" << size;
+    // 清理已存在的摄像头实例，避免重复初始化导致资源泄漏
+    if (m_cameraWidget) {
+        if (m_cameraWidget->getCameraStatus()) {
+            m_cameraWidget->cameraStop();
+        }
+        delete m_cameraWidget;
+        m_cameraWidget = nullptr;
+    }
     m_cameraWidget = new CameraWidget();
 
     QRect r = this->geometry();

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -3024,43 +3024,97 @@ void MainWindow::responseEsc()
 
 void MainWindow::compositeChanged()
 {
+    bool newComposite = m_wmHelper->hasBlurWindow();
+
     // 滚动截图过程中动态切换为2D模式，直接结束
     if (m_functionType == status::shot) {
         // Treeland：工具栏在 sourceReady 后才创建，Wayland 初始化可能先触发 hasBlurWindowChanged
         if (m_toolBar) {
-            m_toolBar->setScrollShotDisabled(!m_wmHelper->hasBlurWindow());
+            m_toolBar->setScrollShotDisabled(!newComposite);
         }
         return;
     }
-    if (!m_wmHelper->hasBlurWindow() && m_functionType == status::scrollshot) {
+    if (!newComposite && m_functionType == status::scrollshot) {
         saveScreenShot();
         return;
     }
 
-    // 在非录屏状态下，通过快捷键关闭特效模式
-    if (recordButtonStatus != RECORD_BUTTON_RECORDING) {
-        m_hasComposite = m_wmHelper->hasBlurWindow();
+    // 录制中或非录制（含倒计时）：合成器变化时统一处理 2D/3D 切换
+    if (m_hasComposite != newComposite) {
+        if (newComposite) {
+            // 2D → 3D：恢复主窗口，隐藏录制框
+            qCInfo(dsrApp) << "Composite state change to 3D";
+            if (this->testAttribute(Qt::WA_TranslucentBackground))
+                show();
+            if (m_pRecorderRegion)
+                m_pRecorderRegion->hide();
+        } else {
+            // 3D → 2D：确保录制框存在并迁移摄像头，再隐藏主窗口、显示录制框
+            qCInfo(dsrApp) << "Composite state change to 2D";
+            ensureRecorderRegionAndMigrateCameraFor2D();
+            if (this->testAttribute(Qt::WA_TranslucentBackground))
+                hide();
+            if (m_pRecorderRegion) {
+                m_pRecorderRegion->show();
+                m_pRecorderRegion->setCameraShow(true);
+            }
+        }
         update();
-        return;
     }
 
-    if (m_hasComposite && !m_wmHelper->hasBlurWindow()) {
-        // 录屏过程中 由初始3D转2D模式, 强制暂停录屏.
-        // 如果录屏由 由初始2D转3D模式, 则不强制退出录屏.
-        // 强制退出通知
-        forciblySavingNotify();
-        if (recordButtonStatus == RECORD_BUTTON_RECORDING) {
-            // 录屏过程中， 从3D切换回2D， 停止录屏。
-            stopRecord();
-            return;
-        } else {
-            // 倒计时3s内， 从3D切换回2D直接退出。
-            exitApp();
-        }
-    }
+    // 更新内部状态
+    m_hasComposite = newComposite;
+
     // 2D录屏, 切换模式后,更新当前按钮的样式
     if (m_keyBoardStatus && m_pRecorderRegion) {
         m_pRecorderRegion->updateKeyBoardButtonStyle();
+    }
+}
+
+void MainWindow::ensureRecorderRegionAndMigrateCameraFor2D()
+{
+    if (!m_pRecorderRegion) {
+        // 对齐 master 既有录制框创建逻辑：设备名 + 多屏缩放 move，避免多屏/缩放/设备名异常
+        m_pRecorderRegion = new RecorderRegionShow();
+#ifdef QT_TESTLIB_LIB
+        m_pRecorderRegion->setDevcieName(m_devnumMonitor ? m_devnumMonitor->availableCamera() : QString());
+#else
+        m_pRecorderRegion->setDevcieName(m_devnumMonitor->availableCamera());
+#endif
+        m_pRecorderRegion->resize(recordWidth + 2, recordHeight + 2);
+        if (m_pixelRatio > 1 && m_screenCount > 1) {
+            if (m_isVertical) {
+                if (recordY > m_screenInfo[0].height / m_pixelRatio) {
+                    // 多屏放缩情况下，小屏在上，整体需要偏移一定距离
+                    m_pRecorderRegion->move(std::max(recordX - 1, 0),
+                                            std::max(recordY - 1, 0) + m_screenInfo[0].height -
+                                                static_cast<int>(m_screenInfo[0].height / m_pixelRatio));
+                } else {
+                    m_pRecorderRegion->move(std::max(recordX - 1, 0), std::max(recordY - 1, 0));
+                }
+
+            } else {
+                if (recordX > m_screenInfo[0].width / m_pixelRatio) {
+                    m_pRecorderRegion->move(std::max(recordX - 1, 0) + m_screenInfo[0].width -
+                                                static_cast<int>(m_screenInfo[0].width / m_pixelRatio),
+                                            std::max(recordY - 1, 0));
+                } else {
+                    m_pRecorderRegion->move(std::max(recordX - 1, 0), std::max(recordY - 1, 0));
+                }
+            }
+        } else {
+            m_pRecorderRegion->move(std::max(recordX - 1, 0), std::max(recordY - 1, 0));
+        }
+
+        if (m_cameraWidget && m_selectedCamera) {
+            m_cameraWidget->hide();
+            m_cameraWidget->cameraStop();
+            m_pRecorderRegion->initCameraInfo(m_cameraWidget->postion(), m_cameraWidget->geometry().size());
+        }
+    } else if (m_cameraWidget && m_selectedCamera) {
+        m_cameraWidget->hide();
+        m_cameraWidget->cameraStop();
+        m_pRecorderRegion->initCameraInfo(m_cameraWidget->postion(), m_cameraWidget->geometry().size());
     }
 }
 
@@ -6969,6 +7023,8 @@ void MainWindow::startRecord()
         if (m_pRecorderRegion) {
             m_pRecorderRegion->setCameraShow();
             m_pRecorderRegion->show();
+        } else {
+            qCWarning(dsrApp) << "m_pRecorderRegion is null, cannot show recording border";
         }
     }
 #endif

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -488,6 +488,8 @@ public slots:
     void showReleaseFeedback(int x, int y);
     void responseEsc();
     void compositeChanged();
+    /// 确保存在录制框并在 2D 下把主窗口摄像头迁到录制框
+    void ensureRecorderRegionAndMigrateCameraFor2D();
     void updateToolBarPos();
     void onRecordingStarted(); // 录屏开始
     void onRecordingStopped(); // 录屏停止

--- a/tests/ut_screen_shot_recorder/ut_main_window_ef_state_cov.h
+++ b/tests/ut_screen_shot_recorder/ut_main_window_ef_state_cov.h
@@ -13,6 +13,10 @@
 
 using namespace testing;
 
+// 回归（bug 349319）：录屏跨合成器切换不再停止，改为迁移摄像头/创建录制框
+ACCESS_PRIVATE_FUN(MainWindow, void(), ensureRecorderRegionAndMigrateCameraFor2D);
+ACCESS_PRIVATE_FIELD(MainWindow, bool, m_hasComposite);
+
 // 现有 MainWindowEFTest 以「空状态」调用 EF 辅助函数，多数命中早返回。
 // 本文件通过设置 m_functionType(shot/record)、recordButtonStatus 等状态字段，
 // 驱动 mousePressEF/mouseMoveEF/mouseReleaseEF 的更深分支（无需改源码）。
@@ -28,6 +32,8 @@ public:
     static int myWidth_stub() { return 1920; }
     static int myHeight_stub() { return 1080; }
     static void myPassInput_stub(int) {}
+    static bool mw_hasNoBlurWindow_stub() { return false; }
+    static bool mw_hasBlurWindow_stub() { return true; }
 
     void SetUp() override
     {
@@ -104,4 +110,71 @@ TEST_F(MainWindowEFStateCovTest, shotModeWheel)
                       Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
     bool needRepaint = false;
     EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowwheelEF(*m_w, &wheel, needRepaint));
+}
+
+
+// 回归（bug 349319）：录屏中 3D→2D 切换不再停止录屏，改为创建录制框并迁移摄像头
+TEST_F(MainWindowEFStateCovTest, recordModeCompositeSwitchTo2DCreatesRegion)
+{
+    setFunc(MainWindow::status::record);
+    access_private_field::MainWindowm_hasComposite(*m_w) = true;
+    access_private_field::MainWindowm_screenCount(*m_w) = 1;
+    access_private_field::MainWindowm_pixelRatio(*m_w) = 1.0;
+    stub.set(ADDR(DWindowManagerHelper, hasBlurWindow), mw_hasNoBlurWindow_stub);
+
+    EXPECT_EQ(access_private_field::MainWindowm_pRecorderRegion(*m_w), nullptr);
+    EXPECT_NO_FATAL_FAILURE(m_w->compositeChanged());
+    // 切换后未停止录屏，且录制框已创建（旧逻辑会 stopRecord/exitApp，不会创建录制框）
+    EXPECT_NE(access_private_field::MainWindowm_pRecorderRegion(*m_w), nullptr);
+}
+
+// 回归（bug 349319）：ensureRecorderRegionAndMigrateCameraFor2D 空时创建录制框
+TEST_F(MainWindowEFStateCovTest, ensureRecorderRegionAndMigrateCameraFor2DCreatesRegion)
+{
+    setFunc(MainWindow::status::record);
+    access_private_field::MainWindowm_screenCount(*m_w) = 1;
+    access_private_field::MainWindowm_pixelRatio(*m_w) = 1.0;
+    EXPECT_EQ(access_private_field::MainWindowm_pRecorderRegion(*m_w), nullptr);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowensureRecorderRegionAndMigrateCameraFor2D(*m_w));
+    EXPECT_NE(access_private_field::MainWindowm_pRecorderRegion(*m_w), nullptr);
+}
+
+
+// 回归（bug 349319）：录屏中 2D→3D 切换恢复主窗口、隐藏录制框，且不重新创建录制框
+TEST_F(MainWindowEFStateCovTest, recordModeCompositeSwitchTo3DHidesRegion)
+{
+    setFunc(MainWindow::status::record);
+    access_private_field::MainWindowm_hasComposite(*m_w) = false; // 当前 2D
+    access_private_field::MainWindowm_screenCount(*m_w) = 1;
+    access_private_field::MainWindowm_pixelRatio(*m_w) = 1.0;
+    // 预置已存在的录制框并显示，验证 2D→3D 分支会隐藏它且不重新 new
+    auto *region = new RecorderRegionShow();
+    region->resize(800, 600);
+    region->move(50, 50);
+    region->show();
+    access_private_field::MainWindowm_pRecorderRegion(*m_w) = region;
+    stub.set(ADDR(DWindowManagerHelper, hasBlurWindow), mw_hasBlurWindow_stub); // -> 3D
+
+    EXPECT_NO_FATAL_FAILURE(m_w->compositeChanged());
+    // 录制框指针不变（未被重新 new）
+    EXPECT_EQ(access_private_field::MainWindowm_pRecorderRegion(*m_w), region);
+    // 录制框被隐藏
+    EXPECT_FALSE(region->isVisible());
+}
+
+// 回归（bug 349319）：ensureRecorderRegionAndMigrateCameraFor2D 复用已存在录制框，不新建
+TEST_F(MainWindowEFStateCovTest, ensureRecorderRegionAndMigrateCameraFor2DReusesExisting)
+{
+    setFunc(MainWindow::status::record);
+    access_private_field::MainWindowm_screenCount(*m_w) = 1;
+    access_private_field::MainWindowm_pixelRatio(*m_w) = 1.0;
+    // 预置已存在的录制框（无摄像头 -> 不触发迁移，仅验证复用/不新建路径）
+    auto *region = new RecorderRegionShow();
+    region->resize(800, 600);
+    region->move(50, 50);
+    access_private_field::MainWindowm_pRecorderRegion(*m_w) = region;
+
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowensureRecorderRegionAndMigrateCameraFor2D(*m_w));
+    // 指针不变、未新建
+    EXPECT_EQ(access_private_field::MainWindowm_pRecorderRegion(*m_w), region);
 }


### PR DESCRIPTION
### 修复内容

将 v20（release/eagle）commit `91de0fb9` 的录屏修复移植到 v25（master）：

- 录屏过程中合成器在 3D/2D 之间切换时不再强制停止录屏。
- 切换到 2D 时将摄像头 widget 迁移到 `RecorderRegionShow` 录制框中以保持可见。
- 新增 `MainWindow::ensureRecorderRegionAndMigrateCameraFor2D()`：2D 下按需创建/复用录制框并迁移摄像头。
- 修复 `RecorderRegionShow::initCameraInfo()` 重复初始化导致的摄像头实例资源泄漏：重建前清理已存在实例。
- `MainWindow::startRecord()` 增加 `m_pRecorderRegion` 空指针保护与告警日志。
- 补充/扩展 `ut_main_window_ef_state_cov.h` 中 2D/合成器切换路径的单元测试。

### 改动文件
- `src/RecorderRegionShow.cpp`
- `src/main_window.cpp`
- `src/main_window.h`
- `tests/ut_screen_shot_recorder/ut_main_window_ef_state_cov.h`

### 验证
- AI 代码审查复审通过
- 单元测试 / 构建 / 启动通过
- 本机补丁验证（打包安装）通过
- 人工功能验收通过

Bug: https://pms.uniontech.com/bug-view-349319.html

## Summary by Sourcery

Handle compositor (2D/3D) switching during recording without stopping the recording and keep the camera visible by migrating it into the recording region in 2D mode.

Bug Fixes:
- Fix recording being forcibly stopped when switching between 3D and 2D compositors by instead toggling main window/recording border visibility and maintaining recording state.
- Fix camera widget leaks in RecorderRegionShow by clearing existing camera instances before reinitialization.
- Prevent potential null dereference when showing the recording border by guarding against a null m_pRecorderRegion and logging a warning.

Enhancements:
- Introduce ensureRecorderRegionAndMigrateCameraFor2D to create or reuse the recording region and migrate the camera widget when entering 2D mode.
- Refine compositeChanged logic to centralize 2D/3D transition handling for both recording and pre-record countdown states.

Tests:
- Extend MainWindow EF state coverage tests to cover compositor switching in record mode and the new ensureRecorderRegionAndMigrateCameraFor2D behavior, ensuring regions are created or reused appropriately.