### PR TITLE
test: fix missing unit test cases, increase from 26 to 1609

### DIFF
--- a/tests/test-prj-running.sh
+++ b/tests/test-prj-running.sh
@@ -72,21 +72,112 @@ if [ -x "$SSR_BIN" ]; then
         /^[A-Za-z0-9_]+.*\.$/{s=$0; sub(/\.$/, "", s)}
         /^  [A-Za-z0-9_]+/{gsub(/^ +/, ""); print s"."$0}')
     ssr_ok=0; ssr_bad=0
+    # 逐用例生成 JUnit XML 报告（供 CI 统计用例数）；崩/hang 用例无 XML，合并时标记为 error。
+    mkdir -p "$SSR_DIR/report_individual"
+    : > "$SSR_DIR/ssr_results.tsv"
     # 用 offscreen：native(dxcb)平台下大量 GUI 用例(MainWindow 构造/paint/cursor 路径)
     # 会 ASan abort，逐用例隔离运行时整用例丢覆盖。offscreen 为纯软件平台，用例稳定运行。
     for t in "${SSR_TESTS[@]}"; do
+        safe_name="${t//[^A-Za-z0-9_]/_}"
+        xml_path="report_individual/${safe_name}.xml"
         ( cd "$SSR_DIR" && DISPLAY=:0 QT_QPA_PLATFORM=offscreen QT_LOGGING_RULES="*=false" \
           ASAN_OPTIONS=fast_unwind_on_malloc=1:detect_leaks=0 \
-          timeout "$SSR_TEST_TIMEOUT" ./ut_screen_shot_recorder --gtest_filter="$t" >/dev/null 2>&1 )
-        case $? in 0|1) ssr_ok=$((ssr_ok+1));; *) ssr_bad=$((ssr_bad+1));; esac
+          timeout "$SSR_TEST_TIMEOUT" ./ut_screen_shot_recorder --gtest_filter="$t" \
+          --gtest_output=xml:"$xml_path" >/dev/null 2>&1 )
+        rc=$?
+        case $rc in 0|1) ssr_ok=$((ssr_ok+1));; *) ssr_bad=$((ssr_bad+1));; esac
+        printf '%s\t%d\n' "$t" "$rc" >> "$SSR_DIR/ssr_results.tsv"
     done
     echo "[INFO] ssr 逐用例：$ssr_ok 正常退出，$ssr_bad 崩/hang 跳过（共 ${#SSR_TESTS[@]} 个）。"
+
+    # 合并逐用例 XML 报告为单一 JUnit XML（供 CI 统计全部用例数）。
+    # 崩/hang 用例无 XML，按退出码标记为 error，确保用例总数完整。
+    python3 - "$SSR_DIR/report_individual" "$SSR_DIR/ssr_results.tsv" \
+             "$OUT/report/report_ut_screen_shot_recorder.xml" <<'PYEOF'
+import os, sys
+from xml.etree import ElementTree as ET
+
+indiv_dir, results_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Read per-test exit codes
+exit_codes = {}
+with open(results_path) as f:
+    for line in f:
+        parts = line.rstrip('\n').split('\t')
+        if len(parts) == 2:
+            exit_codes[parts[0]] = int(parts[1])
+
+# Collect per-test XML results (pass/fail with detail)
+xml_results = {}
+if os.path.isdir(indiv_dir):
+    for fn in os.listdir(indiv_dir):
+        if not fn.endswith('.xml'):
+            continue
+        try:
+            tree = ET.parse(os.path.join(indiv_dir, fn))
+        except ET.ParseError:
+            continue
+        for tc in tree.iter('testcase'):
+            full = f"{tc.get('classname','')}.{tc.get('name','')}"
+            fails = tc.findall('failure')
+            if fails:
+                xml_results[full] = ('fail', tc.get('time','0'), fails[0].get('message',''))
+            elif tc.findall('error'):
+                xml_results[full] = ('error', tc.get('time','0'), '')
+            else:
+                xml_results[full] = ('pass', tc.get('time','0'), '')
+
+# Build merged JUnit XML: all tests from exit_codes, enriched by XML where available
+suites = {}
+for full_name, rc in exit_codes.items():
+    if '.' not in full_name:
+        continue
+    suite, tname = full_name.rsplit('.', 1)
+    if full_name in xml_results:
+        st, tm, msg = xml_results[full_name]
+    elif rc == 0:
+        st, tm, msg = 'pass', '0', ''
+    elif rc == 1:
+        st, tm, msg = 'fail', '0', 'gtest assertion failure'
+    else:
+        st, tm, msg = 'error', '0', f'crashed/hang (exit {rc})'
+    suites.setdefault(suite, []).append((tname, st, tm, msg))
+
+root = ET.Element('testsuites')
+total = sum(len(ts) for ts in suites.values())
+total_fail = sum(1 for ts in suites.values() for _, st, _, _ in ts if st == 'fail')
+total_err = sum(1 for ts in suites.values() for _, st, _, _ in ts if st == 'error')
+root.set('tests', str(total)); root.set('failures', str(total_fail))
+root.set('errors', str(total_err)); root.set('disabled', '0')
+root.set('name', 'ut_screen_shot_recorder')
+
+for sname, tests in sorted(suites.items()):
+    ts = ET.SubElement(root, 'testsuite')
+    ts.set('name', sname); ts.set('tests', str(len(tests)))
+    ts.set('failures', str(sum(1 for _, st, _, _ in tests if st == 'fail')))
+    ts.set('errors', str(sum(1 for _, st, _, _ in tests if st == 'error')))
+    ts.set('disabled', '0')
+    for tname, st, tm, msg in tests:
+        tc = ET.SubElement(ts, 'testcase')
+        tc.set('name', tname); tc.set('classname', sname)
+        tc.set('status', 'run'); tc.set('time', tm)
+        if st == 'fail':
+            ET.SubElement(tc, 'failure').set('message', msg)
+        elif st == 'error':
+            ET.SubElement(tc, 'error').set('message', msg)
+
+ET.ElementTree(root).write(out_path, encoding='UTF-8', xml_declaration=True)
+print(f"[INFO] 合并 ssr 报告：{total} 用例，{total_fail} 失败，{total_err} 错误 -> {out_path}")
+PYEOF
 else
     echo "[WARN] ssr 二进制不存在，跳过其运行（仅 recordtime 覆盖）。"
 fi
 
-# 2) 编译 + 运行 ut_record_time（真实覆盖率）
+# 2) 编译 + 运行 dock 插件测试（ut_record_time + ut_shot_start + ut_shot_start_record）
 "$HERE/ut_dde_dock_plugins/build_run_ut.sh"
+
+# 2.5) 编译 + 运行 ut_pin_screenshots（贴图模块单元测试）
+"$HERE/ut_pin_screenshots/build_run_ut.sh" || echo "[WARN] ut_pin_screenshots 运行失败，继续。"
 
 # 3) 聚合覆盖率（ssr 基线 + ssr 运行时 + recordtime）
 RT_DIR="$HERE/ut_dde_dock_plugins/ut_record_time/build-ut"

--- a/tests/ut_dde_dock_plugins/build_run_ut.sh
+++ b/tests/ut_dde_dock_plugins/build_run_ut.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-./ut_dde_dock_plugins/ut_record_time/build_run_ut.sh
+# 运行全部三个 dock 插件子模块的单元测试与覆盖率。
+# 各子模块脚本独立构建/运行/收集覆盖率，任一失败不影响其余。
+
+for mod in ut_record_time ut_shot_start ut_shot_start_record; do
+    echo "[INFO] 运行 dock 插件子模块：$mod"
+    ./ut_dde_dock_plugins/"$mod"/build_run_ut.sh || echo "[WARN] $mod 运行失败，继续后续模块。"
+done
+
 exit 0

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
@@ -29,7 +29,9 @@ equals(TSAN_TOOL_ENABLE, true ){
 
 HEADERS += \
     ut_mock_pluginproxyinterface.h \
+    ../../../src/dbus_name.h \
     ../../../src/dde-dock-plugins/shotstart/iconwidget.h \
+    ../../../src/dde-dock-plugins/shotstart/iconwidget_interface.h \
     ../../../src/dde-dock-plugins/shotstart/shotstartplugin.h \
     ../../../src/dde-dock-plugins/shotstart/tipswidget.h \
     ../../../src/dde-dock-plugins/shotstart/quickpanelwidget.h \
@@ -37,7 +39,9 @@ HEADERS += \
 
 SOURCES += \
     main.cpp \
+    ../../../src/dbus_name.cpp \
     ../../../src/dde-dock-plugins/shotstart/iconwidget.cpp \
+    ../../../src/dde-dock-plugins/shotstart/iconwidget_interface.cpp \
     ../../../src/dde-dock-plugins/shotstart/shotstartplugin.cpp \
     ../../../src/dde-dock-plugins/shotstart/tipswidget.cpp \
     ../../../src/dde-dock-plugins/shotstart/quickpanelwidget.cpp \

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
@@ -29,7 +29,9 @@ equals(TSAN_TOOL_ENABLE, true ){
 
 HEADERS += \
     ut_mock_pluginproxyinterface.h \
+    ../../../src/dbus_name.h \
     ../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget.h \
+    ../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget_interface.h \
     ../../../src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h \
     ../../../src/dde-dock-plugins/shotstartrecord/tipswidget.h \
     ../../../src/dde-dock-plugins/shotstartrecord/quickpanelwidget.h \
@@ -37,7 +39,9 @@ HEADERS += \
 
 SOURCES += \
     main.cpp \
+    ../../../src/dbus_name.cpp \
     ../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget.cpp \
+    ../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget_interface.cpp \
     ../../../src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp \
     ../../../src/dde-dock-plugins/shotstartrecord/tipswidget.cpp \
     ../../../src/dde-dock-plugins/shotstartrecord/quickpanelwidget.cpp \

--- a/tests/ut_pin_screenshots/build_run_ut.sh
+++ b/tests/ut_pin_screenshots/build_run_ut.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+export DISPLAY="${DISPLAY:-:0}"
+export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}"
+
+rm -rf ./ut_pin_screenshots/build-ut
+mkdir ./ut_pin_screenshots/build-ut
+
+cd ./ut_pin_screenshots/build-ut
+export QT_SELECT=qt6
+qmake6 ../
+make -j4
+
+mkdir -p html report
+
+executable=ut_pin_screenshots
+
+extract_info="*/pin_screenshots/*"
+remove_info="*tests* *build-ut*"
+
+ASAN_OPTIONS="fast_unwind_on_malloc=1"
+./${executable} --gtest_output=xml:report/report_${executable}.xml
+
+lcov -d . -c -o ${executable}_coverage.info 2>/dev/null || true
+lcov --extract ./${executable}_coverage.info $extract_info --output-file ${executable}_coverage.info 2>/dev/null || true
+lcov --remove ./${executable}_coverage.info $remove_info --output-file ${executable}_coverage.info 2>/dev/null || true
+
+genhtml -o ./html ${executable}_coverage.info 2>/dev/null || true
+
+cp ./report/report_${executable}.xml ../../../build-ut/report/ 2>/dev/null || true
+cp ./html/index.html ../../../build-ut/html/cov_${executable}.html 2>/dev/null || true
+
+exit 0

--- a/tests/ut_pin_screenshots/test_all_interfaces.h
+++ b/tests/ut_pin_screenshots/test_all_interfaces.h
@@ -1,6 +1,12 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
+#include "ut_pin_screenshots.h"
+#include "ut_pin_settings.h"
+#include "ut_pinsavemenumanager.h"
+#include "ut_putils.h"
+#include "ut_pinscreenshotsinterface.h"
+#include "ut_dbusadaptor.h"

--- a/tests/ut_pin_screenshots/ut_dbusadaptor.h
+++ b/tests/ut_pin_screenshots/ut_dbusadaptor.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_DBUSADAPTOR_H
+#define UT_DBUSADAPTOR_H
+#include <gtest/gtest.h>
+#include <QObject>
+#include "service/dbuspinscreenshotsadaptor.h"
+
+TEST_F(PinScreenShotsTest, adaptorConstruction)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor *adaptor = new DbusPinScreenShotsAdaptor(&parent);
+    EXPECT_NE(adaptor, nullptr);
+    delete adaptor;
+}
+
+TEST_F(PinScreenShotsTest, adaptorParentSet)
+{
+    QObject *parent = new QObject();
+    DbusPinScreenShotsAdaptor *adaptor = new DbusPinScreenShotsAdaptor(parent);
+    EXPECT_EQ(adaptor->parent(), parent);
+    delete parent;
+}
+
+#endif // UT_DBUSADAPTOR_H

--- a/tests/ut_pin_screenshots/ut_pin_screenshots.pro
+++ b/tests/ut_pin_screenshots/ut_pin_screenshots.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT              += core widgets dbus
+QT              += core gui widgets dbus testlib
 CONFIG          += c++11 plugin link_pkgconfig
 PKGCONFIG += dtk6gui dtk6widget
 include(../../3rdparty/stub_linux/stub.pri)
@@ -15,7 +15,9 @@ QMAKE_CXXFLAGS += -g -Wno-error=deprecated-declarations -Wno-deprecated-declarat
 QMAKE_LFLAGS += -g -Wall -fprofile-arcs -ftest-coverage  -O0
 
 #内存检测标签
-TSAN_TOOL_ENABLE = true
+# TSAN/ASAN disabled: DMenu construction under offscreen platform triggers
+# ASan false-positives that abort the process before tests run.
+TSAN_TOOL_ENABLE = false
 equals(TSAN_TOOL_ENABLE, true ){
     #DEFINES += TSAN_THREAD #互斥
     DEFINES += ENABLE_TSAN_TOOL
@@ -31,11 +33,33 @@ equals(TSAN_TOOL_ENABLE, true ){
     }
 }
 
+INCLUDEPATH += ../../src/pin_screenshots
+INCLUDEPATH += ../../src/pin_screenshots/ui
+INCLUDEPATH += ../../src/pin_screenshots/service
+INCLUDEPATH += ../../src/utils
+
 SOURCES += \
-    main.cpp
+    main.cpp \
+    ../../src/pin_screenshots/settings.cpp \
+    ../../src/pin_screenshots/putils.cpp \
+    ../../src/pin_screenshots/ui/pinsavemenumanager.cpp \
+    ../../src/pin_screenshots/service/pinscreenshotsinterface.cpp \
+    ../../src/pin_screenshots/service/dbuspinscreenshotsadaptor.cpp \
+    ../../src/utils/log.cpp
 
 HEADERS += \
-        ut_pin_screenshots.h \
-    test_all_interfaces.h
+    ut_pin_screenshots.h \
+    ut_pin_settings.h \
+    ut_pinsavemenumanager.h \
+    ut_putils.h \
+    ut_pinscreenshotsinterface.h \
+    ut_dbusadaptor.h \
+    test_all_interfaces.h \
+    ../../src/pin_screenshots/settings.h \
+    ../../src/pin_screenshots/putils.h \
+    ../../src/pin_screenshots/ui/pinsavemenumanager.h \
+    ../../src/pin_screenshots/service/pinscreenshotsinterface.h \
+    ../../src/pin_screenshots/service/dbuspinscreenshotsadaptor.h \
+    ../../src/utils/log.h
 
 include(../../3rdparty/googletest/gtest_dependency.pri)

--- a/tests/ut_pin_screenshots/ut_pin_settings.h
+++ b/tests/ut_pin_screenshots/ut_pin_settings.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PIN_SETTINGS_H
+#define UT_PIN_SETTINGS_H
+#include <gtest/gtest.h>
+#include "settings.h"
+#include "ui/pinsavemenumanager.h"
+
+class TestPinSettings : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        Settings::release();
+        m_s = Settings::instance();
+    }
+    void TearDown() override
+    {
+        Settings::release();
+    }
+    Settings *m_s;
+};
+
+TEST_F(TestPinSettings, instanceSingleton)
+{
+    Settings *s1 = Settings::instance();
+    Settings *s2 = Settings::instance();
+    EXPECT_EQ(s1, s2);
+}
+
+TEST_F(TestPinSettings, saveOptionRoundTrip)
+{
+    QPair<int, int> opt(DESKTOP, 1);
+    m_s->setSaveOption(opt);
+    QPair<int, int> result = m_s->getSaveOption();
+    EXPECT_EQ(result.first, DESKTOP);
+    EXPECT_EQ(result.second, 1);
+}
+
+TEST_F(TestPinSettings, savePathRoundTrip)
+{
+    m_s->setSavePath("/tmp/test_pin_savepath");
+    EXPECT_EQ(m_s->getSavePath().toStdString(), "/tmp/test_pin_savepath");
+}
+
+TEST_F(TestPinSettings, askSavePathRoundTrip)
+{
+    m_s->setAskSavePath("/tmp/test_pin_askpath");
+    EXPECT_EQ(m_s->getAskSavePath().toStdString(), "/tmp/test_pin_askpath");
+}
+
+TEST_F(TestPinSettings, isChangeSavePathRoundTrip)
+{
+    m_s->setIsChangeSavePath(true);
+    EXPECT_TRUE(m_s->getIsChangeSavePath());
+    m_s->setIsChangeSavePath(false);
+    EXPECT_FALSE(m_s->getIsChangeSavePath());
+}
+
+#endif // UT_PIN_SETTINGS_H

--- a/tests/ut_pin_screenshots/ut_pinsavemenumanager.h
+++ b/tests/ut_pin_screenshots/ut_pinsavemenumanager.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PINSAVEMENUMANAGER_H
+#define UT_PINSAVEMENUMANAGER_H
+#include <gtest/gtest.h>
+#include <QStandardPaths>
+#include "ui/pinsavemenumanager.h"
+#include "settings.h"
+
+class TestPinSaveMenuManager : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        Settings::release();
+        m_mgr = new PinSaveMenuManager(nullptr);
+    }
+    void TearDown() override
+    {
+        if (m_mgr) {
+            delete m_mgr;
+            m_mgr = nullptr;
+        }
+        Settings::release();
+    }
+    PinSaveMenuManager *m_mgr;
+};
+
+TEST_F(TestPinSaveMenuManager, getMenuNotNull)
+{
+    EXPECT_NE(m_mgr->getMenu(), nullptr);
+}
+
+TEST_F(TestPinSaveMenuManager, getCurrentSaveOptionIsValid)
+{
+    int opt = m_mgr->getCurrentSaveOption();
+    EXPECT_TRUE(opt == ASK || opt == DESKTOP || opt == PICTURES ||
+                opt == FOLDER || opt == FOLDER_CHANGE);
+}
+
+TEST_F(TestPinSaveMenuManager, updateCustomPathNonexistentDoesNotCrash)
+{
+    m_mgr->updateCustomPath("/nonexistent/path/that/does/not/exist");
+    SUCCEED();
+}
+
+TEST_F(TestPinSaveMenuManager, updateCustomPathValid)
+{
+    QString tmpDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+    m_mgr->updateCustomPath(tmpDir);
+    SUCCEED();
+}
+
+#endif // UT_PINSAVEMENUMANAGER_H

--- a/tests/ut_pin_screenshots/ut_pinscreenshotsinterface.h
+++ b/tests/ut_pin_screenshots/ut_pinscreenshotsinterface.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PINSCREENSHOTSINTERFACE_H
+#define UT_PINSCREENSHOTSINTERFACE_H
+#include <gtest/gtest.h>
+#include <QDBusConnection>
+#include "service/pinscreenshotsinterface.h"
+
+TEST_F(PinScreenShotsTest, interfaceConstruction)
+{
+    PinScreenShotsInterface *iface = new PinScreenShotsInterface(
+        "com.deepin.PinScreenShots", "/com/deepin/PinScreenShots",
+        QDBusConnection::sessionBus());
+    EXPECT_NE(iface, nullptr);
+    delete iface;
+}
+
+TEST_F(PinScreenShotsTest, interfaceStaticName)
+{
+    EXPECT_STREQ(PinScreenShotsInterface::staticInterfaceName(), "com.deepin.PinScreenShots");
+}
+
+#endif // UT_PINSCREENSHOTSINTERFACE_H

--- a/tests/ut_pin_screenshots/ut_putils.h
+++ b/tests/ut_pin_screenshots/ut_putils.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_PUTILS_H
+#define UT_PUTILS_H
+#include <gtest/gtest.h>
+#include "putils.h"
+
+TEST_F(PinScreenShotsTest, putilsDefaultValues)
+{
+    EXPECT_FALSE(PUtils::isWaylandMode);
+    EXPECT_FALSE(PUtils::isTreelandMode);
+}
+
+TEST_F(PinScreenShotsTest, putilsToggleWaylandMode)
+{
+    PUtils::isWaylandMode = true;
+    EXPECT_TRUE(PUtils::isWaylandMode);
+    PUtils::isWaylandMode = false;
+    EXPECT_FALSE(PUtils::isWaylandMode);
+}
+
+TEST_F(PinScreenShotsTest, putilsToggleTreelandMode)
+{
+    PUtils::isTreelandMode = true;
+    EXPECT_TRUE(PUtils::isTreelandMode);
+    PUtils::isTreelandMode = false;
+    EXPECT_FALSE(PUtils::isTreelandMode);
+}
+
+#endif // UT_PUTILS_H

--- a/tests/ut_screen_shot_recorder/build_run_ut.sh
+++ b/tests/ut_screen_shot_recorder/build_run_ut.sh
@@ -36,10 +36,14 @@ result_report_dir=$build_dir/report/report_ut_screen_shot_recorder.xml
 ASAN_OPTIONS="fast_unwind_on_malloc=1:disable_coredump=1:abort_on_error=0"
 # Per-test isolation: run each test in its own process so a crashing test
 # only loses its own gcda instead of poisoning the whole run. gcda counters
-# accumulate across processes. Slow/hang-prone tests are skipped.
+# accumulate across processes. Slow/hang-prone tests are skipped for coverage
+# but still counted in the report (marked as error).
 test_list=$build_dir/${executable}_tests.txt
 $build_dir/$executable --gtest_list_tests > $test_list 2>/dev/null
 SKIP_TESTS="screenShotShapes screenShot screenRecord scrollShot fullScreenshot fullScreenRecord startRecord stopRecord startAutoScrollShot startManualScrollShot pauseAutoScrollShot continueAutoScrollShot handleManualScrollShot initPadShot delayScreenshot onHelp onViewShortcut fullScreenRecord_screenshotOnly shotCurrentImg shotFullScreen saveTopWindow topWindow initScreenRecorder initScrollShot initBackground setupRegistry waylandwindowinfo"
+# 逐用例生成 JUnit XML 报告（供 CI 统计用例数）；崩/hang 用例无 XML，合并时标记为 error。
+mkdir -p "$build_dir/report_individual"
+: > "$build_dir/ssr_results.tsv"
 last_suite=""
 while IFS= read -r line; do
   case "$line" in
@@ -49,16 +53,99 @@ while IFS= read -r line; do
       base="${tname##*.}"
       skip=0
       for s in $SKIP_TESTS; do [ "$base" = "$s" ] && skip=1 && break; done
-      [ "$skip" = "1" ] && continue
-      timeout 25 $build_dir/$executable --gtest_filter="$tname" >/dev/null 2>&1
+      if [ "$skip" = "1" ]; then
+        printf '%s\t77\n' "$tname" >> "$build_dir/ssr_results.tsv"
+        continue
+      fi
+      safe_name="${tname//[^A-Za-z0-9_]/_}"
+      timeout 25 $build_dir/$executable --gtest_filter="$tname" \
+        --gtest_output=xml:"report_individual/${safe_name}.xml" >/dev/null 2>&1
+      printf '%s\t%d\n' "$tname" "$?" >> "$build_dir/ssr_results.tsv"
       ;;
     *)
       last_suite="$line"
       ;;
   esac
 done < $test_list
-# Generate a JUnit-style report from a single light invocation (non-fatal if it crashes)
-$build_dir/$executable --gtest_filter='*-MainWindowTest.*:*Cov*Test:*CalculaterectTest.*:*ConfigSettingsTest.*:*ShortcutTest.*:*TempFileTest.*:*DBusNameTest.*:*MenuControllerTest.*:*DelayTimeTest.*' --gtest_output=xml:$result_report_dir >/dev/null 2>&1 || true
+
+# 合并逐用例 XML 报告为单一 JUnit XML（供 CI 统计全部用例数）。
+# 崩/hang/skip 用例无 XML，按退出码标记为 error，确保用例总数完整。
+python3 - "$build_dir/report_individual" "$build_dir/ssr_results.tsv" \
+         "$result_report_dir" <<'PYEOF'
+import os, sys
+from xml.etree import ElementTree as ET
+
+indiv_dir, results_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+exit_codes = {}
+with open(results_path) as f:
+    for line in f:
+        parts = line.rstrip('\n').split('\t')
+        if len(parts) == 2:
+            exit_codes[parts[0]] = int(parts[1])
+
+xml_results = {}
+if os.path.isdir(indiv_dir):
+    for fn in os.listdir(indiv_dir):
+        if not fn.endswith('.xml'):
+            continue
+        try:
+            tree = ET.parse(os.path.join(indiv_dir, fn))
+        except ET.ParseError:
+            continue
+        for tc in tree.iter('testcase'):
+            full = f"{tc.get('classname','')}.{tc.get('name','')}"
+            fails = tc.findall('failure')
+            if fails:
+                xml_results[full] = ('fail', tc.get('time','0'), fails[0].get('message',''))
+            elif tc.findall('error'):
+                xml_results[full] = ('error', tc.get('time','0'), '')
+            else:
+                xml_results[full] = ('pass', tc.get('time','0'), '')
+
+suites = {}
+for full_name, rc in exit_codes.items():
+    if '.' not in full_name:
+        continue
+    suite, tname = full_name.rsplit('.', 1)
+    if full_name in xml_results:
+        st, tm, msg = xml_results[full_name]
+    elif rc == 0:
+        st, tm, msg = 'pass', '0', ''
+    elif rc == 1:
+        st, tm, msg = 'fail', '0', 'gtest assertion failure'
+    elif rc == 77:
+        st, tm, msg = 'error', '0', 'skipped (known hang/crash)'
+    else:
+        st, tm, msg = 'error', '0', f'crashed/hang (exit {rc})'
+    suites.setdefault(suite, []).append((tname, st, tm, msg))
+
+root = ET.Element('testsuites')
+total = sum(len(ts) for ts in suites.values())
+total_fail = sum(1 for ts in suites.values() for _, st, _, _ in ts if st == 'fail')
+total_err = sum(1 for ts in suites.values() for _, st, _, _ in ts if st == 'error')
+root.set('tests', str(total)); root.set('failures', str(total_fail))
+root.set('errors', str(total_err)); root.set('disabled', '0')
+root.set('name', 'ut_screen_shot_recorder')
+
+for sname, tests in sorted(suites.items()):
+    ts = ET.SubElement(root, 'testsuite')
+    ts.set('name', sname); ts.set('tests', str(len(tests)))
+    ts.set('failures', str(sum(1 for _, st, _, _ in tests if st == 'fail')))
+    ts.set('errors', str(sum(1 for _, st, _, _ in tests if st == 'error')))
+    ts.set('disabled', '0')
+    for tname, st, tm, msg in tests:
+        tc = ET.SubElement(ts, 'testcase')
+        tc.set('name', tname); tc.set('classname', sname)
+        tc.set('status', 'run'); tc.set('time', tm)
+        if st == 'fail':
+            ET.SubElement(tc, 'failure').set('message', msg)
+        elif st == 'error':
+            ET.SubElement(tc, 'error').set('message', msg)
+
+ET.ElementTree(root).write(out_path, encoding='UTF-8', xml_declaration=True)
+print(f"[INFO] 合并 ssr 报告：{total} 用例，{total_fail} 失败，{total_err} 错误 -> {out_path}")
+PYEOF
 
 lcov -d $build_dir -c -o $build_dir/coverage.info
 


### PR DESCRIPTION
Fix dock plugin script to run all 3 sub-modules, add missing source files to ut_shot_start/ut_shot_start_record .pro to fix link errors, add per-test XML merge for ssr report, add 16 pin_screenshots tests.

修复单元测试用例缺失：补全dock插件3个子模块构建脚本，修复
shot_start/record的链接错误，ssr改为逐用例生成XML并合并为
JUnit报告，新增pin_screenshots模块16个测试用例。

Log: 修复单元测试用例缺失，用例数从26提升至1609
Influence: 单元测试报告从仅ut_record_time的26个用例提升至全部
5个模块共1609个用例，所有模块均正确生成JUnit XML报告。

## Summary by Sourcery

Expand unit test coverage and reporting for screenshot-related modules and dock plugins, ensuring all submodules are built, executed, and correctly aggregated into JUnit XML reports.

New Features:
- Add per-test JUnit XML generation and merged JUnit report for ut_screen_shot_recorder to fully account for passing, failing, and crashing tests.
- Introduce build and run infrastructure plus JUnit and coverage reports for the ut_pin_screenshots module, covering pin screenshot settings, save menu manager, utilities, DBus adaptor, and interface.
- Enable running all three dock plugin test submodules (ut_record_time, ut_shot_start, ut_shot_start_record) from the unified dock plugin test script.

Bug Fixes:
- Fix missing source and header references in ut_shot_start and ut_shot_start_record test projects to resolve link errors.
- Ensure skipped or crash-prone tests in ut_screen_shot_recorder are still counted in CI reports by marking them as errors in the merged JUnit XML.

Enhancements:
- Refine test harness scripts to isolate tests, record exit codes, and robustly merge per-test XML results into single JUnit reports for CI use.
- Adjust ut_pin_screenshots test project configuration to include necessary Qt modules, production sources, and headers, while disabling TSAN/ASAN to avoid false-positive aborts.

Tests:
- Add multiple new unit test cases for pin screenshot settings, save menu manager, utilities, DBus adaptor, and interface, significantly increasing total test count across modules.