### PR TITLE
ut: Utils 单元测试补全（析构 + X11 输入函数）

### DIFF
--- a/tests/ut_screen_shot_recorder/test_all_interfaces.h
+++ b/tests/ut_screen_shot_recorder/test_all_interfaces.h
@@ -168,6 +168,8 @@
 // --- P1: 启用孤儿测试 ---
 #include "widgets/ut_colorbutton.h"
 #include "gstrecord/ut_gstrecordx.h"
+// --- P1: 单例析构与 Utils X11 函数覆盖补充 ---
+#include "ut_utils_cov3.h"
 // 以下孤儿测试已删除（测试对应的源码类在主项目中已无任何外部引用，属历史遗留
 // 死代码，且源码自身存在 ConfigSettings::value/drawTooltipBackground 等 API 漂移）：
 // widgets/ut_majtoolbar.h / widgets/ut_subtoolbar.h / ut_record_option_panel.h

--- a/tests/ut_screen_shot_recorder/ut_utils_cov3.h
+++ b/tests/ut_screen_shot_recorder/ut_utils_cov3.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// 覆盖补充（UtilsCov3Test）：Utils 中此前从未被任何用例直接调用的函数。
+//
+// 经核对现有用例（ut_utils_cov.h / ut_utils_cov2.h / ut_utils_ext*.h）：
+//   - enableXGrabButton / cancelInputEvent1 已由 UtilsCovTest 调用覆盖；
+//   - passInputEvent / getInputEvent / cancelInputEvent / disableXGrabButton 仅在
+//     注释中提及，没有任何用例真正调用 → 一直为 0% 覆盖；
+//   - Utils::~Utils：Utils 为"创建一次永不销毁"的单例（instance() 返回 new 出的
+//     对象，m_utils 永不 delete），故其析构函数（含 deleting destructor D0/D2）
+//     在全部用例中均为 0% 覆盖。
+//
+// 这些函数在测试构建（ENABLE_UNIT_TEST）下，于无 X11 连接时会走早期 return 分支，
+// 可安全直接调用；~Utils 通过 delete 单例触发（每个用例独占进程，互不影响）。
+
+#pragma once
+#include <gtest/gtest.h>
+#include <QDebug>
+#include "../../src/utils.h"
+
+using namespace testing;
+
+class UtilsCov3Test : public testing::Test {
+public:
+    void SetUp() override { std::cout << "start UtilsCov3Test" << std::endl; }
+    void TearDown() override { std::cout << "end UtilsCov3Test" << std::endl; }
+};
+
+// Utils::passInputEvent —— 既有用例从未调用，覆盖其入口与（无 X11 时）早期返回。
+TEST_F(UtilsCov3Test, passInputEventIsCallableAndCrashFree)
+{
+    EXPECT_NO_FATAL_FAILURE(Utils::passInputEvent(0));
+}
+
+// Utils::getInputEvent —— 既有用例从未调用。
+TEST_F(UtilsCov3Test, getInputEventIsCallableAndCrashFree)
+{
+    EXPECT_NO_FATAL_FAILURE(Utils::getInputEvent(0, 0, 0, 0, 0));
+}
+
+// Utils::cancelInputEvent —— 既有用例从未调用（仅 cancelInputEvent1 被覆盖）。
+TEST_F(UtilsCov3Test, cancelInputEventIsCallableAndCrashFree)
+{
+    EXPECT_NO_FATAL_FAILURE(Utils::cancelInputEvent(0, 0, 0, 0, 0));
+}
+
+// Utils::disableXGrabButton —— 既有用例从未调用（仅 enableXGrabButton 被覆盖）。
+TEST_F(UtilsCov3Test, disableXGrabButtonIsCallableAndCrashFree)
+{
+    EXPECT_NO_FATAL_FAILURE(Utils::disableXGrabButton());
+}
+
+// Utils::~Utils（D2/D0）—— 单例永不销毁，故析构从未覆盖。此处 delete 触发析构链。
+// 用例在 per-test 进程隔离下运行，删除缓存单例不影响其他用例。
+TEST_F(UtilsCov3Test, singletonDestructorRunsCleanly)
+{
+    Utils *u = Utils::instance();
+    ASSERT_NE(nullptr, u);
+    EXPECT_NO_FATAL_FAILURE(delete u);
+}


### PR DESCRIPTION
## 概述
为 `src/utils.cpp` 中此前 **0% 函数覆盖** 的 5 个函数补全 Google Test 用例（`UtilsCov3Test`，新文件 `tests/ut_screen_shot_recorder/ut_utils_cov3.h`）。

## 覆盖的函数（均为既有用例从未真正调用）
| 函数 | 之前状态 | 补全方式 |
|------|---------|---------|
| `Utils::~Utils` (D2/D0) | 单例 `instance()` 创建后永不销毁，析构从未执行 | per-test 进程隔离下 `delete Utils::instance()` 触发析构链 |
| `Utils::passInputEvent(int)` | 仅在 `ut_utils_cov*.h` 注释中提及，无实际调用 | 直接调用（ENABLE_UNIT_TEST + 无 X11 时走早期返回） |
| `Utils::getInputEvent(...)` | 同上 | 直接调用 |
| `Utils::cancelInputEvent(...)` | 同上（仅 `cancelInputEvent1` 被覆盖） | 直接调用 |
| `Utils::disableXGrabButton()` | 同上（仅 `enableXGrabButton` 被覆盖） | 直接调用 |

> 说明：基类 `utils_interface::~utils_interface` 已由 `UtilsInterfaceCovTest::heapDestructor` 覆盖；`enableXGrabButton`/`cancelInputEvent1` 已由 `UtilsCovTest` 覆盖。本 PR 不重复覆盖。

## 验证
- 构建：`qmake6 && make -j16` 干净通过，未引入新警告/错误
- 运行：5/5 用例 PASS（per-test 进程隔离）
- 覆盖率：lcov 确认上述 5 个目标函数（含 D2/D0 共 6 个 FN 条目）由 0% → 命中

## 变更范围
- 新增：`tests/ut_screen_shot_recorder/ut_utils_cov3.h`
- 追加（仅 2 行）：`tests/ut_screen_shot_recorder/test_all_interfaces.h` 中 `#include "ut_utils_cov3.h"`
- 未修改任何源码、未提交构建产物/session 文件

## 基线
`1b34a5d7`（origin/master, "chore: bump version to 6.6.39"）

## Summary by Sourcery

Add unit tests to cover previously untested Utils singleton destructor and X11-related input helper functions.

Tests:
- Introduce UtilsCov3Test to exercise the Utils singleton destructor and X11 input event helper APIs for crash-free invocation.
- Include the new Utils coverage test header in the aggregated test_all_interfaces suite so the added tests are executed.