### PR TITLE
ut: voicevolumewatcher_interface 单元测试

### DIFF
--- a/tests/ut_screen_shot_recorder/test_all_interfaces.h
+++ b/tests/ut_screen_shot_recorder/test_all_interfaces.h
@@ -168,6 +168,8 @@
 // --- P1: 启用孤儿测试 ---
 #include "widgets/ut_colorbutton.h"
 #include "gstrecord/ut_gstrecordx.h"
+// --- 批次8: voicevolumewatcher_interface 全量属性/异步方法覆盖 (21 funcs, 0% -> covered) ---
+#include "ut_voicevolumewatcher_interface_cov.h"
 // 以下孤儿测试已删除（测试对应的源码类在主项目中已无任何外部引用，属历史遗留
 // 死代码，且源码自身存在 ConfigSettings::value/drawTooltipBackground 等 API 漂移）：
 // widgets/ut_majtoolbar.h / widgets/ut_subtoolbar.h / ut_record_option_panel.h

--- a/tests/ut_screen_shot_recorder/ut_voicevolumewatcher_interface_cov.h
+++ b/tests/ut_screen_shot_recorder/ut_voicevolumewatcher_interface_cov.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include <gtest/gtest.h>
+#include <QtDBus>
+#include <QDBusConnection>
+#include <QDBusPendingReply>
+#include "stub.h"
+
+#include "../../src/utils/voicevolumewatcher_interface.h"
+
+using namespace testing;
+
+// voicevolumewatcher_interface is the qdbusxml2cpp-generated proxy for
+// com.deepin.daemon.Audio. voiceVolumeWatcher *inherits* this interface but
+// never calls any of its inline property getters / setters / async method
+// wrappers, leaving all 21 of them at 0% function coverage (only the destructor
+// was previously touched by ut_smallfiles_cov.h::heapDestructor).
+//
+// Safety: the service "com.deepin.daemon.Audio" is neither registered nor
+// DBus-activatable on the headless test session bus (only org.deepin.dde.Audio1
+// has a .service file). Consequently every sync property()/setProperty() call
+// receives an org.freedesktop.DBus.Error.ServiceUnknown reply from the bus
+// daemon immediately (no activation, no hang), and the asyncCallWithArgumentList
+// wrappers return a QDBusPendingReply without blocking. Constructing the proxy
+// (QDBusAbstractInterface ctor) likewise performs no synchronous round-trip.
+//
+// NOTE: uses plain TEST (not TEST_F) to stay fixture-compatible with the
+// existing TEST(VoiceVolumeWatcherInterfaceCovTest, heapDestructor) in
+// ut_smallfiles_cov.h, which shares this suite name.
+
+// ---------- 12 Q_PROPERTY getters (sync property() fast-fail) ----------
+TEST(VoiceVolumeWatcherInterfaceCovTest, allPropertyGettersRunCleanly)
+{
+    voicevolumewatcher_interface *iface = nullptr;
+    EXPECT_NO_FATAL_FAILURE(iface = new voicevolumewatcher_interface(
+                                 QStringLiteral("com.deepin.daemon.Audio"),
+                                 QStringLiteral("/com/deepin/daemon/Audio"),
+                                 QDBusConnection::sessionBus()));
+    if (iface) {
+        EXPECT_NO_FATAL_FAILURE(iface->bluetoothAudioMode());
+        EXPECT_NO_FATAL_FAILURE(iface->bluetoothAudioModeOpts());
+        EXPECT_NO_FATAL_FAILURE(iface->cards());
+        EXPECT_NO_FATAL_FAILURE(iface->cardsWithoutUnavailable());
+        EXPECT_NO_FATAL_FAILURE(iface->defaultSink());
+        EXPECT_NO_FATAL_FAILURE(iface->defaultSource());
+        EXPECT_NO_FATAL_FAILURE(iface->increaseVolume());
+        EXPECT_NO_FATAL_FAILURE(iface->maxUIVolume());
+        EXPECT_NO_FATAL_FAILURE(iface->reduceNoise());
+        EXPECT_NO_FATAL_FAILURE(iface->sinkInputs());
+        EXPECT_NO_FATAL_FAILURE(iface->sinks());
+        EXPECT_NO_FATAL_FAILURE(iface->sources());
+        EXPECT_NO_FATAL_FAILURE(delete iface);
+    }
+}
+
+// ---------- 2 Q_PROPERTY setters (sync setProperty() fast-fail) ----------
+TEST(VoiceVolumeWatcherInterfaceCovTest, propertySettersRunCleanly)
+{
+    voicevolumewatcher_interface *iface = nullptr;
+    EXPECT_NO_FATAL_FAILURE(iface = new voicevolumewatcher_interface(
+                                 QStringLiteral("com.deepin.daemon.Audio"),
+                                 QStringLiteral("/com/deepin/daemon/Audio"),
+                                 QDBusConnection::sessionBus()));
+    if (iface) {
+        EXPECT_NO_FATAL_FAILURE(iface->setIncreaseVolume(true));
+        EXPECT_NO_FATAL_FAILURE(iface->setReduceNoise(false));
+        EXPECT_NO_FATAL_FAILURE(delete iface);
+    }
+}
+
+// ---------- 7 async method wrappers (asyncCallWithArgumentList, non-blocking) ----------
+TEST(VoiceVolumeWatcherInterfaceCovTest, asyncMethodWrappersRunCleanly)
+{
+    voicevolumewatcher_interface *iface = nullptr;
+    EXPECT_NO_FATAL_FAILURE(iface = new voicevolumewatcher_interface(
+                                 QStringLiteral("com.deepin.daemon.Audio"),
+                                 QStringLiteral("/com/deepin/daemon/Audio"),
+                                 QDBusConnection::sessionBus()));
+    if (iface) {
+        EXPECT_NO_FATAL_FAILURE(iface->Reset());
+        EXPECT_NO_FATAL_FAILURE(iface->SetBluetoothAudioMode(QStringLiteral("a2dp")));
+        EXPECT_NO_FATAL_FAILURE(iface->SetDefaultSink(QStringLiteral("/Sink0")));
+        EXPECT_NO_FATAL_FAILURE(iface->SetDefaultSource(QStringLiteral("/Source0")));
+        EXPECT_NO_FATAL_FAILURE(iface->SetPort(0, QStringLiteral("analog-output"), 0));
+        EXPECT_NO_FATAL_FAILURE(iface->SetPortEnabled(0, QStringLiteral("analog-output"), true));
+        // IsPortEnabled returns a QDBusPendingReply<bool>; do not waitForFinished —
+        // just let the async call be issued without blocking.
+        EXPECT_NO_FATAL_FAILURE((void)iface->IsPortEnabled(0, QStringLiteral("analog-output")));
+        EXPECT_NO_FATAL_FAILURE(delete iface);
+    }
+}


### PR DESCRIPTION
# ut: voicevolumewatcher_interface 单元测试

## 覆盖内容

为 `voicevolumewatcher_interface`（qdbusxml2cpp 生成的 `com.deepin.daemon.Audio` 代理类）补全全部 21 个内联方法的单元测试。`voiceVolumeWatcher` 虽继承该接口，但从不调用这些成员，致使其函数覆盖率为 0%（此前仅析构函数被覆盖）。

覆盖的 21 个函数：
- 12 个 Q_PROPERTY getter：`bluetoothAudioMode` / `bluetoothAudioModeOpts` / `cards` / `cardsWithoutUnavailable` / `defaultSink` / `defaultSource` / `increaseVolume` / `maxUIVolume` / `reduceNoise` / `sinkInputs` / `sinks` / `sources`
- 2 个 Q_PROPERTY setter：`setIncreaseVolume` / `setReduceNoise`
- 7 个异步方法包装：`Reset` / `SetBluetoothAudioMode` / `SetDefaultSink` / `SetDefaultSource` / `SetPort` / `SetPortEnabled` / `IsPortEnabled`

## 安全性

服务 `com.deepin.daemon.Audio` 在无头测试会话总线上既未注册也不可 DBus 激活（只有 `org.deepin.dde.Audio1` 有 `.service` 文件），因此同步 `property()` / `setProperty()` 调用立即收到 `ServiceUnknown` 错误返回，`asyncCallWithArgumentList` 立即返回 `QDBusPendingReply` 不阻塞。3 个新用例独立运行均通过，无 hang/crash（单用例 ≤19 ms）。

## 覆盖率

- `utils/voicevolumewatcher_interface.h`：函数覆盖率 **0% → 100%（21/21）**
- 整体（src/，已剔除 Wayland 生成代码）：函数覆盖率约 87%（1391 分母）

## 改动文件

- `tests/ut_screen_shot_recorder/ut_voicevolumewatcher_interface_cov.h`（新增，3 个用例）
- `tests/ut_screen_shot_recorder/test_all_interfaces.h`（仅追加 1 行 `#include`）

不涉及源码修改、构建产物或 session 文件。

## Summary by Sourcery

Add unit tests to cover all inline property accessors and async method wrappers of the voicevolumewatcher_interface DBus proxy, raising its function coverage from 0% to full coverage.

Tests:
- Introduce ut_voicevolumewatcher_interface_cov.h with tests covering all 21 Q_PROPERTY getters, setters, and async wrappers of voicevolumewatcher_interface.
- Register the new voicevolumewatcher_interface coverage tests in the aggregated test_all_interfaces.h include list.