### PR TITLE
test(dde-dock-plugins): add interface and coverage tests for plugins

### DIFF
--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time.pro
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time.pro
@@ -40,7 +40,9 @@ SOURCES += \
     ../../../src/dde-dock-plugins/recordtime/dbusservice.cpp \
     ut_mock_stub_recordtimeplugin.cpp \
     ut_timewidget.cpp \
-    ut_dbusservice.cpp
+    ut_timewidget_interface.cpp \
+    ut_dbusservice.cpp \
+    ut_record_time_cov2.cpp
 
 INCLUDEPATH += /usr/include/dde-dock
 include(../../../3rdparty/googletest/gtest_dependency.pri)

--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time_cov2.cpp
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_record_time_cov2.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QShowEvent>
+#include <QVariant>
+#include <QMetaObject>
+#include <QDBusConnection>
+
+#include "ut_mock_pluginproxyinterface.h"
+
+#define protected public
+#define private public
+#include "../../../src/dde-dock-plugins/recordtime/timewidget.h"
+#include "../../../src/dde-dock-plugins/recordtime/recordtimeplugin.h"
+#undef protected
+#undef private
+
+namespace {
+class TestRecordTimeCov2 : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_plugin.reset(new RecordTimePlugin());
+        m_plugin->init(&mock_proxy);
+        if (!m_plugin->m_timeWidget)
+            m_plugin->m_timeWidget = new TimeWidget();
+    }
+    void TearDown() override {}
+
+public:
+    MockPluginProxyInterface mock_proxy;
+    std::shared_ptr<RecordTimePlugin> m_plugin;
+};
+
+class TestTimeWidgetCov2 : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_widget = new TimeWidget();
+    }
+    void TearDown() override
+    {
+        if (m_widget)
+            delete m_widget;
+    }
+
+public:
+    TimeWidget *m_widget;
+};
+}
+
+TEST_F(TestRecordTimeCov2, flags)
+{
+    Dock::PluginFlags expected = Dock::Type_System | Dock::Attribute_ForceDock | Dock::Attribute_Normal;
+    EXPECT_EQ(expected, m_plugin->flags());
+}
+
+TEST_F(TestRecordTimeCov2, pluginSizePolicy)
+{
+    EXPECT_EQ(PluginsItemInterface::Custom, m_plugin->pluginSizePolicy());
+}
+
+TEST_F(TestRecordTimeCov2, pluginIsDisableReturnsFalse)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(false)));
+    EXPECT_FALSE(m_plugin->pluginIsDisable());
+}
+
+TEST_F(TestRecordTimeCov2, pluginIsDisableReturnsTrue)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(true)));
+    EXPECT_TRUE(m_plugin->pluginIsDisable());
+}
+
+TEST_F(TestRecordTimeCov2, pluginStateSwitchedToDisabled)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(false)));
+    EXPECT_CALL(mock_proxy, saveValue(testing::_, testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    EXPECT_CALL(mock_proxy, itemRemoved(testing::_, testing::_))
+        .Times(testing::AtLeast(1));
+    EXPECT_CALL(mock_proxy, itemAdded(testing::_, testing::_))
+        .Times(testing::Exactly(0));
+    m_plugin->pluginStateSwitched();
+}
+
+TEST_F(TestRecordTimeCov2, pluginStateSwitchedToEnabled)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(true)));
+    EXPECT_CALL(mock_proxy, saveValue(testing::_, testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    EXPECT_CALL(mock_proxy, itemRemoved(testing::_, testing::_))
+        .Times(testing::Exactly(0));
+    EXPECT_CALL(mock_proxy, itemAdded(testing::_, testing::_))
+        .Times(testing::AtLeast(1));
+    m_plugin->pluginStateSwitched();
+}
+
+TEST_F(TestRecordTimeCov2, onRecordingCreatesWatcher)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(false)));
+    EXPECT_CALL(mock_proxy, itemRemoved(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    EXPECT_CALL(mock_proxy, itemAdded(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    m_plugin->m_bshow = true;
+    m_plugin->onRecording();
+    EXPECT_NE(nullptr, m_plugin->m_serviceWatcher);
+}
+
+TEST_F(TestRecordTimeCov2, onRecordingNullWidgetCallsOnStart)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(false)));
+    EXPECT_CALL(mock_proxy, itemRemoved(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    EXPECT_CALL(mock_proxy, itemAdded(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    if (m_plugin->m_timeWidget) {
+        delete m_plugin->m_timeWidget.data();
+        m_plugin->m_timeWidget = nullptr;
+    }
+    m_plugin->onRecording();
+    EXPECT_NE(nullptr, m_plugin->m_timeWidget);
+}
+
+TEST_F(TestRecordTimeCov2, onRecordingLambdaTriggersOnStop)
+{
+    EXPECT_CALL(mock_proxy, getValue(testing::_, testing::_, testing::_))
+        .WillRepeatedly(testing::Return(QVariant(false)));
+    EXPECT_CALL(mock_proxy, itemRemoved(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    EXPECT_CALL(mock_proxy, itemAdded(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+    m_plugin->m_bshow = true;
+    m_plugin->onRecording();
+    ASSERT_NE(nullptr, m_plugin->m_serviceWatcher);
+    QMetaObject::invokeMethod(m_plugin->m_serviceWatcher,
+        "serviceUnregistered", Qt::DirectConnection,
+        Q_ARG(QString, QString("com.deepin.ScreenRecorder")));
+}
+
+TEST_F(TestTimeWidgetCov2, setting)
+{
+    EXPECT_NE(nullptr, m_widget->setting());
+}
+
+TEST_F(TestTimeWidgetCov2, showEvent)
+{
+    QShowEvent event;
+    m_widget->showEvent(&event);
+}

--- a/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget_interface.cpp
+++ b/tests/ut_dde_dock_plugins/ut_record_time/ut_timewidget_interface.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QDBusConnection>
+
+#include "../../../src/dde-dock-plugins/recordtime/timewidget_interface.h"
+
+namespace {
+class TimewidgetInterfaceTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_iface = new timewidget_interface(
+            QStringLiteral("org.deepin.dde.daemon.Dock1"),
+            QStringLiteral("/org/deepin/dde/daemon/Dock1"),
+            QDBusConnection::sessionBus());
+    }
+    void TearDown() override
+    {
+        if (m_iface) {
+            delete m_iface;
+            m_iface = nullptr;
+        }
+    }
+    timewidget_interface *m_iface = nullptr;
+};
+} // namespace
+
+// ---- getters ----
+TEST_F(TimewidgetInterfaceTest, DisplayMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->displayMode());
+}
+
+TEST_F(TimewidgetInterfaceTest, FrontendWindowRect_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->frontendWindowRect());
+}
+
+TEST_F(TimewidgetInterfaceTest, HideMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideMode());
+}
+
+TEST_F(TimewidgetInterfaceTest, HideState_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideState());
+}
+
+TEST_F(TimewidgetInterfaceTest, WindowSizeEfficient_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeEfficient());
+}
+
+TEST_F(TimewidgetInterfaceTest, WindowSizeFashion_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeFashion());
+}
+
+// ---- setters ----
+TEST_F(TimewidgetInterfaceTest, DisplayMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setDisplayMode(0));
+}
+
+TEST_F(TimewidgetInterfaceTest, HideMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setHideMode(0));
+}
+
+TEST_F(TimewidgetInterfaceTest, Position_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setPosition(1));
+}
+
+TEST_F(TimewidgetInterfaceTest, WindowSizeEfficient_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeEfficient(100u));
+}
+
+TEST_F(TimewidgetInterfaceTest, WindowSizeFashion_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeFashion(100u));
+}
+
+// ---- D-Bus methods ----
+TEST_F(TimewidgetInterfaceTest, IsDocked_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsDocked(QStringLiteral("test.desktop")));
+}
+
+TEST_F(TimewidgetInterfaceTest, RequestDock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestDock(QStringLiteral("test.desktop"), 0));
+}
+
+TEST_F(TimewidgetInterfaceTest, RequestUndock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestUndock(QStringLiteral("test.desktop")));
+}
+
+// ---- staticInterfaceName ----
+TEST_F(TimewidgetInterfaceTest, StaticInterfaceName_ReturnsInterfaceName)
+{
+    EXPECT_STRNE(nullptr, timewidget_interface::staticInterfaceName());
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_commoniconbutton_cov.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_commoniconbutton_cov.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QIcon>
+#include <DGuiApplicationHelper>
+DGUI_USE_NAMESPACE
+
+#include "stub.h"
+
+static DGuiApplicationHelper::ColorType lightTheme_stub() {
+    return DGuiApplicationHelper::LightType;
+}
+
+#include "../../../src/dde-dock-plugins/shotstart/commoniconbutton.h"
+
+namespace {
+class CommonIconButtonCovTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_btn = new CommonIconButton(nullptr);
+        m_btn->show();
+    }
+    void TearDown() override
+    {
+        if (m_btn) {
+            delete m_btn;
+            m_btn = nullptr;
+        }
+    }
+    CommonIconButton *m_btn = nullptr;
+};
+} // namespace
+
+TEST_F(CommonIconButtonCovTest, SetClickable_ToggleState_NoException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setClickable(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setClickable(false));
+}
+
+TEST_F(CommonIconButtonCovTest, SetRotatable_TrueThenFalse_CleansTimer)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setRotatable(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setRotatable(false));
+}
+
+TEST_F(CommonIconButtonCovTest, StartRotate_TriggersRotationAnimation)
+{
+    m_btn->setRotatable(true);
+    EXPECT_NO_FATAL_FAILURE(m_btn->startRotate());
+}
+
+TEST_F(CommonIconButtonCovTest, StopRotate_StopsTimerAndResetsAngle)
+{
+    m_btn->setRotatable(true);
+    m_btn->startRotate();
+    EXPECT_NO_FATAL_FAILURE(m_btn->stopRotate());
+}
+
+TEST_F(CommonIconButtonCovTest, SetHoverIcon_StoresIcon)
+{
+    QIcon icon;
+    EXPECT_NO_FATAL_FAILURE(m_btn->setHoverIcon(icon));
+}
+
+TEST_F(CommonIconButtonCovTest, SetActiveState_TogglesHighlight)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setActiveState(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setActiveState(false));
+}
+
+TEST_F(CommonIconButtonCovTest, SetStateIconMapping_AppliesMapping)
+{
+    QMap<CommonIconButton::State, QPair<QString, QString>> mapping;
+    mapping.insert(CommonIconButton::On, qMakePair(QString("on"), QString("on-fallback")));
+    mapping.insert(CommonIconButton::Off, qMakePair(QString("off"), QString("off-fallback")));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setStateIconMapping(mapping));
+}
+
+TEST_F(CommonIconButtonCovTest, SetState_WithMapping_AppliesIconFromMapping)
+{
+    QMap<CommonIconButton::State, QPair<QString, QString>> mapping;
+    mapping.insert(CommonIconButton::On, qMakePair(QString("edit"), QString("")));
+    m_btn->setStateIconMapping(mapping);
+    EXPECT_NO_FATAL_FAILURE(m_btn->setState(CommonIconButton::On));
+}
+
+TEST_F(CommonIconButtonCovTest, SetState_WithoutMapping_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setState(CommonIconButton::Default));
+}
+
+TEST_F(CommonIconButtonCovTest, RefreshIcon_ReappliesCurrentState)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->refreshIcon());
+}
+
+TEST_F(CommonIconButtonCovTest, SetIconWithStringAndSuffix_LoadsThemeIcon)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setIcon(QStringLiteral("edit"), QStringLiteral("edit-fallback"), QStringLiteral(".svg")));
+}
+
+TEST_F(CommonIconButtonCovTest, PaintEvent_RendersWidgetWithoutException)
+{
+    QPaintEvent pe(m_btn->rect());
+    EXPECT_NO_FATAL_FAILURE(m_btn->paintEvent(&pe));
+}
+
+TEST_F(CommonIconButtonCovTest, MousePressEvent_RecordsPressPosition)
+{
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(CommonIconButtonCovTest, MouseReleaseEvent_ClickableEmitsClickedSignal)
+{
+    m_btn->setClickable(true);
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+    QTest::mouseRelease(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(CommonIconButtonCovTest, MouseReleaseEvent_RotatableStartsRotation)
+{
+    m_btn->setClickable(true);
+    m_btn->setRotatable(true);
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+    QTest::mouseRelease(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(CommonIconButtonCovTest, SetIcon_LightTheme_TriggersDarkMarkLambda)
+{
+    Stub s;
+    s.set(ADDR(DGuiApplicationHelper, themeType), lightTheme_stub);
+    EXPECT_NO_FATAL_FAILURE(m_btn->setIcon(QStringLiteral("edit"), QStringLiteral("edit-fallback"), QStringLiteral(".svg")));
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_iconwidget_interface.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_iconwidget_interface.cpp
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QDBusConnection>
+#include <QDBusPendingReply>
+
+#include "../../../src/dde-dock-plugins/shotstart/iconwidget_interface.h"
+
+namespace {
+class IconwidgetInterfaceTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_iface = new iconwidget_interface(
+            QStringLiteral("org.deepin.dde.daemon.Dock1"),
+            QStringLiteral("/org/deepin/dde/daemon/Dock1"),
+            QDBusConnection::sessionBus());
+    }
+    void TearDown() override
+    {
+        if (m_iface) {
+            delete m_iface;
+            m_iface = nullptr;
+        }
+    }
+    iconwidget_interface *m_iface = nullptr;
+};
+} // namespace
+
+// ---- property getters ----
+TEST_F(IconwidgetInterfaceTest, DisplayMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->displayMode());
+}
+
+TEST_F(IconwidgetInterfaceTest, DockedApps_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->dockedApps());
+}
+
+TEST_F(IconwidgetInterfaceTest, Entries_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->entries());
+}
+
+TEST_F(IconwidgetInterfaceTest, FrontendWindowRect_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->frontendWindowRect());
+}
+
+TEST_F(IconwidgetInterfaceTest, HideMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideMode());
+}
+
+TEST_F(IconwidgetInterfaceTest, HideState_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideState());
+}
+
+TEST_F(IconwidgetInterfaceTest, HideTimeout_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideTimeout());
+}
+
+TEST_F(IconwidgetInterfaceTest, IconSize_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->iconSize());
+}
+
+TEST_F(IconwidgetInterfaceTest, Opacity_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->opacity());
+}
+
+TEST_F(IconwidgetInterfaceTest, ShowTimeout_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->showTimeout());
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSize_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSize());
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSizeEfficient_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeEfficient());
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSizeFashion_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeFashion());
+}
+
+// ---- property setters ----
+TEST_F(IconwidgetInterfaceTest, DisplayMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setDisplayMode(0));
+}
+
+TEST_F(IconwidgetInterfaceTest, HideMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setHideMode(0));
+}
+
+TEST_F(IconwidgetInterfaceTest, HideTimeout_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setHideTimeout(30u));
+}
+
+TEST_F(IconwidgetInterfaceTest, IconSize_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setIconSize(48u));
+}
+
+TEST_F(IconwidgetInterfaceTest, Opacity_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setOpacity(0.5));
+}
+
+TEST_F(IconwidgetInterfaceTest, Position_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setPosition(1));
+}
+
+TEST_F(IconwidgetInterfaceTest, ShowTimeout_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setShowTimeout(20u));
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSize_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSize(100u));
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSizeEfficient_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeEfficient(100u));
+}
+
+TEST_F(IconwidgetInterfaceTest, WindowSizeFashion_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeFashion(100u));
+}
+
+// ---- D-Bus methods ----
+TEST_F(IconwidgetInterfaceTest, ActivateWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->ActivateWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, CancelPreviewWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->CancelPreviewWindow());
+}
+
+TEST_F(IconwidgetInterfaceTest, CloseWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->CloseWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, GetDockedAppsDesktopFiles_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetDockedAppsDesktopFiles());
+}
+
+TEST_F(IconwidgetInterfaceTest, GetEntryIDs_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetEntryIDs());
+}
+
+TEST_F(IconwidgetInterfaceTest, GetPluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetPluginSettings());
+}
+
+TEST_F(IconwidgetInterfaceTest, IsDocked_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsDocked(QStringLiteral("test.desktop")));
+}
+
+TEST_F(IconwidgetInterfaceTest, IsOnDock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsOnDock(QStringLiteral("test.desktop")));
+}
+
+TEST_F(IconwidgetInterfaceTest, MakeWindowAbove_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MakeWindowAbove(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, MaximizeWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MaximizeWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, MergePluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MergePluginSettings(QStringLiteral("cfg")));
+}
+
+TEST_F(IconwidgetInterfaceTest, MinimizeWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MinimizeWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, MoveEntry_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MoveEntry(0, 1));
+}
+
+TEST_F(IconwidgetInterfaceTest, MoveWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MoveWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, PreviewWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->PreviewWindow(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, QueryWindowIdentifyMethod_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->QueryWindowIdentifyMethod(1u));
+}
+
+TEST_F(IconwidgetInterfaceTest, RemovePluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RemovePluginSettings(QStringLiteral("key"), QStringList{}));
+}
+
+TEST_F(IconwidgetInterfaceTest, RequestDock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestDock(QStringLiteral("test.desktop"), 0));
+}
+
+TEST_F(IconwidgetInterfaceTest, RequestUndock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestUndock(QStringLiteral("test.desktop")));
+}
+
+TEST_F(IconwidgetInterfaceTest, SetFrontendWindowRect_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetFrontendWindowRect(0, 0, 100u, 100u));
+}
+
+TEST_F(IconwidgetInterfaceTest, SetPluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetPluginSettings(QStringLiteral("cfg")));
+}
+
+// ---- staticInterfaceName / constructor / destructor ----
+TEST_F(IconwidgetInterfaceTest, StaticInterfaceName_ReturnsDockInterfaceName)
+{
+    EXPECT_STRNE(nullptr, iconwidget_interface::staticInterfaceName());
+}
+
+TEST_F(IconwidgetInterfaceTest, Constructor_WithNullService_ConstructsObject)
+{
+    iconwidget_interface *iface = new iconwidget_interface(
+        QStringLiteral(""), QStringLiteral("/test"),
+        QDBusConnection::sessionBus());
+    delete iface;
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start.pro
@@ -7,7 +7,7 @@ include(../../../3rdparty/stub_linux/stub.pri)
 
 TARGET = ut_shot_start
 
-QMAKE_CXXFLAGS += -g -Wno-error=deprecated-declarations -Wno-deprecated-declarations -Wall -fprofile-arcs -ftest-coverage -O0
+QMAKE_CXXFLAGS += -g -Wno-error=deprecated-declarations -Wno-deprecated-declarations -Wall -fprofile-arcs -ftest-coverage -O0 -fno-access-control
 QMAKE_LFLAGS += -g -Wall -fprofile-arcs -ftest-coverage  -O0
 
 #内存检测标签
@@ -47,8 +47,11 @@ SOURCES += \
     ../../../src/dde-dock-plugins/shotstart/quickpanelwidget.cpp \
     ../../../src/dde-dock-plugins/shotstart/commoniconbutton.cpp \
     ut_iconwidget.cpp \
+    ut_iconwidget_interface.cpp \
+    ut_commoniconbutton_cov.cpp \
     ut_shotstartplugin.cpp \
-    ut_tipswidget.cpp
+    ut_tipswidget.cpp \
+    ut_shot_start_cov2.cpp
 
 INCLUDEPATH += /usr/include/dde-dock
 include(../../../3rdparty/googletest/gtest_dependency.pri)

--- a/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start_cov2.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start/ut_shot_start_cov2.cpp
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QEvent>
+#include <QIcon>
+#include <QVariant>
+#include <QDebug>
+
+#include "../../../src/dde-dock-plugins/shotstart/iconwidget.h"
+#include "../../../src/dde-dock-plugins/shotstart/quickpanelwidget.h"
+#include "../../../src/dde-dock-plugins/shotstart/shotstartplugin.h"
+#include "ut_mock_pluginproxyinterface.h"
+
+namespace {
+class IconWidgetCovTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_iconWidget = new IconWidget(nullptr);
+        m_iconWidget->show();
+    }
+    void TearDown() override
+    {
+        if (m_iconWidget) {
+            delete m_iconWidget;
+            m_iconWidget = nullptr;
+        }
+    }
+    IconWidget *m_iconWidget = nullptr;
+};
+
+class QuickPanelWidgetCovTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_quickPanel = new QuickPanelWidget(nullptr);
+        m_quickPanel->show();
+    }
+    void TearDown() override
+    {
+        if (m_quickPanel) {
+            delete m_quickPanel;
+            m_quickPanel = nullptr;
+        }
+    }
+    QuickPanelWidget *m_quickPanel = nullptr;
+};
+
+class ShotStartPluginCovTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_plugin.reset(new ShotStartPlugin());
+        m_plugin->init(&mock_proxy);
+    }
+    void TearDown() override {}
+
+    MockPluginProxyInterface mock_proxy;
+    std::shared_ptr<ShotStartPlugin> m_plugin;
+};
+} // namespace
+
+TEST_F(IconWidgetCovTest, MouseMoveEvent_SetsHoverState)
+{
+    QMouseEvent me(QEvent::MouseMove, QPointF(1, 1), QPointF(1, 1),
+                   Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->mouseMoveEvent(&me));
+}
+
+TEST_F(IconWidgetCovTest, InvokedMenuItem_AllBranches)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->invokedMenuItem("shot"));
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->invokedMenuItem("recorder"));
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->invokedMenuItem("unknown"));
+}
+
+TEST_F(IconWidgetCovTest, PaintEvent_MinSize_NoBackground)
+{
+    m_iconWidget->resize(PLUGIN_BACKGROUND_MIN_SIZE, PLUGIN_BACKGROUND_MIN_SIZE);
+    QPaintEvent pe(m_iconWidget->rect());
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->paintEvent(&pe));
+}
+
+TEST_F(IconWidgetCovTest, PaintEvent_LargeSize_DrawsBackground)
+{
+    m_iconWidget->resize(40, 40);
+    QPaintEvent pe(m_iconWidget->rect());
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->paintEvent(&pe));
+}
+
+TEST_F(IconWidgetCovTest, OnPropertyChanged_PositionAndOther)
+{
+    QVariant posValue(2);
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->onPropertyChanged("Position", posValue));
+    QVariant otherValue(1);
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->onPropertyChanged("DisplayMode", otherValue));
+}
+
+TEST_F(IconWidgetCovTest, OnPositionChanged_UpdatesPosition)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->onPositionChanged(0));
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->onPositionChanged(1));
+}
+
+TEST_F(IconWidgetCovTest, LeaveEvent_ResetsState)
+{
+    QEvent e(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(m_iconWidget->leaveEvent(&e));
+}
+
+TEST_F(QuickPanelWidgetCovTest, Start_BeginTimer)
+{
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->start());
+    QTest::qWait(500);
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->stop());
+}
+
+TEST_F(QuickPanelWidgetCovTest, Stop_WhenTimerInactive)
+{
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->stop());
+}
+
+TEST_F(QuickPanelWidgetCovTest, Pause_StopsTimerAndUpdatesDescription)
+{
+    m_quickPanel->start();
+    QTest::qWait(500);
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->pause());
+    m_quickPanel->stop();
+}
+
+TEST_F(QuickPanelWidgetCovTest, OnTimeout_UpdatesShowTime)
+{
+    m_quickPanel->start();
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->onTimeout());
+    m_quickPanel->stop();
+}
+
+TEST_F(QuickPanelWidgetCovTest, RefreshIcon_ReappliesType)
+{
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->refreshIcon());
+}
+
+TEST_F(QuickPanelWidgetCovTest, SetWidgetState_ActiveAndNormal)
+{
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->setWidgetState(QuickPanelWidget::WS_ACTIVE));
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->setWidgetState(QuickPanelWidget::WS_NORMAL));
+}
+
+TEST_F(QuickPanelWidgetCovTest, MouseReleaseEvent_NotUnderMouse)
+{
+    QMouseEvent me(QEvent::MouseButtonRelease, QPointF(1, 1), QPointF(1, 1),
+                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_quickPanel->mouseReleaseEvent(&me));
+}
+
+TEST_F(ShotStartPluginCovTest, OnStart_DisablesWidgets)
+{
+    EXPECT_TRUE(m_plugin->onStart());
+}
+
+TEST_F(ShotStartPluginCovTest, OnStop_EnablesWidgets)
+{
+    m_plugin->onStart();
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onStop());
+}
+
+TEST_F(ShotStartPluginCovTest, OnPause_DoesNothing)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onPause());
+}
+
+TEST_F(ShotStartPluginCovTest, OnRecording_FirstAndSubsequentCalls)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onRecording());
+    QTest::qWait(2100);
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onRecording());
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onStop());
+}
+
+TEST_F(ShotStartPluginCovTest, OnClickQuickPanel_NotRecording)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onClickQuickPanel());
+    QTest::qWait(500);
+}
+
+TEST_F(ShotStartPluginCovTest, OnClickQuickPanel_WhileRecording)
+{
+    m_plugin->onStart();
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onClickQuickPanel());
+}
+
+TEST_F(ShotStartPluginCovTest, Flags_ReturnsQuickPanelFlags)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->flags());
+}
+
+TEST_F(ShotStartPluginCovTest, PluginSizePolicy_ReturnsCustom)
+{
+    EXPECT_EQ(PluginsItemInterface::Custom, m_plugin->pluginSizePolicy());
+}
+
+TEST_F(ShotStartPluginCovTest, ItemSortKey_ReturnsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->itemSortKey("shot-start-plugin"));
+}
+
+TEST_F(ShotStartPluginCovTest, SetSortKey_SavesValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->setSortKey("shot-start-plugin", 5));
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_commoniconbutton_cov.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_commoniconbutton_cov.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QIcon>
+
+#include "../../../src/dde-dock-plugins/shotstartrecord/commoniconbutton.h"
+#include <DGuiApplicationHelper>
+DGUI_USE_NAMESPACE
+
+#include "stub.h"
+
+static DGuiApplicationHelper::ColorType lightTheme_stub() {
+    return DGuiApplicationHelper::LightType;
+}
+
+namespace {
+class RecordCommonIconButtonCovTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_btn = new CommonIconButton(nullptr);
+        m_btn->show();
+    }
+    void TearDown() override
+    {
+        if (m_btn) {
+            delete m_btn;
+            m_btn = nullptr;
+        }
+    }
+    CommonIconButton *m_btn = nullptr;
+};
+} // namespace
+
+TEST_F(RecordCommonIconButtonCovTest, SetClickable_ToggleState_NoException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setClickable(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setClickable(false));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetRotatable_TrueThenFalse_CleansTimer)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setRotatable(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setRotatable(false));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, StartRotate_TriggersRotationAnimation)
+{
+    m_btn->setRotatable(true);
+    EXPECT_NO_FATAL_FAILURE(m_btn->startRotate());
+}
+
+TEST_F(RecordCommonIconButtonCovTest, StopRotate_StopsTimerAndResetsAngle)
+{
+    m_btn->setRotatable(true);
+    m_btn->startRotate();
+    EXPECT_NO_FATAL_FAILURE(m_btn->stopRotate());
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetHoverIcon_StoresIcon)
+{
+    QIcon icon;
+    EXPECT_NO_FATAL_FAILURE(m_btn->setHoverIcon(icon));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetActiveState_TogglesHighlight)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setActiveState(true));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setActiveState(false));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetStateIconMapping_AppliesMapping)
+{
+    QMap<CommonIconButton::State, QPair<QString, QString>> mapping;
+    mapping.insert(CommonIconButton::On, qMakePair(QString("on"), QString("on-fallback")));
+    mapping.insert(CommonIconButton::Off, qMakePair(QString("off"), QString("off-fallback")));
+    EXPECT_NO_FATAL_FAILURE(m_btn->setStateIconMapping(mapping));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetState_WithMapping_AppliesIconFromMapping)
+{
+    QMap<CommonIconButton::State, QPair<QString, QString>> mapping;
+    mapping.insert(CommonIconButton::On, qMakePair(QString("edit"), QString("")));
+    m_btn->setStateIconMapping(mapping);
+    EXPECT_NO_FATAL_FAILURE(m_btn->setState(CommonIconButton::On));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetState_WithoutMapping_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setState(CommonIconButton::Default));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, RefreshIcon_ReappliesCurrentState)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->refreshIcon());
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetIconWithStringAndSuffix_LoadsThemeIcon)
+{
+    EXPECT_NO_FATAL_FAILURE(m_btn->setIcon(QStringLiteral("edit"), QStringLiteral("edit-fallback"), QStringLiteral(".svg")));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, PaintEvent_RendersWidgetWithoutException)
+{
+    QPaintEvent pe(m_btn->rect());
+    EXPECT_NO_FATAL_FAILURE(m_btn->paintEvent(&pe));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, MousePressEvent_RecordsPressPosition)
+{
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, MouseReleaseEvent_ClickableEmitsClickedSignal)
+{
+    m_btn->setClickable(true);
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+    QTest::mouseRelease(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, MouseReleaseEvent_RotatableStartsRotation)
+{
+    m_btn->setClickable(true);
+    m_btn->setRotatable(true);
+    QTest::mousePress(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+    QTest::mouseRelease(m_btn, Qt::LeftButton, Qt::NoModifier, QPoint(5, 5));
+}
+
+TEST_F(RecordCommonIconButtonCovTest, SetIcon_LightTheme_TriggersDarkMarkLambda)
+{
+    Stub s;
+    s.set(ADDR(DGuiApplicationHelper, themeType), lightTheme_stub);
+    EXPECT_NO_FATAL_FAILURE(m_btn->setIcon(QStringLiteral("edit"), QStringLiteral("edit-fallback"), QStringLiteral(".svg")));
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_recordiconwidget_interface.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_recordiconwidget_interface.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QDBusConnection>
+#include <QDBusPendingReply>
+
+#include "../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget_interface.h"
+
+namespace {
+class RecordIconwidgetInterfaceTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_iface = new recordiconwidget_interface(
+            QStringLiteral("org.deepin.dde.daemon.Dock1"),
+            QStringLiteral("/org/deepin/dde/daemon/Dock1"),
+            QDBusConnection::sessionBus());
+    }
+    void TearDown() override
+    {
+        if (m_iface) {
+            delete m_iface;
+            m_iface = nullptr;
+        }
+    }
+    recordiconwidget_interface *m_iface = nullptr;
+};
+} // namespace
+
+// ---- property getters ----
+TEST_F(RecordIconwidgetInterfaceTest, DisplayMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->displayMode());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, DockedApps_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->dockedApps());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, Entries_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->entries());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, FrontendWindowRect_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->frontendWindowRect());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, HideMode_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideMode());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, HideState_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideState());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, HideTimeout_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->hideTimeout());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, IconSize_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->iconSize());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, Opacity_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->opacity());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, ShowTimeout_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->showTimeout());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSize_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSize());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSizeEfficient_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeEfficient());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSizeFashion_Getter_ReturnsValueWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->windowSizeFashion());
+}
+
+// ---- property setters ----
+TEST_F(RecordIconwidgetInterfaceTest, DisplayMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setDisplayMode(0));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, HideMode_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setHideMode(0));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, HideTimeout_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setHideTimeout(30u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, IconSize_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setIconSize(48u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, Opacity_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setOpacity(0.5));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, Position_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setPosition(1));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, ShowTimeout_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setShowTimeout(20u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSize_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSize(100u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSizeEfficient_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeEfficient(100u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, WindowSizeFashion_Setter_AcceptsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setWindowSizeFashion(100u));
+}
+
+// ---- D-Bus methods ----
+TEST_F(RecordIconwidgetInterfaceTest, ActivateWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->ActivateWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, CancelPreviewWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->CancelPreviewWindow());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, CloseWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->CloseWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, GetDockedAppsDesktopFiles_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetDockedAppsDesktopFiles());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, GetEntryIDs_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetEntryIDs());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, GetPluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->GetPluginSettings());
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, IsDocked_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsDocked(QStringLiteral("test.desktop")));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, IsOnDock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsOnDock(QStringLiteral("test.desktop")));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MakeWindowAbove_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MakeWindowAbove(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MaximizeWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MaximizeWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MergePluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MergePluginSettings(QStringLiteral("cfg")));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MinimizeWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MinimizeWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MoveEntry_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MoveEntry(0, 1));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, MoveWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->MoveWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, PreviewWindow_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->PreviewWindow(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, QueryWindowIdentifyMethod_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->QueryWindowIdentifyMethod(1u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, RemovePluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RemovePluginSettings(QStringLiteral("key"), QStringList{}));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, RequestDock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestDock(QStringLiteral("test.desktop"), 0));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, RequestUndock_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->RequestUndock(QStringLiteral("test.desktop")));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, SetFrontendWindowRect_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetFrontendWindowRect(0, 0, 100u, 100u));
+}
+
+TEST_F(RecordIconwidgetInterfaceTest, SetPluginSettings_CallsMethodWithoutException)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetPluginSettings(QStringLiteral("cfg")));
+}
+
+// ---- staticInterfaceName ----
+TEST_F(RecordIconwidgetInterfaceTest, StaticInterfaceName_ReturnsDockInterfaceName)
+{
+    EXPECT_STRNE(nullptr, recordiconwidget_interface::staticInterfaceName());
+}

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record.pro
@@ -48,7 +48,10 @@ SOURCES += \
     ../../../src/dde-dock-plugins/shotstartrecord/commoniconbutton.cpp \
     ut_tipswidget.cpp \
     ut_shotstartrecordplugin.cpp \
-    ut_recordiconwidget.cpp
+    ut_recordiconwidget.cpp \
+    ut_recordiconwidget_interface.cpp \
+    ut_commoniconbutton_cov.cpp \
+    ut_shot_start_record_cov2.cpp
 
 INCLUDEPATH += /usr/include/dde-dock
 include(../../../3rdparty/googletest/gtest_dependency.pri)

--- a/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record_cov2.cpp
+++ b/tests/ut_dde_dock_plugins/ut_shot_start_record/ut_shot_start_record_cov2.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../../src/dde-dock-plugins/shotstartrecord/quickpanelwidget.h"
+#include "../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget.h"
+#include "../../../src/dde-dock-plugins/shotstartrecord/recordiconwidget_interface.h"
+#include "../../../src/dde-dock-plugins/shotstartrecord/shotstartrecordplugin.h"
+#include "ut_mock_pluginproxyinterface.h"
+
+#include <gtest/gtest.h>
+
+#include <QDBusArgument>
+#include <QDebug>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QSignalSpy>
+#include <QTest>
+
+namespace {
+
+class QuickPanelWidgetCov2Test : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_widget = new QuickPanelWidget();
+        m_widget->show();
+    }
+    void TearDown() override
+    {
+        delete m_widget;
+    }
+    QuickPanelWidget *m_widget = nullptr;
+};
+
+TEST_F(QuickPanelWidgetCov2Test, Pause_StopsTimerAndUpdatesDescription)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->pause());
+}
+
+TEST_F(QuickPanelWidgetCov2Test, RefreshIcon_ReappliesCurrentType)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->refreshIcon());
+}
+
+TEST_F(QuickPanelWidgetCov2Test, OnTimeout_UpdatesTimeDisplay)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->onTimeout());
+}
+
+TEST_F(QuickPanelWidgetCov2Test, MouseReleaseEvent_UnderMouseEmitsClicked)
+{
+    m_widget->setAttribute(Qt::WA_UnderMouse, true);
+    QSignalSpy spy(m_widget, &QuickPanelWidget::clicked);
+    QMouseEvent me(QEvent::MouseButtonRelease, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_widget->mouseReleaseEvent(&me));
+    EXPECT_EQ(1, spy.count());
+}
+
+TEST_F(QuickPanelWidgetCov2Test, MouseReleaseEvent_NotUnderMouseSkipsEmit)
+{
+    m_widget->setAttribute(Qt::WA_UnderMouse, false);
+    QSignalSpy spy(m_widget, &QuickPanelWidget::clicked);
+    QMouseEvent me(QEvent::MouseButtonRelease, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_widget->mouseReleaseEvent(&me));
+    EXPECT_EQ(0, spy.count());
+}
+
+
+class RecordIconWidgetCov2Test : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_widget = new RecordIconWidget();
+        m_widget->show();
+    }
+    void TearDown() override
+    {
+        delete m_widget;
+    }
+    RecordIconWidget *m_widget = nullptr;
+};
+
+TEST_F(RecordIconWidgetCov2Test, MouseMoveEvent_SetsHoverState)
+{
+    QMouseEvent me(QEvent::MouseMove, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_widget->mouseMoveEvent(&me));
+}
+
+TEST_F(RecordIconWidgetCov2Test, LeaveEvent_ResetsHoverAndPressed)
+{
+    QEvent e(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(m_widget->leaveEvent(&e));
+}
+
+TEST_F(RecordIconWidgetCov2Test, OnPositionChanged_UpdatesPositionAndIcon)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->onPositionChanged(0));
+    EXPECT_NO_FATAL_FAILURE(m_widget->onPositionChanged(1));
+    EXPECT_NO_FATAL_FAILURE(m_widget->onPositionChanged(3));
+}
+
+TEST_F(RecordIconWidgetCov2Test, InvokedMenuItem_Screenshot)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->invokedMenuItem("shot"));
+}
+
+TEST_F(RecordIconWidgetCov2Test, InvokedMenuItem_Recorder)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->invokedMenuItem("recorder"));
+}
+
+TEST_F(RecordIconWidgetCov2Test, InvokedMenuItem_Unknown)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->invokedMenuItem("unknown"));
+}
+
+TEST_F(RecordIconWidgetCov2Test, OnPropertyChanged_Position)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->onPropertyChanged("Position", QVariant(0)));
+}
+
+TEST_F(RecordIconWidgetCov2Test, OnPropertyChanged_NonPosition)
+{
+    EXPECT_NO_FATAL_FAILURE(m_widget->onPropertyChanged("DisplayMode", QVariant(1)));
+}
+
+TEST_F(RecordIconWidgetCov2Test, PaintEvent_SmallSize)
+{
+    QPaintEvent pe(m_widget->rect());
+    EXPECT_NO_FATAL_FAILURE(m_widget->paintEvent(&pe));
+}
+
+TEST_F(RecordIconWidgetCov2Test, PaintEvent_LargeSize)
+{
+    m_widget->resize(60, 60);
+    QPaintEvent pe(m_widget->rect());
+    EXPECT_NO_FATAL_FAILURE(m_widget->paintEvent(&pe));
+}
+
+
+class ShotStartRecordPluginCov2Test : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_plugin.reset(new ShotStartRecordPlugin());
+        m_plugin->init(&mock_proxy);
+    }
+    void TearDown() override {}
+
+    MockPluginProxyInterface mock_proxy;
+    std::shared_ptr<ShotStartRecordPlugin> m_plugin;
+};
+
+TEST_F(ShotStartRecordPluginCov2Test, SetSortKey_SavesValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->setSortKey("shot-start-record-plugin", 5));
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, Flags_ReturnsQuickPanelFlags)
+{
+    Dock::PluginFlags f = m_plugin->flags();
+    EXPECT_TRUE(f.testFlag(Dock::Type_Quick));
+    EXPECT_TRUE(f.testFlag(Dock::Quick_Panel_Single));
+    EXPECT_TRUE(f.testFlag(Dock::Attribute_Normal));
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, OnRecording_InitializesCheckTimer)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onRecording());
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, OnRecording_TriggersCheckTimerLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onRecording());
+    QTest::qWait(2100);
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onRecording());
+    QTest::qWait(2100);
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, OnPause_PausesQuickPanel)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onPause());
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, OnClickQuickPanel_StopsRecording)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->onClickQuickPanel());
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, ItemSortKey_ReturnsValue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->itemSortKey("shot-start-record-plugin"));
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, SetTrayIconVisible_TogglesVisibility)
+{
+    EXPECT_NO_FATAL_FAILURE(m_plugin->setTrayIconVisible(true));
+    EXPECT_NO_FATAL_FAILURE(m_plugin->setTrayIconVisible(false));
+}
+
+TEST_F(ShotStartRecordPluginCov2Test, PluginSizePolicy_ReturnsCustom)
+{
+    EXPECT_EQ(PluginsItemInterface::Custom, m_plugin->pluginSizePolicy());
+}
+
+
+TEST(DockRectSerializationCov2Test, Serialize_WritesAllFieldsWithoutException)
+{
+    DockRect inRect{10, 20, 100u, 200u};
+    QDBusArgument writeArg;
+    EXPECT_NO_FATAL_FAILURE(writeArg << inRect);
+}
+
+TEST(DockRectSerializationCov2Test, Deserialize_ReadsAllFieldsWithoutException)
+{
+    DockRect outRect{0, 0, 0u, 0u};
+    QDBusArgument arg;
+    EXPECT_NO_FATAL_FAILURE(arg >> outRect);
+}
+
+} // namespace


### PR DESCRIPTION
Add interface and cov2 test sources to recordtime, shotstart and shotstartrecord plugin unit tests, and update .pro files.

为 recordtime、shotstart、shotstartrecord 插件单测补充接口与
覆盖率测试源文件，并更新对应工程文件。

Log: 补充 dde-dock 插件单测覆盖率
Influence: 仅影响单元测试，提升三个 dde-dock 插件的测试覆盖率。

## Summary by Sourcery

Expand dde-dock plugin unit-test coverage across interface, widget, plugin, and serialization behavior.

Tests:
- Add interface and coverage tests for the record time, shot start, and shot start record dock plugins and their supporting widgets.

Chores:
- Update the affected unit-test project files and coverage compiler settings to include the new test sources.