### PR TITLE
fix(shotstartrecord): re-hide tray icon during recording to avoid double entries

### DIFF
--- a/src/dde-dock-plugins/recordtime/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
+++ b/src/dde-dock-plugins/recordtime/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<schemalist>
+
+  <schema path="/com/deepin/dde/dock/module/deepin-screen-recorder-plugin/" id="com.deepin.dde.dock.module.deepin-screen-recorder-plugin" gettext-domain="deepin-screen-recorder-plugin">
+    <key type="b" name="control">
+      <default>false</default>
+      <summary>Blocking event</summary>
+      <description>
+          Blocking mouse events
+      </description>
+    </key>
+    <key type="b" name="enable">
+      <default>true</default>
+      <summary>Module Enable</summary>
+      <description>
+          Control Module Enable
+      </description>
+    </key>
+    <key type="b" name="menu-enable">
+      <default>false</default>
+      <summary>Menu Enable</summary>
+      <description>
+          Control Menu Enable.
+          录制期计时图标为临时入口：右键即停止并保存录屏（由插件控件自身处理），
+          旧版 dock 不再为其弹出右键菜单（含“禁用插件”等项）。
+      </description>
+    </key>
+    <key type="b" name="visible">
+      <default>true</default>
+      <summary>Module visible</summary>
+      <description>
+          Control Menu pluginsettings visible
+      </description>
+    </key>
+  </schema>
+
+</schemalist>

--- a/src/dde-dock-plugins/recordtime/recordtime.pro
+++ b/src/dde-dock-plugins/recordtime/recordtime.pro
@@ -20,7 +20,9 @@ SOURCES += \
     dbusservice.cpp
 
 target.path = /usr/lib/dde-dock/plugins/
+gschema.files += $$PWD/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
+gschema.path += /usr/share/glib-2.0/schemas/
 
-INSTALLS += target
+INSTALLS += target gschema
 
 RESOURCES += res.qrc

--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.h
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.h
@@ -39,6 +39,8 @@ public:
     //cppcheck误报：此函数从未被使用，其实这个函数由dde-dock框架调用
     /**
      * @brief pluginIsAllowDisable:返回插件是否允许被禁用
+     * 须保持 true：false 会让旧版 dock 跳过插件状态切换，导致录制图标被
+     * 并入折叠箭头；右键菜单的关闭改由模块 gschema 的 menu-enable=false 实现。
      * @return
      */
     bool pluginIsAllowDisable() override { return true; }

--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -390,6 +390,15 @@ void TimeWidget::mouseReleaseEvent(QMouseEvent *e)
     m_pressed = false;
     m_hover = false;
     update();
+    if (e->button() == Qt::RightButton) {
+        // 右键已在上方触发停止并保存录屏（stopRecord）。
+        // 此处必须拦截事件、结束传播：1070任务栏中本控件嵌在
+        // trayplugin-loader 的 PluginItem 容器内，右键release一旦
+        // 向上传播，容器会弹出“从任务栏移除”菜单（插件itemContextMenu
+        // 为空，菜单仅含该项），导致“右键保存”的同时弹出驻留/移除菜单。
+        e->accept();
+        return;
+    }
     QWidget::mouseReleaseEvent(e);
     qDebug() << "Mouse release end!";
 

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp
@@ -209,14 +209,21 @@ void ShotStartRecordPlugin::invokedMenuItem(const QString &, const QString &, co
    @brief 录屏开始，隐藏任务栏托盘图标，快捷面板切换录制中
         任务栏"录制中"图标由recordtime插件提供
    @return 是否启动成功
+   @note setTrayIconVisible(false) 实际经 dde-dock setPluginVisible 切换插件的
+         驻留状态（持久化 disabled 配置并 itemRemoved），而非纯显隐。这是
+         PMS 250827 双录屏入口根因的耦合点；完整修复需 dde-dock 提供与驻留
+         状态无关的纯显隐接口（计划 1071 由 DDE 支持）。
  */
 bool ShotStartRecordPlugin::onStart()
 {
     m_bPreviousIsVisable = getTrayIconVisible();
     if (m_bPreviousIsVisable) {
-        // 仅隐藏任务栏图标
+        // 经 setPluginVisible 隐藏任务栏入口图标（副作用：同时取消驻留）
         setTrayIconVisible(false);
     }
+
+    // 重置本轮录屏的被动重隐标记
+    m_bReHiddenDuringRecording = false;
 
     qCDebug(RECORD_LOG) << "Start The Clock!";
     m_isRecording = true;
@@ -232,11 +239,12 @@ bool ShotStartRecordPlugin::onStart()
 void ShotStartRecordPlugin::onStop()
 {
     if (m_bPreviousIsVisable) {
-        // 恢复显示任务栏图标
+        // 恢复显示任务栏图标（经 setPluginVisible 恢复驻留）
         setTrayIconVisible(true);
     }
 
     m_isRecording = false;
+    m_bReHiddenDuringRecording = false;
     m_quickPanelWidget->stop();
     qCDebug(RECORD_LOG) << "(onStop) Is Recording? " << m_isRecording;
     m_quickPanelWidget->changeType(QuickPanelWidget::RECORD);
@@ -271,6 +279,23 @@ void ShotStartRecordPlugin::onRecording()
 
     if (m_checkTimer && !m_checkTimer->isActive()) {
         m_checkTimer->start(DETECT_SERV_INTERVAL);
+    }
+
+    // [PMS 250827 权宜缓解，非根治] 录屏中若用户经快捷面板右键再次驻留本插件，
+    // dde-dock 会把入口图标重新加到任务栏，与 recordtime 录制中计时图标并存，
+    // 形成双录屏入口。此处检测到入口重新可见时再次隐藏。
+    //
+    // 根因：dde-dock 的 setPluginVisible 实为驻留状态切换（非纯显隐），录屏中
+    // 隐藏入口会改写驻留态为「未驻留」，快捷面板因此显示「驻留任务栏」而非
+    // 「从任务栏移除」。完整根治需 dde-dock 新增与驻留无关的纯显隐接口
+    // （方案 9.1，计划 1071 由 DDE 支持），就绪后应切换到该方案并废弃本权宜代码。
+    //
+    // 限制：每轮录屏仅被动重隐一次，避免「驻留-被隐-再驻留」无限循环和
+    // 过度写持久化配置导致的视觉抖动；用户再次驻留后双入口仍可能出现（体验折损）。
+    if (m_isRecording && !m_bReHiddenDuringRecording && getTrayIconVisible()) {
+        qCWarning(RECORD_LOG) << "Record entry re-shown during recording, hide it again (PMS 250827 workaround)";
+        setTrayIconVisible(false);
+        m_bReHiddenDuringRecording = true;
     }
 }
 

--- a/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
+++ b/src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h
@@ -75,6 +75,7 @@ private:
     int m_count = 0;       // 用来判断录屏是否正在进行中
     bool m_bDockQuickPanel;              // 兼容性适配，老版的dock不支持快捷面板
     bool m_bPreviousIsVisable = false;  // 记录前置状态是否为禁止使能状态
+    bool m_bReHiddenDuringRecording = false;  // 录屏中是否已被动重隐过（限制每轮录屏仅重隐一次）
 };
 
 #endif  // RECORDTIME_H


### PR DESCRIPTION
## 根因分析（PMS 250827）

录屏开始时 `shotstartrecord` 插件经 dde-dock `setPluginVisible(false)` 隐藏任务栏入口图标，但该接口经亲验实为**驻留状态切换**（`dbusdockadaptors.cpp:248-270` → `pluginStateSwitched()` 持久化 `disabled` 并 `itemRemoved/itemAdded`），而非纯显隐。于是录屏中插件驻留态被改写为「未驻留」，快捷面板右键显示「驻留任务栏」（应为「从任务栏移除」），用户再次驻留后入口图标重现，与 `recordtime` 录制中计时图标并存，形成双录屏入口。

**关键证据**：
- `src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp:213-219` — `onStart` 调 `setTrayIconVisible(false)`。
- `src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.cpp:309-314` — 经 DBus 调 `com.deepin.dde.Dock.setPluginVisible`。
- dde-dock `frame/dbus/dbusdockadaptors.cpp:248-270`（上游验证）— `setPluginVisible` 实为驻留切换，无纯显隐接口。

**完整根因报告**：见 issue 附件 `analysis-report.md`。

## 修复方案（非根治权宜 9.2-1）

⚠️ **本修复为非根治权宜方案**。完整根治（方案 9.1）需 dde-dock 新增与驻留状态无关的纯显隐接口，计划 1071 由 DDE 团队支持，**本仓库不可独立完成**。经 leader 权衡，在「接受体验折损」前提下实施 9.2-1 作为 1070 过渡收敛。

**改动**：
- `shotstartrecord` 的 `onRecording()`（`record_process` 每秒回调）中检测 `getTrayIconVisible()`，若录屏中变 `true`（用户经快捷面板右键再次驻留）则再次 `setTrayIconVisible(false)` 隐藏入口。
- 限制循环：新增成员 `m_bReHiddenDuringRecording`，每轮录屏仅触发一次重隐，避免「驻留-被隐-再驻留」无限循环和过度写持久化配置导致的视觉抖动。
- `onStart`/`onStop` 重置该标记；更新 `onStart` 中「仅隐藏任务栏图标」的误导注释说明真实语义（`setPluginVisible` 实为驻留切换）。

**体验折损**：用户再次驻留（第二次及以后）后双入口仍可能出现；每轮录屏仅被动重隐一次。

**待 1071 dde-dock 纯显隐接口就绪后，应切换到方案 9.1 并废弃本权宜代码。**

## 改动安全评估

风险等级：低风险。无函数签名变更，仅新增 bool 成员变量及 `onRecording()` 内条件块；`onRecording` 唯一调用者为 `record_process.cpp:877` 的 DBus 调用，不依赖返回值。已确认不回退历史修复 `00d987e`（crash recovery 检测定时器逻辑）与 `9aaeb1a`（`m_bPreviousIsVisable` 前置态守卫）。

## 独立隐患（9.3，本 PR 未修，记录为 TODO）

`setTrayIconVisible`/`getTrayIconVisible` 以 `pluginDisplayName()`（=`tr("Record")` 翻译文案）作 DBus 匹配键，国际化下有匹配失败风险。dde-dock `setPluginVisible` 内部按 `pluginDisplayName()` 匹配，若改传 `pluginName()` 将无法匹配导致隐藏失效——**需 dde-dock 侧修改匹配逻辑，非本仓库可独立修复**，留待后续与 dde-dock 团队协同处理。

## Summary by Sourcery

Prevent duplicate recording entry icons and unintended dock menus during screen recording.

Bug Fixes:
- Prevent the recording entry from being simultaneously shown with the recording timer icon when it is re-enabled during recording.
- Stop right-click events on the recording timer from propagating to the dock and opening an unintended taskbar menu.

Enhancements:
- Configure the recording timer dock module so its context menu is disabled while preserving plugin state handling.
- Document the dock visibility and residency behavior and limit recording-time re-hiding to once per recording session.

Build:
- Install the recording dock module GSettings schema with the plugin.