### PR TITLE
test(pin-screenshots): add adaptor, interface and menu manager cases

### DIFF
--- a/tests/ut_pin_screenshots/ut_dbusadaptor.h
+++ b/tests/ut_pin_screenshots/ut_dbusadaptor.h
@@ -6,7 +6,18 @@
 #define UT_DBUSADAPTOR_H
 #include <gtest/gtest.h>
 #include <QObject>
+#include <QBuffer>
+#include <QImage>
+#include <QPoint>
 #include "service/dbuspinscreenshotsadaptor.h"
+
+static inline QByteArray encodeImageForAdaptor(const QImage &img)
+{
+    QByteArray raw;
+    QBuffer stream(&raw);
+    img.save(&stream, "PNG");
+    return qCompress(raw, 9).toBase64();
+}
 
 TEST_F(PinScreenShotsTest, adaptorConstruction)
 {
@@ -22,6 +33,50 @@ TEST_F(PinScreenShotsTest, adaptorParentSet)
     DbusPinScreenShotsAdaptor *adaptor = new DbusPinScreenShotsAdaptor(parent);
     EXPECT_EQ(adaptor->parent(), parent);
     delete parent;
+}
+
+TEST_F(PinScreenShotsTest, adaptorOpenImage)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor adaptor(&parent);
+    QImage img(8, 8, QImage::Format_ARGB32);
+    img.fill(Qt::red);
+    adaptor.openImage(encodeImageForAdaptor(img));
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, adaptorOpenImageEmptyData)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor adaptor(&parent);
+    adaptor.openImage(QByteArray());
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, adaptorOpenImageAndName)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor adaptor(&parent);
+    QImage img(16, 16, QImage::Format_ARGB32);
+    img.fill(Qt::blue);
+    adaptor.openImageAndName(encodeImageForAdaptor(img), QStringLiteral("test.png"), QPoint(10, 20));
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, adaptorOpenImageAndNameEmptyData)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor adaptor(&parent);
+    adaptor.openImageAndName(QByteArray(), QStringLiteral("empty.png"), QPoint(0, 0));
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, adaptorOpenFile)
+{
+    QObject parent;
+    DbusPinScreenShotsAdaptor adaptor(&parent);
+    bool ret = adaptor.openFile(QStringLiteral("/tmp/test_screenshot.png"));
+    EXPECT_TRUE(ret);
 }
 
 #endif // UT_DBUSADAPTOR_H

--- a/tests/ut_pin_screenshots/ut_pinsavemenumanager.h
+++ b/tests/ut_pin_screenshots/ut_pinsavemenumanager.h
@@ -6,6 +6,8 @@
 #define UT_PINSAVEMENUMANAGER_H
 #include <gtest/gtest.h>
 #include <QStandardPaths>
+#include <QAction>
+#include <DMenu>
 #include "ui/pinsavemenumanager.h"
 #include "settings.h"
 
@@ -15,6 +17,9 @@ public:
     void SetUp() override
     {
         Settings::release();
+        Settings *s = Settings::instance();
+        s->setSavePath(QString());
+        s->setSaveOption(qMakePair(ASK, 0));
         m_mgr = new PinSaveMenuManager(nullptr);
     }
     void TearDown() override
@@ -24,6 +29,36 @@ public:
             m_mgr = nullptr;
         }
         Settings::release();
+    }
+    QAction *askEveryTimeAction() const
+    {
+        QList<QAction*> acts = m_mgr->getMenu()->actions();
+        return acts.isEmpty() ? nullptr : acts.first();
+    }
+    QAction *specifiedLocationMenuAction() const
+    {
+        QList<QAction*> acts = m_mgr->getMenu()->actions();
+        return acts.size() > 1 ? acts.at(1) : nullptr;
+    }
+    DMenu *specifiedLocationSubMenu() const
+    {
+        QAction *ma = specifiedLocationMenuAction();
+        return ma ? ma->menu() : nullptr;
+    }
+    QList<QAction*> locationActions() const
+    {
+        DMenu *sub = specifiedLocationSubMenu();
+        return sub ? sub->actions() : QList<QAction*>();
+    }
+    void invokeSaveOptionSlot(QAction *action)
+    {
+        QMetaObject::invokeMethod(m_mgr, "onSaveOptionTriggered",
+                                  Qt::DirectConnection, Q_ARG(QAction*, action));
+    }
+    void invokeLocationSlot(QAction *action)
+    {
+        QMetaObject::invokeMethod(m_mgr, "onLocationActionTriggered",
+                                  Qt::DirectConnection, Q_ARG(QAction*, action));
     }
     PinSaveMenuManager *m_mgr;
 };
@@ -50,6 +85,73 @@ TEST_F(TestPinSaveMenuManager, updateCustomPathValid)
 {
     QString tmpDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
     m_mgr->updateCustomPath(tmpDir);
+    SUCCEED();
+}
+
+TEST_F(TestPinSaveMenuManager, saveOptionTriggeredAskEveryTime)
+{
+    QAction *ask = askEveryTimeAction();
+    ASSERT_NE(ask, nullptr);
+    ask->setChecked(true);
+    invokeSaveOptionSlot(ask);
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), ASK);
+}
+
+TEST_F(TestPinSaveMenuManager, saveOptionTriggeredSpecifiedLocationWithDesktop)
+{
+    QList<QAction*> locActs = locationActions();
+    ASSERT_GE(locActs.size(), 1);
+    locActs.at(0)->setChecked(true);
+    QAction *menuAction = specifiedLocationMenuAction();
+    ASSERT_NE(menuAction, nullptr);
+    invokeSaveOptionSlot(menuAction);
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), DESKTOP);
+}
+
+TEST_F(TestPinSaveMenuManager, saveOptionTriggeredSpecifiedLocationNoChild)
+{
+    QAction *menuAction = specifiedLocationMenuAction();
+    ASSERT_NE(menuAction, nullptr);
+    menuAction->setChecked(true);
+    invokeSaveOptionSlot(menuAction);
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), ASK);
+}
+
+TEST_F(TestPinSaveMenuManager, saveOptionTriggeredUnknownAction)
+{
+    QAction unknown("unknown", nullptr);
+    invokeSaveOptionSlot(&unknown);
+    SUCCEED();
+}
+
+TEST_F(TestPinSaveMenuManager, locationActionTriggeredDesktop)
+{
+    QList<QAction*> locActs = locationActions();
+    ASSERT_GE(locActs.size(), 1);
+    invokeLocationSlot(locActs.at(0));
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), DESKTOP);
+}
+
+TEST_F(TestPinSaveMenuManager, locationActionTriggeredPictures)
+{
+    QList<QAction*> locActs = locationActions();
+    ASSERT_GE(locActs.size(), 2);
+    invokeLocationSlot(locActs.at(1));
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), PICTURES);
+}
+
+TEST_F(TestPinSaveMenuManager, locationActionTriggeredFolderChange)
+{
+    QList<QAction*> locActs = locationActions();
+    ASSERT_GE(locActs.size(), 3);
+    invokeLocationSlot(locActs.at(2));
+    EXPECT_EQ(m_mgr->getCurrentSaveOption(), FOLDER_CHANGE);
+}
+
+TEST_F(TestPinSaveMenuManager, locationActionTriggeredUnknown)
+{
+    QAction unknown("unknown", nullptr);
+    invokeLocationSlot(&unknown);
     SUCCEED();
 }
 

--- a/tests/ut_pin_screenshots/ut_pinscreenshotsinterface.h
+++ b/tests/ut_pin_screenshots/ut_pinscreenshotsinterface.h
@@ -6,6 +6,8 @@
 #define UT_PINSCREENSHOTSINTERFACE_H
 #include <gtest/gtest.h>
 #include <QDBusConnection>
+#include <QImage>
+#include <QPoint>
 #include "service/pinscreenshotsinterface.h"
 
 TEST_F(PinScreenShotsTest, interfaceConstruction)
@@ -20,6 +22,57 @@ TEST_F(PinScreenShotsTest, interfaceConstruction)
 TEST_F(PinScreenShotsTest, interfaceStaticName)
 {
     EXPECT_STREQ(PinScreenShotsInterface::staticInterfaceName(), "com.deepin.PinScreenShots");
+}
+
+TEST_F(PinScreenShotsTest, interfaceOpenImage)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img(8, 8, QImage::Format_ARGB32);
+    img.fill(Qt::red);
+    iface.openImage(img);
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, interfaceOpenImageNull)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img;
+    iface.openImage(img);
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, interfaceOpenImageAndName)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img(16, 16, QImage::Format_ARGB32);
+    img.fill(Qt::green);
+    iface.openImageAndName(img, QStringLiteral("shot.png"), QPoint(5, 5));
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, interfaceOpenImageAndNameNull)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img;
+    iface.openImageAndName(img, QStringLiteral("empty.png"), QPoint(0, 0));
+    SUCCEED();
+}
+
+TEST_F(PinScreenShotsTest, interfaceOpenFile)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    iface.openFile(QStringLiteral("/tmp/test_screenshot.png"));
+    SUCCEED();
 }
 
 #endif // UT_PINSCREENSHOTSINTERFACE_H


### PR DESCRIPTION
Add test cases for DBus adaptor image APIs, screenshots interface open* methods and pin save menu manager actions.

补充贴图 DBus 适配器图像接口、screenshots 接口 open 系列方法
与贴图保存菜单管理器动作的测试用例。

Log: 补充贴图模块单测用例
Influence: 仅影响单元测试，提升 pin-screenshots 模块测试覆盖率。

## Summary by Sourcery

Tests:
- Expand pin-screenshots unit-test coverage for DBus image and file APIs, screenshots interface open methods, and save-location menu actions, including valid, empty, null, and unknown-action cases.