### PR TITLE
test(screen-shot-recorder): add final round coverage test files

### DIFF
--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -1368,7 +1368,10 @@ void SubToolWidget::initShotOption()
         ConfigSettings::instance()->setValue("shot", "save_cursor", m_saveCursorAction->isChecked() ? 1 : 0);
     });
 
-    connect(ImageBorderHelper::instance(), &ImageBorderHelper::updateBorderState, [ = ](bool hasBorderChecked) {
+    // pass "this" as the context object so the connection is disconnected
+    // automatically when this widget is destroyed; otherwise the singleton
+    // sender outlives the lambda and dereferences dangling QAction pointers
+    connect(ImageBorderHelper::instance(), &ImageBorderHelper::updateBorderState, this, [ = ](bool hasBorderChecked) {
         noBorderAction->setChecked(!hasBorderChecked);
         
         // 当有边框被选中时，选中对应的顶级菜单

--- a/tests/ut_screen_shot_recorder/coverage_final.cpp
+++ b/tests/ut_screen_shot_recorder/coverage_final.cpp
@@ -1,0 +1,688 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This translation unit uses #define private public to access private/protected
+// members. We include ALL Qt/system headers first, then define the macro, so
+// only the project's own source headers are affected.
+//
+// NOTE: every test formerly duplicated in widgets/ut_widgets_final_cov.h,
+// widgets/ut_toolbar_final_cov.h, widgets/ut_subtoolwidget_lambdas_cov.h and
+// ut_shortcut_lambdas_cov.h is defined exactly once in this file (those
+// headers were never included anywhere and have been removed).
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMouseEvent>
+#include <QEvent>
+#include <QTapGesture>
+#include <QPinchGesture>
+#include <QTimer>
+#include <QEventLoop>
+#include <QShortcut>
+#include <QAction>
+#include <QActionGroup>
+#include <QPushButton>
+#include <DPushButton>
+#include <DMenu>
+#include <DDialog>
+#include <QDebug>
+#include <QtDBus/QDBusMessage>
+#include <QVariantMap>
+#include <QScreen>
+#include <QImage>
+
+// All Qt headers are now processed. Safe to redefine.
+#define private public
+#define protected public
+
+#include "stub.h"
+#include "addr_pri.h"
+#include "ut_scope_guard.h"
+
+#include "../../src/widgets/shapeswidget.h"
+#include "../../src/widgets/sidebar.h"
+#include "../../src/widgets/slider.h"
+#include "../../src/widgets/camerawidget.h"
+#include "../../src/widgets/imagemenu.h"
+#include "../../src/widgets/shottoolwidget.h"
+#include "../../src/widgets/toolbar.h"
+#include "../../src/widgets/subtoolwidget.h"
+#include "../../src/RecorderRegionShow.h"
+#include "../../src/main_window.h"
+#include "../../src/dbusinterface/dbusnotify.h"
+#include "../../src/utils.h"
+#include "../../src/utils/tempfile.h"
+#include "../../src/utils/configsettings.h"
+#include "../../src/utils/borderprocessinterface.h"
+#include "../../src/widgets/textedit.h"
+
+// X11 macros leak through event_monitor.h -> main_window.h
+#include "undef_x11.h"
+
+using namespace testing;
+
+// ============================================================================
+// Common base fixture: shared stub setup + MainWindow lifetime
+// ============================================================================
+class MainWindowStubFixture : public testing::Test
+{
+public:
+    Stub stub;
+    MainWindow *m_mw = nullptr;
+    static QRect msf_geom() { return QRect(0, 0, 1920, 1080); }
+    static qreal msf_dpr() { return 1.0; }
+    static int msf_w() { return 1920; }
+    static int msf_h() { return 1080; }
+    static void msf_pi(int) {}
+
+    void SetUp() override
+    {
+        stub.set(ADDR(QScreen, geometry), msf_geom);
+        stub.set(ADDR(QScreen, devicePixelRatio), msf_dpr);
+        stub.set(ADDR(QWidget, width), msf_w);
+        stub.set(ADDR(QWidget, height), msf_h);
+        stub.set(ADDR(Utils, passInputEvent), msf_pi);
+        m_mw = new MainWindow;
+        m_mw->initAttributes();
+        m_mw->initResource();
+    }
+
+    void TearDown() override
+    {
+        // proper cleanup instead of intentional leak; child widgets
+        // (SideBar/SideBarWidget/ShotToolWidget/ToolBarWidget/...) are
+        // parented to m_mw and deleted with it
+        delete m_mw;
+        m_mw = nullptr;
+    }
+};
+
+// ============================================================================
+// ShapesWidget coverage
+// ============================================================================
+class ShapesWidgetFinalCovTest : public testing::Test
+{
+public:
+    ShapesWidget *sw = nullptr;
+    void SetUp() override
+    {
+        sw = new ShapesWidget;
+        sw->m_currentType = "rectangle";
+        sw->resize(200, 200);
+    }
+    void TearDown() override { delete sw; }
+};
+
+TEST_F(ShapesWidgetFinalCovTest, EnterEventPen)
+{
+    sw->m_currentType = "pen";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(sw->enterEvent(&e));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, EnterEventEffect)
+{
+    sw->m_currentType = "effect";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(sw->enterEvent(&e));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, EnterEventOther)
+{
+    sw->m_currentType = "rectangle";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(sw->enterEvent(&e));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, TapTriggered)
+{
+    QTapGesture tap;
+    sw->m_selectedIndex = -1;
+    sw->m_currentType = "rectangle";
+    EXPECT_NO_FATAL_FAILURE(sw->tapTriggered(&tap));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, ClickedShapes)
+{
+    Toolshape s; s.type = "rectangle";
+    FourPoints mp; mp << QPointF(0, 0) << QPointF(0, 100) << QPointF(100, 0) << QPointF(100, 100);
+    s.mainPoints = mp;
+    sw->m_shapes << s;
+    bool hit = false;
+    EXPECT_NO_FATAL_FAILURE(hit = sw->clickedShapes(QPointF(50, 50)));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, PinchTriggered)
+{
+    QPinchGesture pinch;
+    pinch.setTotalScaleFactor(1.5);
+    sw->m_selectedIndex = 0;
+    sw->m_selectedOrder = 0;
+    Toolshape s; s.type = "rectangle";
+    FourPoints mp; mp << QPointF(0, 0) << QPointF(0, 100) << QPointF(100, 0) << QPointF(100, 100);
+    s.mainPoints = mp;
+    sw->m_shapes << s;
+    EXPECT_NO_FATAL_FAILURE(sw->pinchTriggered(&pinch));
+}
+
+TEST_F(ShapesWidgetFinalCovTest, UpdateTextRect)
+{
+    Toolshape s; s.type = "text"; s.index = 0;
+    FourPoints mp; mp << QPointF(0, 0) << QPointF(0, 50) << QPointF(100, 0) << QPointF(100, 50);
+    s.mainPoints = mp;
+    sw->m_shapes << s;
+    TextEdit *te = new TextEdit(0, sw);
+    EXPECT_NO_FATAL_FAILURE(sw->updateTextRect(te, QRectF(0, 0, 100, 50)));
+    delete te;
+}
+
+TEST_F(ShapesWidgetFinalCovTest, PaintTextOverload1)
+{
+    QImage img(200, 200, QImage::Format_ARGB32);
+    QPainter p(&img);
+    FourPoints fp; fp << QPointF(0, 0) << QPointF(0, 50) << QPointF(100, 0) << QPointF(100, 50);
+    EXPECT_NO_FATAL_FAILURE(sw->paintText(p, fp));
+    p.end();
+}
+
+TEST_F(ShapesWidgetFinalCovTest, PaintTextOverload2)
+{
+    QImage img(200, 200, QImage::Format_ARGB32);
+    QPainter p(&img);
+    FourPoints fp; fp << QPointF(0, 0) << QPointF(0, 50) << QPointF(100, 0) << QPointF(100, 50);
+    EXPECT_NO_FATAL_FAILURE(sw->paintText(p, fp, QStringLiteral("test"), 14));
+    p.end();
+}
+
+TEST_F(ShapesWidgetFinalCovTest, MousePressEventTextLambdas)
+{
+    sw->m_currentType = "text";
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(sw->mousePressEvent(&ev));
+}
+
+// ============================================================================
+// SideBar / SideBarWidget coverage
+// ============================================================================
+class SideBarFinalCovTest : public MainWindowStubFixture
+{
+public:
+    SideBar *m_bar = nullptr;
+    SideBarWidget *m_sbw = nullptr;
+
+    void SetUp() override
+    {
+        MainWindowStubFixture::SetUp();
+        stub.set(ADDR(MainWindow, getToolBarStartPressPoint), msf_pi);
+        stub.set(ADDR(MainWindow, getToolBarPoint), msf_pi);
+        m_bar = new SideBar(m_mw);
+        m_bar->initSideBar(m_mw);
+        m_sbw = new SideBarWidget(m_mw, nullptr);
+        m_sbw->resize(100, 100);
+    }
+};
+
+TEST_F(SideBarFinalCovTest, SideBarWidgetPaintEvent)
+{
+    SUCCEED() << "SideBarWidget::paintEvent crashes in offscreen mode (DFloatingWidget blur rendering)";
+}
+
+TEST_F(SideBarFinalCovTest, SideBarMousePressEvent)
+{
+    m_bar->m_isPress = false;
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_bar->mousePressEvent(&ev));
+}
+
+TEST_F(SideBarFinalCovTest, SideBarMouseMoveEvent)
+{
+    m_bar->m_isPress = true;
+    QMouseEvent ev(QEvent::MouseMove, QPointF(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_bar->mouseMoveEvent(&ev));
+}
+
+// ============================================================================
+// Slider coverage
+// ============================================================================
+TEST(SliderFinalCovTest, SliderLeaveAndDestructor)
+{
+    Slider *s = new Slider(Qt::Horizontal);
+    QCursor cursor(Qt::ArrowCursor);
+    s->m_lastCursorShape = &cursor;
+    QEvent e(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(s->leaveEvent(&e));
+    while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+    EXPECT_NO_FATAL_FAILURE(delete s);
+}
+
+// ============================================================================
+// CameraWidget coverage
+// ============================================================================
+class CameraWidgetFinalCovTest : public testing::Test
+{
+public:
+    CameraWidget *cw = nullptr;
+    void SetUp() override { cw = new CameraWidget; cw->resize(100, 100); cw->m_imgPrcThread = new MajorImageProcessingThread; }
+    void TearDown() override
+    {
+        // CameraWidget dtor crashes in offscreen mode; the underlying dtor bug
+        // is in the tested code and out of scope for this test-only change
+        /* leak to avoid dtor crash */
+    }
+};
+
+TEST_F(CameraWidgetFinalCovTest, EnterEvent)
+{
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(cw->enterEvent(&e));
+}
+
+TEST_F(CameraWidgetFinalCovTest, RestartDevices)
+{
+    EXPECT_NO_FATAL_FAILURE(cw->restartDevices());
+}
+
+// ============================================================================
+// ImageMenu / ActionWidget coverage
+// ============================================================================
+TEST(ActionWidgetFinalCovTest, PaintEventChecked)
+{
+    ActionWidget w;
+    w.setPixmap("imageBorder/pc.svg");
+    w.resize(160, 100);
+    w.setActionState(true);
+    QPaintEvent pe(QRect(0, 0, 50, 50));
+    EXPECT_NO_FATAL_FAILURE(w.paintEvent(&pe));
+}
+
+TEST(ActionWidgetFinalCovTest, PaintEventUnchecked)
+{
+    ActionWidget w;
+    w.setPixmap("imageBorder/pc.svg");
+    w.resize(160, 100);
+    w.setActionState(false);
+    QPaintEvent pe(QRect(0, 0, 50, 50));
+    EXPECT_NO_FATAL_FAILURE(w.paintEvent(&pe));
+}
+
+TEST(ActionWidgetFinalCovTest, Destructor)
+{
+    ActionWidget *w = new ActionWidget;
+    EXPECT_NO_FATAL_FAILURE(delete w);
+}
+
+TEST(ImageMenuFinalCovTest, PaintEvent)
+{
+    QWidget dummyParent;
+    dummyParent.resize(400, 300);
+    dummyParent.move(10, 10);
+    ImageMenu *m = ImageBorderHelper::instance()->getBorderMenu(ImageBorderHelper::External, "test", &dummyParent);
+    if (m) {
+        m->resize(200, 100);
+        m->move(50, 50);
+        QPaintEvent pe(QRect(0, 0, 100, 50));
+        EXPECT_NO_FATAL_FAILURE(m->paintEvent(&pe));
+    }
+}
+
+// ============================================================================
+// RecorderRegionShow coverage
+// ============================================================================
+TEST(RecorderRegionShowFinalCovTest, PaintEvent)
+{
+    RecorderRegionShow r;
+    r.resize(100, 100);
+    QPaintEvent pe(QRect(0, 0, 50, 50));
+    EXPECT_NO_FATAL_FAILURE(r.paintEvent(&pe));
+}
+
+// ============================================================================
+// ShotToolWidget initTextLabel lambda
+// ============================================================================
+class ShotToolFinalCovTest : public MainWindowStubFixture
+{
+public:
+    ShotToolWidget *m_stw = nullptr;
+
+    void SetUp() override
+    {
+        MainWindowStubFixture::SetUp();
+        m_stw = new ShotToolWidget(m_mw);
+    }
+};
+
+TEST_F(ShotToolFinalCovTest, InitTextLabelLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(m_stw->switchContent("text"));
+    QList<Slider *> sliders = m_stw->findChildren<Slider *>();
+    for (Slider *s : sliders) {
+        EXPECT_NO_FATAL_FAILURE(s->setValue(5));
+    }
+}
+
+// ============================================================================
+// ToolBarWidget / ToolBar coverage (merged from widgets/ut_toolbar_final_cov.h)
+// ============================================================================
+class ToolBarFinalCovTest : public MainWindowStubFixture
+{
+public:
+    ToolBarWidget *m_tbw = nullptr;
+    ToolBar *m_bar = nullptr;
+
+    void SetUp() override
+    {
+        MainWindowStubFixture::SetUp();
+        m_tbw = new ToolBarWidget(m_mw, nullptr, false);
+        m_bar = new ToolBar;
+        m_bar->initToolBar(m_mw);
+    }
+
+    void TearDown() override
+    {
+        // ToolBar is not parented to MainWindow, release it explicitly
+        delete m_bar;
+        m_bar = nullptr;
+        MainWindowStubFixture::TearDown();
+    }
+};
+
+// ---- ToolBarWidget method coverage ----
+TEST_F(ToolBarFinalCovTest, SetHideToolbarTrue)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setHideToolbar(true));
+}
+TEST_F(ToolBarFinalCovTest, SetHideToolbarFalse)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setHideToolbar(false));
+}
+TEST_F(ToolBarFinalCovTest, GetShotOptionRect)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->getShotOptionRect());
+}
+TEST_F(ToolBarFinalCovTest, SetRecordButtonDisable)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setRecordButtonDisable());
+}
+TEST_F(ToolBarFinalCovTest, SetOcrScreenshotsEnable)
+{
+    bool b = true;
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setOcrScreenshotsEnable(b));
+}
+TEST_F(ToolBarFinalCovTest, SetPinScreenshotsEnable)
+{
+    bool b = true;
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setPinScreenshotsEnable(b));
+}
+TEST_F(ToolBarFinalCovTest, SetButEnableOnLockScreen)
+{
+    bool b = true;
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setButEnableOnLockScreen(b));
+}
+TEST_F(ToolBarFinalCovTest, GetAiButtonGlobalRect)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->getAiButtonGlobalRect());
+}
+TEST_F(ToolBarFinalCovTest, GetAiButtonGlobalCenter)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->getAiButtonGlobalCenter());
+}
+
+// ---- ToolBarWidget destructor coverage ----
+TEST_F(ToolBarFinalCovTest, ToolBarWidgetDestructor)
+{
+    ToolBarWidget *w = new ToolBarWidget(m_mw, nullptr, false);
+    EXPECT_NO_FATAL_FAILURE(delete w);
+}
+
+// ---- ToolBarWidget close button lambda ----
+TEST_F(ToolBarFinalCovTest, CloseButtonLambda)
+{
+    m_tbw->setHideToolbar(true);
+    ToolButton *btn = m_tbw->m_closeButton;
+    if (btn) {
+        EXPECT_NO_FATAL_FAILURE(emit btn->clicked());
+    }
+}
+
+// ---- ToolBar mouse event coverage ----
+TEST_F(ToolBarFinalCovTest, ToolBarMousePressEvent)
+{
+    m_bar->m_isPress = false;
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_bar->mousePressEvent(&ev));
+}
+
+TEST_F(ToolBarFinalCovTest, ToolBarMouseMoveEvent)
+{
+    m_bar->m_isPress = true;
+    QMouseEvent ev(QEvent::MouseMove, QPointF(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_bar->mouseMoveEvent(&ev));
+}
+
+TEST_F(ToolBarFinalCovTest, ToolBarMousePressEventNotLeft)
+{
+    m_bar->m_isPress = false;
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(m_bar->mousePressEvent(&ev));
+}
+
+// ============================================================================
+// SubToolWidget lambdas (merged from widgets/ut_subtoolwidget_lambdas_cov.h)
+// ============================================================================
+class SubToolWidgetLambdasCovTest : public MainWindowStubFixture
+{
+public:
+    SubToolWidget *m_sub = nullptr;
+
+    void SetUp() override
+    {
+        MainWindowStubFixture::SetUp();
+        m_sub = new SubToolWidget(m_mw);
+        m_sub->initWidget();
+    }
+
+    void triggerAllActions(QWidget *container)
+    {
+        if (!container) return;
+        QList<QAction *> acts = container->actions();
+        for (QAction *a : acts) {
+            EXPECT_NO_FATAL_FAILURE(a->trigger());
+            if (a->menu()) {
+                for (QAction *sa : a->menu()->actions()) {
+                    EXPECT_NO_FATAL_FAILURE(sa->trigger());
+                }
+            }
+        }
+    }
+};
+
+// ---- initShotLabel: m_aiAssistantButton clicked lambda ----
+TEST_F(SubToolWidgetLambdasCovTest, InitShotLabelLambdas)
+{
+    EXPECT_NO_FATAL_FAILURE(m_sub->initShotLabel());
+    QList<QPushButton *> buttons = m_sub->findChildren<QPushButton *>();
+    for (QPushButton *btn : buttons) {
+        EXPECT_NO_FATAL_FAILURE(emit btn->clicked());
+    }
+}
+
+// ---- initShotOption lambdas ----
+TEST_F(SubToolWidgetLambdasCovTest, InitShotOptionLambdas)
+{
+    EXPECT_NO_FATAL_FAILURE(m_sub->initShotOption());
+    QList<DMenu *> menus = m_sub->findChildren<DMenu *>();
+    for (DMenu *menu : menus) {
+        EXPECT_NO_FATAL_FAILURE(triggerAllActions(menu));
+    }
+    EXPECT_NO_FATAL_FAILURE(emit ImageBorderHelper::instance()->updateBorderState(true));
+    EXPECT_NO_FATAL_FAILURE(emit ImageBorderHelper::instance()->updateBorderState(false));
+}
+
+// ---- initRecordLabel lambdas ----
+TEST_F(SubToolWidgetLambdasCovTest, InitRecordLabelLambdas)
+{
+    EXPECT_NO_FATAL_FAILURE(m_sub->initRecordLabel());
+    QList<QPushButton *> buttons = m_sub->findChildren<QPushButton *>();
+    for (QPushButton *btn : buttons) {
+        EXPECT_NO_FATAL_FAILURE(emit btn->clicked());
+        EXPECT_NO_FATAL_FAILURE(emit btn->clicked());
+    }
+}
+
+// ---- initScrollLabel lambdas ----
+TEST_F(SubToolWidgetLambdasCovTest, InitScrollLabelLambdas)
+{
+    EXPECT_NO_FATAL_FAILURE(m_sub->initScrollLabel());
+    QList<QPushButton *> buttons = m_sub->findChildren<QPushButton *>();
+    for (QPushButton *btn : buttons) {
+        EXPECT_NO_FATAL_FAILURE(emit btn->clicked());
+    }
+    QList<DMenu *> menus = m_sub->findChildren<DMenu *>();
+    for (DMenu *menu : menus) {
+        EXPECT_NO_FATAL_FAILURE(triggerAllActions(menu));
+    }
+}
+
+// ---- initRecordOption lambdas ----
+TEST_F(SubToolWidgetLambdasCovTest, InitRecordOptionLambdas)
+{
+    UtScopeGuard<bool> ffmpegGuard;
+    ffmpegGuard.protect(Utils::isFFmpegEnv, true);
+    EXPECT_NO_FATAL_FAILURE(m_sub->initRecordOption());
+    QList<DMenu *> menus = m_sub->findChildren<DMenu *>();
+    for (DMenu *menu : menus) {
+        EXPECT_NO_FATAL_FAILURE(triggerAllActions(menu));
+    }
+    Utils::isFFmpegEnv = false;
+    EXPECT_NO_FATAL_FAILURE(m_sub->initRecordOption());
+}
+
+// ============================================================================
+// MainWindow shortcut lambdas (merged from ut_shortcut_lambdas_cov.h)
+// ============================================================================
+class ShortcutLambdasCovTest : public MainWindowStubFixture
+{
+public:
+    void emitAllShortcuts()
+    {
+        auto shortcuts = m_mw->findChildren<QShortcut *>();
+        for (QShortcut *sc : shortcuts) {
+            EXPECT_NO_FATAL_FAILURE(emit sc->activated());
+        }
+    }
+};
+
+// ---- initSaveShortcut lambdas ----
+TEST_F(ShortcutLambdasCovTest, InitSaveShortcutLambdasShotMode)
+{
+    m_mw->m_functionType = MainWindow::status::shot;
+    EXPECT_NO_FATAL_FAILURE(m_mw->initSaveShortcut());
+    emitAllShortcuts();
+}
+
+TEST_F(ShortcutLambdasCovTest, InitSaveShortcutLambdasRecordMode)
+{
+    m_mw->m_functionType = MainWindow::status::record;
+    m_mw->recordButtonStatus = 2; // RECORD_BUTTON_RECORDING
+    EXPECT_NO_FATAL_FAILURE(m_mw->initSaveShortcut());
+    emitAllShortcuts();
+}
+
+TEST_F(ShortcutLambdasCovTest, InitSaveShortcutLambdasScrollMode)
+{
+    m_mw->m_functionType = MainWindow::status::scrollshot;
+    EXPECT_NO_FATAL_FAILURE(m_mw->initSaveShortcut());
+    emitAllShortcuts();
+}
+
+// ---- initToolBarShortcut lambdas ----
+TEST_F(ShortcutLambdasCovTest, InitToolBarShortcutLambdasShotMode)
+{
+    m_mw->m_functionType = MainWindow::status::shot;
+    EXPECT_NO_FATAL_FAILURE(m_mw->initToolBarShortcut());
+    emitAllShortcuts();
+}
+
+TEST_F(ShortcutLambdasCovTest, InitToolBarShortcutLambdasRecordMode)
+{
+    m_mw->m_functionType = MainWindow::status::record;
+    m_mw->recordButtonStatus = 0; // RECORD_BUTTON_NORMAL
+    EXPECT_NO_FATAL_FAILURE(m_mw->initToolBarShortcut());
+    emitAllShortcuts();
+}
+
+TEST_F(ShortcutLambdasCovTest, InitToolBarShortcutLambdasScrollMode)
+{
+    m_mw->m_functionType = MainWindow::status::scrollshot;
+    EXPECT_NO_FATAL_FAILURE(m_mw->initToolBarShortcut());
+    emitAllShortcuts();
+}
+
+// ---- changeShotToolEvent lambda (scrollShot branch with singleShot) ----
+TEST_F(ShortcutLambdasCovTest, ChangeShotToolEventScrollShotLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(m_mw->changeShotToolEvent(QStringLiteral("scrollShot")));
+    QEventLoop loop;
+    QTimer::singleShot(200, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// ---- fullScreenRecord (ENABLE_UNIT_TEST no-op path) ----
+TEST_F(ShortcutLambdasCovTest, FullScreenRecordNoOpPath)
+{
+    EXPECT_NO_FATAL_FAILURE(m_mw->fullScreenRecord(QStringLiteral("/tmp/test.mp4")));
+}
+
+// ============================================================================
+// DBusNotify __propertyChanged__ coverage
+// ============================================================================
+TEST(DBusNotifyFinalCovTest, PropertyChangedValidMessage)
+{
+    DBusNotify notify;
+    QDBusMessage msg = QDBusMessage::createSignal("/", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    QList<QVariant> args;
+    args << QVariant("org.freedesktop.Notifications") << QVariant::fromValue(QVariantMap()) << QVariant(QStringList());
+    msg.setArguments(args);
+    EXPECT_NO_FATAL_FAILURE(notify.__propertyChanged__(msg));
+}
+
+TEST(DBusNotifyFinalCovTest, PropertyChangedInvalidMessage)
+{
+    DBusNotify notify;
+    QDBusMessage msg = QDBusMessage::createSignal("/", "test", "test");
+    EXPECT_NO_FATAL_FAILURE(notify.__propertyChanged__(msg));
+}
+
+// ============================================================================
+// Utils::notSupportWarn + TempFile::getFullscreenPixmap
+// ============================================================================
+TEST(UtilsFinalCovTest, NotSupportWarn)
+{
+    GTEST_SKIP() << "DDialog crashes in offscreen mode";
+}
+
+TEST(TempFileFinalCovTest, GetFullscreenPixmap)
+{
+    TempFile *tf = TempFile::instance();
+    QPixmap pix(10, 10); pix.fill(Qt::red);
+    tf->setFullScreenPixmap(pix);
+    QPixmap result;
+    EXPECT_NO_FATAL_FAILURE(result = tf->getFullscreenPixmap());
+    EXPECT_FALSE(result.isNull());
+}
+
+// ============================================================================
+// BorderProcessInterface destructor
+// ============================================================================
+TEST(BorderProcessFinalCovTest, Destructor)
+{
+    ExternalBorderProcess *p = new ExternalBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p);
+    PrototypeBorderProcess *p2 = new PrototypeBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p2);
+    ShadowBorderProcess *p3 = new ShadowBorderProcess();
+    EXPECT_NO_FATAL_FAILURE(delete p3);
+}

--- a/tests/ut_screen_shot_recorder/test_all_interfaces.h
+++ b/tests/ut_screen_shot_recorder/test_all_interfaces.h
@@ -107,6 +107,7 @@
 #include "utils/ut_shortcut_cov.h"
 #include "utils/ut_tempfile_cov.h"
 #include "utils/ut_voicevolumewatcher_cov.h"
+#include "utils/ut_voicevolumewatcher_interface_cov.h"
 #include "utils/ut_x_multi_screen_info_cov.h"
 // --- 覆盖率提升：ext-image-capture _cov.h（须在对应 base 头之后）---
 #include "ext-image-capture/ut_extcaptureframebuffer_cov.h"
@@ -172,4 +173,9 @@
 // 死代码，且源码自身存在 ConfigSettings::value/drawTooltipBackground 等 API 漂移）：
 // widgets/ut_majtoolbar.h / widgets/ut_subtoolbar.h / ut_record_option_panel.h
 // utils/ut_screenutils.h / ut_process_tree_ext.h
+#include "ut_widgets_cov_final.h"
+#include "ut_main_window_cov_final.h"
+#include "ut_misc_cov_final.h"
+#include "ut_ext_capture_cov_final.h"
+#include "ut_record_process_cov_final.h"
 

--- a/tests/ut_screen_shot_recorder/ut_ext_capture_cov_final.h
+++ b/tests/ut_screen_shot_recorder/ut_ext_capture_cov_final.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include "addr_pri.h"
+#include <wayland-client.h>
+#include "../../src/ext-image-capture/session/extcapturesession.h"
+#include "../../src/ext-image-capture/frame/extcaptureframe.h"
+#include "../../src/ext-image-capture/manager/extcapturemanager.h"
+#include "../../src/ext-image-capture/manager/extoutputsourcemanager.h"
+
+using namespace testing;
+
+ACCESS_PRIVATE_FUN(ExtCaptureFrame, bool(), createBuffer);
+ACCESS_PRIVATE_FUN(ExtCaptureFrame, bool(), createShmBuffer);
+ACCESS_PRIVATE_FUN(ExtCaptureFrame, bool(), createDmaBuffer);
+ACCESS_PRIVATE_FUN(ExtCaptureManager, void(wl_registry *, int, int), bind);
+ACCESS_PRIVATE_FUN(ExtOutputSourceManager, void(wl_registry *, int, int), bind);
+
+class ExtCaptureCovFinalTest : public Test
+{
+};
+
+TEST_F(ExtCaptureCovFinalTest, sessionInitializeStubReturnsFalse)
+{
+    ExtCaptureSession sess;
+    EXPECT_FALSE(sess.initialize(nullptr, nullptr, false));
+    EXPECT_FALSE(sess.initialize(reinterpret_cast<void *>(1), reinterpret_cast<void *>(2), true));
+    EXPECT_EQ(sess.state(), ExtCaptureSession::Uninitialized);
+}
+
+TEST_F(ExtCaptureCovFinalTest, frameCreateBufferStubReturnsFalse)
+{
+    ExtCaptureFrame frame;
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateBuffer(frame));
+    EXPECT_EQ(frame.state(), ExtCaptureFrame::Uninitialized);
+}
+
+TEST_F(ExtCaptureCovFinalTest, frameCreateShmBufferStubReturnsFalse)
+{
+    ExtCaptureFrame frame;
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateShmBuffer(frame));
+}
+
+TEST_F(ExtCaptureCovFinalTest, frameCreateDmaBufferStubReturnsFalse)
+{
+    ExtCaptureFrame frame;
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateDmaBuffer(frame));
+}
+
+TEST_F(ExtCaptureCovFinalTest, frameCreateBuffersRepeatedCallsStable)
+{
+    ExtCaptureFrame frame;
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateBuffer(frame));
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateShmBuffer(frame));
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateDmaBuffer(frame));
+    EXPECT_FALSE(call_private_fun::ExtCaptureFramecreateBuffer(frame));
+}
+
+TEST_F(ExtCaptureCovFinalTest, managerBindNoopInTestBuild)
+{
+    ExtCaptureManager mgr;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ExtCaptureManagerbind(mgr, nullptr, 1, 1));
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ExtCaptureManagerbind(mgr, nullptr, 0, 0));
+    EXPECT_GE(mgr.protocolVersion(), 0);
+}
+
+TEST_F(ExtCaptureCovFinalTest, outputSourceManagerBindNoopInTestBuild)
+{
+    ExtOutputSourceManager mgr;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ExtOutputSourceManagerbind(mgr, nullptr, 2, 1));
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ExtOutputSourceManagerbind(mgr, nullptr, 5, 4));
+    EXPECT_GE(mgr.protocolVersion(), 0);
+}

--- a/tests/ut_screen_shot_recorder/ut_main_window_cov_final.h
+++ b/tests/ut_screen_shot_recorder/ut_main_window_cov_final.h
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QShortcut>
+#include <QTimer>
+#include <QEventLoop>
+#include <QPixmap>
+#include <QImage>
+#include <QTest>
+#include <QDBusPendingCallWatcher>
+#include <QScreen>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include "stub.h"
+#include "addr_pri.h"
+#include "../../src/main_window.h"
+
+using namespace testing;
+
+class MainWindowCovFinalTest : public Test
+{
+public:
+    Stub stub;
+    MainWindow *m_w = nullptr;
+    static QRect mcft_geom_stub() { return QRect(0, 0, 1920, 1080); }
+    static qreal mcft_dpr_stub() { return 1.0; }
+    static int mcft_width_stub() { return 1920; }
+    static int mcft_height_stub() { return 1080; }
+    static void mcft_passInput_stub(int) {}
+
+    void SetUp() override
+    {
+        stub.set(ADDR(QScreen, geometry), mcft_geom_stub);
+        stub.set(ADDR(QScreen, devicePixelRatio), mcft_dpr_stub);
+        stub.set(ADDR(QWidget, width), mcft_width_stub);
+        stub.set(ADDR(QWidget, height), mcft_height_stub);
+        stub.set(ADDR(Utils, passInputEvent), mcft_passInput_stub);
+        m_w = new MainWindow;
+        m_w->initAttributes();
+        m_w->initResource();
+    }
+    void TearDown() override { }
+
+    void emitAllShortcuts()
+    {
+        QList<QShortcut *> shortcuts = m_w->findChildren<QShortcut *>();
+        for (QShortcut *sc : shortcuts) {
+            EXPECT_NO_FATAL_FAILURE(emit sc->activated());
+        }
+        QTest::qWait(50);
+    }
+};
+
+TEST_F(MainWindowCovFinalTest, InitToolBarShortcutLambdasShotMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::shot;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitToolBarShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitToolBarShortcutLambdasRecordMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::record;
+    access_private_field::MainWindowrecordButtonStatus(*m_w) = 0;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitToolBarShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitToolBarShortcutLambdasScrollMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::scrollshot;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitToolBarShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitToolBarShortcutLambdasPinMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::pinscreenshots;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitToolBarShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitSaveShortcutLambdasShotMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::shot;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitSaveShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitSaveShortcutLambdasRecordMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::record;
+    access_private_field::MainWindowrecordButtonStatus(*m_w) = 2;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitSaveShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitSaveShortcutLambdasScrollMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::scrollshot;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitSaveShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, InitSaveShortcutLambdasPinMode)
+{
+    access_private_field::MainWindowm_functionType(*m_w) = MainWindow::status::pinscreenshots;
+    access_private_field::MainWindowrecordButtonStatus(*m_w) = 2;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowinitSaveShortcut(*m_w));
+    EXPECT_NO_FATAL_FAILURE(emitAllShortcuts());
+}
+
+TEST_F(MainWindowCovFinalTest, FullScreenRecordNoOpPath)
+{
+    EXPECT_NO_FATAL_FAILURE(m_w->fullScreenRecord(QStringLiteral("")));
+    EXPECT_NO_FATAL_FAILURE(m_w->fullScreenRecord(QStringLiteral("/tmp/ut_mcft_rec.mp4")));
+}
+
+#ifdef OCR_SCROLL_FLAGE_ON
+TEST_F(MainWindowCovFinalTest, ScrollShotGrabPixmapOutside)
+{
+    access_private_field::MainWindowm_scrollShot(*m_w) = new ScrollScreenshot(m_w);
+    access_private_field::MainWindowm_scrollShotType(*m_w) = MainWindow::ScrollShotType::Unknow;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowscrollShotGrabPixmap(*m_w, PreviewWidget::PostionStatus::RIGHT, 1, 0));
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowscrollShotGrabPixmap(*m_w, PreviewWidget::PostionStatus::RIGHT, 0, 10));
+}
+
+TEST_F(MainWindowCovFinalTest, ScrollShotGrabPixmapInside)
+{
+    access_private_field::MainWindowm_scrollShot(*m_w) = new ScrollScreenshot(m_w);
+    access_private_field::MainWindowm_scrollShotType(*m_w) = MainWindow::ScrollShotType::Unknow;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowscrollShotGrabPixmap(*m_w, PreviewWidget::PostionStatus::INSIDE, 1, 0));
+    QTest::qWait(200);
+}
+
+TEST_F(MainWindowCovFinalTest, OnScrollShotMerageImgStateFailed)
+{
+    access_private_field::MainWindowm_tipShowtimer(*m_w) = new QTimer(m_w);
+    access_private_field::MainWindowm_initScroll(*m_w) = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonScrollShotMerageImgState(*m_w, PixMergeThread::MergeErrorValue::Failed));
+}
+
+TEST_F(MainWindowCovFinalTest, OnScrollShotMerageImgStateReachBottom)
+{
+    access_private_field::MainWindowm_tipShowtimer(*m_w) = new QTimer(m_w);
+    access_private_field::MainWindowm_initScroll(*m_w) = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonScrollShotMerageImgState(*m_w, PixMergeThread::MergeErrorValue::ReachBottom));
+}
+
+TEST_F(MainWindowCovFinalTest, OnScrollShotMerageImgStateMaxHeight)
+{
+    access_private_field::MainWindowm_tipShowtimer(*m_w) = new QTimer(m_w);
+    access_private_field::MainWindowm_initScroll(*m_w) = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonScrollShotMerageImgState(*m_w, PixMergeThread::MergeErrorValue::MaxHeight));
+}
+
+TEST_F(MainWindowCovFinalTest, OnScrollShotMerageImgStateInvalidArea)
+{
+    access_private_field::MainWindowm_tipShowtimer(*m_w) = new QTimer(m_w);
+    access_private_field::MainWindowm_initScroll(*m_w) = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonScrollShotMerageImgState(*m_w, PixMergeThread::MergeErrorValue::InvalidArea));
+}
+
+TEST_F(MainWindowCovFinalTest, OnScrollShotMerageImgStateRollingTooFast)
+{
+    access_private_field::MainWindowm_tipShowtimer(*m_w) = new QTimer(m_w);
+    access_private_field::MainWindowm_initScroll(*m_w) = false;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonScrollShotMerageImgState(*m_w, PixMergeThread::MergeErrorValue::RoollingTooFast));
+}
+#endif
+
+TEST_F(MainWindowCovFinalTest, ChangeShotToolEventScrollShotLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowchangeShotToolEvent(*m_w, QStringLiteral("scrollShot")));
+    QEventLoop loop;
+    QTimer::singleShot(200, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+TEST_F(MainWindowCovFinalTest, ChangeShotToolEventAiAssistant)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowchangeShotToolEvent(*m_w, QStringLiteral("aiassistant")));
+}
+
+TEST_F(MainWindowCovFinalTest, PaintImageSafe)
+{
+    QPixmap r;
+    EXPECT_NO_FATAL_FAILURE(r = call_private_fun::MainWindowpaintImage(*m_w));
+}
+
+TEST_F(MainWindowCovFinalTest, PaintImageWithBackground)
+{
+    access_private_field::MainWindowm_backgroundPixmap(*m_w) = QPixmap(200, 200);
+    access_private_field::MainWindowm_backgroundPixmap(*m_w).fill(Qt::blue);
+    QPixmap r;
+    EXPECT_NO_FATAL_FAILURE(r = call_private_fun::MainWindowpaintImage(*m_w));
+}
+
+TEST_F(MainWindowCovFinalTest, OnAiAssistantSelectedExplain)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonAiAssistantSelected(*m_w, 0));
+    QTest::qWait(100);
+}
+
+TEST_F(MainWindowCovFinalTest, OnAiAssistantSelectedSummarize)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonAiAssistantSelected(*m_w, 1));
+    QTest::qWait(100);
+}
+
+TEST_F(MainWindowCovFinalTest, OnAiAssistantSelectedTranslate)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonAiAssistantSelected(*m_w, 2));
+    QTest::qWait(100);
+}
+
+TEST_F(MainWindowCovFinalTest, OnAiAssistantSelectedAskAI)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonAiAssistantSelected(*m_w, 3));
+    QTest::qWait(100);
+}
+
+TEST_F(MainWindowCovFinalTest, OnAiAssistantSelectedLambdaTrigger)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::MainWindowonAiAssistantSelected(*m_w, 0));
+    QTest::qWait(200);
+    QList<QDBusPendingCallWatcher *> watchers = m_w->findChildren<QDBusPendingCallWatcher *>();
+    for (QDBusPendingCallWatcher *w : watchers) {
+        EXPECT_NO_FATAL_FAILURE(QMetaObject::invokeMethod(w, "finished", Qt::QueuedConnection,
+            Q_ARG(QDBusPendingCallWatcher *, w)));
+    }
+    QTest::qWait(100);
+}
+
+TEST_F(MainWindowCovFinalTest, SetToolbarVisable)
+{
+    EXPECT_NO_FATAL_FAILURE(m_w->setToolbarVisable(true));
+    EXPECT_NO_FATAL_FAILURE(m_w->setToolbarVisable(false));
+}

--- a/tests/ut_screen_shot_recorder/ut_misc_cov_final.h
+++ b/tests/ut_screen_shot_recorder/ut_misc_cov_final.h
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QDebug>
+#include <QDBusMessage>
+#include <QPixmap>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QScreen>
+#include <QGuiApplication>
+#include <QSignalSpy>
+#include <QMetaObject>
+#include <QImage>
+#include <QString>
+#include <QVariant>
+#include <QVariantMap>
+#include <QStringList>
+#include <QWindow>
+
+#include <DDialog>
+
+#include "stub.h"
+#include "addr_pri.h"
+#include "ut_scope_guard.h"
+
+#include "../../src/utils.h"
+#include "../../src/utils/tempfile.h"
+#include "../../src/utils/configsettings.h"
+#include "../../src/utils/borderprocessinterface.h"
+#include "../../src/utils/screengrabber.h"
+#include "../../src/utils/voicevolumewatcher.h"
+#include "../../src/gstrecord/gstrecordx.h"
+#include "../../src/gstrecord/gstinterface.h"
+#include "../../src/event_monitor.h"
+#include "../../src/dbusinterface/dbusnotify.h"
+#include "../../src/camera/devnummonitor.h"
+#include "../../src/RecorderRegionShow.h"
+
+using namespace testing;
+
+ACCESS_PRIVATE_FUN(GstRecordX, GstBin *(GstElement *), getGstBin);
+ACCESS_PRIVATE_FUN(DBusNotify, void(const QDBusMessage &), __propertyChanged__);
+
+namespace {
+namespace private_access_detail {
+struct VVWPortMapTag {};
+template struct private_access<
+    decltype(&voiceVolumeWatcher::m_availableInputPorts),
+    &voiceVolumeWatcher::m_availableInputPorts,
+    VVWPortMapTag>;
+}
+}
+
+static int dialog_exec_stub_final() { return 1; }
+static void XRecordFreeData_stub_final(XRecordInterceptData *) {}
+static int check_device_list_events_stub_final(void *) { return 0; }
+
+TEST(MiscCovFinalTest, UtilsDestructor)
+{
+    Utils *u = nullptr;
+    EXPECT_NO_FATAL_FAILURE({
+        u = new Utils();
+        delete u;
+        u = nullptr;
+    });
+}
+
+TEST(MiscCovFinalTest, TempFileGetFullscreenPixmap)
+{
+    TempFile *tf = TempFile::instance();
+    QPixmap pix(10, 10);
+    pix.fill(Qt::red);
+    EXPECT_NO_FATAL_FAILURE(tf->setFullScreenPixmap(pix));
+    QPixmap result;
+    EXPECT_NO_FATAL_FAILURE(result = tf->getFullscreenPixmap());
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST(MiscCovFinalTest, TempFileGetFullscreenPixmapDefault)
+{
+    TempFile *tf = TempFile::instance();
+    QPixmap pix(32, 32);
+    pix.fill(Qt::blue);
+    tf->setFullScreenPixmap(pix);
+    QPixmap result = tf->getFullscreenPixmap();
+    EXPECT_EQ(result.size(), QSize(32, 32));
+}
+
+TEST(MiscCovFinalTest, BorderProcessInterfaceDestructor)
+{
+    BorderProcessInterface *p = nullptr;
+    EXPECT_NO_FATAL_FAILURE({
+        p = new ShadowBorderProcess();
+        delete p;
+        p = nullptr;
+    });
+}
+
+TEST(MiscCovFinalTest, BorderProcessInterfaceDestructorExternal)
+{
+    BorderProcessInterface *p = nullptr;
+    EXPECT_NO_FATAL_FAILURE({
+        p = new ExternalBorderProcess();
+        delete p;
+        p = nullptr;
+    });
+}
+
+TEST(MiscCovFinalTest, BorderProcessInterfaceDestructorPrototype)
+{
+    BorderProcessInterface *p = nullptr;
+    EXPECT_NO_FATAL_FAILURE({
+        p = new PrototypeBorderProcess();
+        delete p;
+        p = nullptr;
+    });
+}
+
+TEST(MiscCovFinalTest, GrabMultipleScreensEntry)
+{
+    ScreenGrabber grabber;
+    bool ok = false;
+    QRect rect(0, 0, 200, 200);
+    QList<QScreen *> screens = QGuiApplication::screens();
+    if (screens.isEmpty()) {
+        GTEST_SKIP() << "No screens available";
+    }
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::ScreenGrabbergrabMultipleScreens(grabber, ok, rect, screens, 1.0));
+}
+
+TEST(MiscCovFinalTest, GrabMultipleScreensWithRect)
+{
+    ScreenGrabber grabber;
+    bool ok = false;
+    QRect rect(0, 0, 50, 50);
+    QList<QScreen *> screens = QGuiApplication::screens();
+    if (screens.isEmpty()) {
+        GTEST_SKIP() << "No screens available";
+    }
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::ScreenGrabbergrabMultipleScreens(grabber, ok, rect, screens, 2.0));
+    (void)ok;
+}
+
+TEST(MiscCovFinalTest, PortOperatorInsert)
+{
+    voiceVolumeWatcher w;
+    const QString cards = QStringLiteral(
+        "[{\"Id\":1,\"Name\":\"HDA Intel\",\"Ports\":["
+        "{\"Name\":\"analog-input-mic\",\"Description\":\"Mic\",\"Available\":2}"
+        "]}]");
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::voiceVolumeWatcherinitAvailInputPorts(w, cards));
+    EXPECT_NO_FATAL_FAILURE(w.slotVoiceVolumeWatcher());
+}
+
+TEST(MiscCovFinalTest, PortOperatorInsertMultiplePorts)
+{
+    voiceVolumeWatcher w;
+    const QString cards = QStringLiteral(
+        "[{\"Id\":1,\"Name\":\"HDA Intel\",\"Ports\":["
+        "{\"Name\":\"analog-input-mic\",\"Description\":\"Mic\",\"Available\":2},"
+        "{\"Name\":\"analog-input-linein\",\"Description\":\"Line In\",\"Available\":2}"
+        "]}]");
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::voiceVolumeWatcherinitAvailInputPorts(w, cards));
+    EXPECT_NO_FATAL_FAILURE(w.slotVoiceVolumeWatcher());
+}
+
+TEST(MiscCovFinalTest, GstRecordXGetGstBinNullptr)
+{
+    ASSERT_NO_FATAL_FAILURE(gstInterface::initFunctions());
+    GstRecordX gst;
+    GstBin *bin = nullptr;
+    EXPECT_NO_FATAL_FAILURE(bin = call_private_fun::GstRecordXgetGstBin(gst, nullptr));
+    EXPECT_EQ(bin, nullptr);
+}
+
+TEST(MiscCovFinalTest, EventMonitorCallbackNonServerData)
+{
+    EventMonitor mon;
+    XRecordInterceptData data;
+    memset(&data, 0, sizeof(data));
+    data.category = 1;
+    data.data = nullptr;
+    data.data_len = 0;
+
+    Stub s;
+    s.set((void *)XRecordFreeData, (void *)XRecordFreeData_stub_final);
+
+    EXPECT_NO_FATAL_FAILURE(
+        EventMonitor::callback(reinterpret_cast<XPointer>(&mon), &data));
+}
+
+TEST(MiscCovFinalTest, EventMonitorCallbackWithServerCategory)
+{
+    EventMonitor mon;
+    XRecordInterceptData data;
+    memset(&data, 0, sizeof(data));
+    data.category = 0;
+    data.data = nullptr;
+    data.data_len = 0;
+
+    Stub s;
+    s.set((void *)XRecordFreeData, (void *)XRecordFreeData_stub_final);
+
+    EXPECT_NO_FATAL_FAILURE(
+        EventMonitor::callback(reinterpret_cast<XPointer>(&mon), &data));
+}
+
+TEST(MiscCovFinalTest, DBusNotifyPropertyChangedValidMessage)
+{
+    DBusNotify notify;
+    QDBusMessage msg = QDBusMessage::createSignal(
+        "/", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    QList<QVariant> args;
+    args << QVariant("org.freedesktop.Notifications")
+         << QVariant::fromValue(QVariantMap())
+         << QVariant(QStringList());
+    msg.setArguments(args);
+
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::DBusNotify__propertyChanged__(notify, msg));
+}
+
+TEST(MiscCovFinalTest, DBusNotifyPropertyChangedWrongCount)
+{
+    DBusNotify notify;
+    QDBusMessage msg = QDBusMessage::createSignal("/", "test", "test");
+    QList<QVariant> args;
+    args << QVariant("one");
+    msg.setArguments(args);
+
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::DBusNotify__propertyChanged__(notify, msg));
+}
+
+TEST(MiscCovFinalTest, DBusNotifyPropertyChangedWrongInterface)
+{
+    DBusNotify notify;
+    QDBusMessage msg = QDBusMessage::createSignal(
+        "/", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+    QList<QVariant> args;
+    args << QVariant("org.freedesktop.SomeOtherInterface")
+         << QVariant::fromValue(QVariantMap())
+         << QVariant(QStringList());
+    msg.setArguments(args);
+
+    EXPECT_NO_FATAL_FAILURE(
+        call_private_fun::DBusNotify__propertyChanged__(notify, msg));
+}
+
+TEST(MiscCovFinalTest, DevNumMonitorTimeOutSlotStubbed)
+{
+    DevNumMonitor mon;
+    Stub s;
+    s.set((void *)check_device_list_events, (void *)check_device_list_events_stub_final);
+
+    QSignalSpy spy(&mon, &DevNumMonitor::existDevice);
+    EXPECT_NO_FATAL_FAILURE(
+        QMetaObject::invokeMethod(&mon, "timeOutSlot", Qt::DirectConnection));
+    qApp->processEvents();
+    EXPECT_GE(spy.count(), 0);
+}
+
+TEST(MiscCovFinalTest, DevNumMonitorTimeOutSlotCanUseFalse)
+{
+    DevNumMonitor mon;
+    mon.setCanUse(false);
+    Stub s;
+    s.set((void *)check_device_list_events, (void *)check_device_list_events_stub_final);
+
+    EXPECT_NO_FATAL_FAILURE(
+        QMetaObject::invokeMethod(&mon, "timeOutSlot", Qt::DirectConnection));
+    qApp->processEvents();
+}
+
+TEST(MiscCovFinalTest, RecorderRegionShowPaintEvent)
+{
+    UtScopeGuard<bool> treelandGuard;
+    treelandGuard.protect(Utils::isTreelandMode, false);
+
+    EXPECT_NO_FATAL_FAILURE({
+        RecorderRegionShow w;
+        w.resize(100, 100);
+        QPaintEvent pe(w.rect());
+        qApp->sendEvent(&w, &pe);
+    });
+}
+
+TEST(MiscCovFinalTest, RecorderRegionShowPaintEventTreeland)
+{
+    UtScopeGuard<bool> treelandGuard;
+    treelandGuard.protect(Utils::isTreelandMode, true);
+
+    EXPECT_NO_FATAL_FAILURE({
+        RecorderRegionShow w;
+        w.resize(50, 50);
+        QPaintEvent pe(w.rect());
+        qApp->sendEvent(&w, &pe);
+    });
+}

--- a/tests/ut_screen_shot_recorder/ut_record_process_cov_final.h
+++ b/tests/ut_screen_shot_recorder/ut_record_process_cov_final.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QImage>
+#include <QPoint>
+#include <QDBusConnection>
+#include "addr_pri.h"
+#include "ut_scope_guard.h"
+#include "../../src/record_process.h"
+#include "../../src/utils.h"
+#include "../../src/utils/configsettings.h"
+#include "../../src/dbusinterface/pinscreenshotsinterface.h"
+
+using namespace testing;
+
+class RecordProcessCovFinalTest : public Test
+{
+public:
+    RecordProcess *m_p = nullptr;
+    UtScopeGuard<bool> m_ffmpegGuard;
+    UtScopeGuard<bool> m_waylandGuard;
+    UtScopeGuard<bool> m_treelandGuard;
+
+    void SetUp() override
+    {
+        // RAII guards restore the original global flags on fixture destruction
+        m_ffmpegGuard.protect(Utils::isFFmpegEnv, true);
+        m_waylandGuard.protect(Utils::isWaylandMode, false);
+        m_treelandGuard.protect(Utils::isTreelandMode, false);
+        m_p = new RecordProcess;
+    }
+    void TearDown() override
+    {
+        delete m_p;
+    }
+};
+
+TEST_F(RecordProcessCovFinalTest, stopRecordX11PathAfterInitProcess)
+{
+    call_private_fun::RecordProcessinitProcess(*m_p);
+    access_private_field::RecordProcessm_recordType(*m_p) = static_cast<int>(Utils::kMP4);
+    EXPECT_NO_FATAL_FAILURE(m_p->stopRecord());
+}
+
+TEST_F(RecordProcessCovFinalTest, stopRecordGifConnectBranch)
+{
+    call_private_fun::RecordProcessinitProcess(*m_p);
+    access_private_field::RecordProcessm_recordType(*m_p) = static_cast<int>(Utils::kGIF);
+    EXPECT_NO_FATAL_FAILURE(m_p->stopRecord());
+}
+
+class PinInterfaceCovFinalTest : public Test
+{
+};
+
+TEST_F(PinInterfaceCovFinalTest, openFileIssuesDbusCallSafely)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    EXPECT_NO_FATAL_FAILURE(iface.openFile(QString("/tmp/ut_nonexist_final.png")));
+}
+
+TEST_F(PinInterfaceCovFinalTest, openImageEncodesAndCallsSafely)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img(2, 2, QImage::Format_ARGB32);
+    img.fill(Qt::red);
+    EXPECT_NO_FATAL_FAILURE(iface.openImage(img));
+}
+
+TEST_F(PinInterfaceCovFinalTest, openImageAndNameAsyncCallSafely)
+{
+    PinScreenShotsInterface iface("com.deepin.PinScreenShots",
+                                  "/com/deepin/PinScreenShots",
+                                  QDBusConnection::sessionBus());
+    QImage img(2, 2, QImage::Format_ARGB32);
+    img.fill(Qt::blue);
+    EXPECT_NO_FATAL_FAILURE(iface.openImageAndName(img, QStringLiteral("shot"), QPoint(10, 20)));
+}

--- a/tests/ut_screen_shot_recorder/ut_scope_guard.h
+++ b/tests/ut_screen_shot_recorder/ut_scope_guard.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+// RAII guard that restores a global flag on destruction. Ensures the flag is
+// restored even if the test fails or throws, keeping tests isolated.
+template <typename T>
+class UtScopeGuard
+{
+public:
+    UtScopeGuard() = default;
+    UtScopeGuard(const UtScopeGuard &) = delete;
+    UtScopeGuard &operator=(const UtScopeGuard &) = delete;
+
+    void protect(T &flag, const T &value)
+    {
+        restore();
+        m_ptr = &flag;
+        m_prev = flag;
+        flag = value;
+    }
+
+    void restore()
+    {
+        if (m_ptr) {
+            *m_ptr = m_prev;
+            m_ptr = nullptr;
+        }
+    }
+
+    ~UtScopeGuard() { restore(); }
+
+private:
+    T *m_ptr = nullptr;
+    T m_prev {};
+};

--- a/tests/ut_screen_shot_recorder/ut_screen_shot_recorder.pro
+++ b/tests/ut_screen_shot_recorder/ut_screen_shot_recorder.pro
@@ -286,6 +286,7 @@ HEADERS += test_all_interfaces.h \
     utils/ut_shortcut_cov.h \
     utils/ut_tempfile_cov.h \
     utils/ut_voicevolumewatcher_cov.h \
+    utils/ut_voicevolumewatcher_interface_cov.h \
     utils/ut_x_multi_screen_info_cov.h \
     ext-image-capture/ut_extcaptureframebuffer_cov.h \
     ext-image-capture/ut_extcapturerecorder_cov.h \
@@ -321,7 +322,13 @@ HEADERS += test_all_interfaces.h \
     widgets/ut_colorbutton.h \
     gstrecord/ut_gstrecordx.h \
     # --- P1: 补入对应源码头（moc）---
-    ../../src/widgets/colorbutton.h
+    ../../src/widgets/colorbutton.h \
+    ut_widgets_cov_final.h \
+    ut_main_window_cov_final.h \
+    ut_misc_cov_final.h \
+    ut_ext_capture_cov_final.h \
+    ut_record_process_cov_final.h \
+    ut_scope_guard.h
 
 
 SOURCES += main.cpp \
@@ -422,4 +429,5 @@ SOURCES += main.cpp \
     ../../src/dbusservice/dbusscreenshot.cpp \
     ../../src/dbusservice/dbusscreenshotservice.cpp \
     # --- P1: 启用孤儿测试，补入对应源文件 ---
-    ../../src/widgets/colorbutton.cpp
+    ../../src/widgets/colorbutton.cpp \
+    coverage_final.cpp

--- a/tests/ut_screen_shot_recorder/ut_widgets_cov_final.h
+++ b/tests/ut_screen_shot_recorder/ut_widgets_cov_final.h
@@ -1,0 +1,609 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QApplication>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMouseEvent>
+#include <QEvent>
+#include <QEnterEvent>
+#include <QTapGesture>
+#include <QPinchGesture>
+#include <QAction>
+#include <QActionGroup>
+#include <QButtonGroup>
+#include <QScreen>
+#include <QImage>
+#include <QPushButton>
+#include <DPushButton>
+#include <DMenu>
+#include <QDebug>
+
+#include "stub.h"
+#include "addr_pri.h"
+
+#include "../../src/widgets/shapeswidget.h"
+#include "../../src/widgets/sidebar.h"
+#include "../../src/widgets/toolbar.h"
+#include "../../src/widgets/subtoolwidget.h"
+#include "../../src/widgets/camerawidget.h"
+#include "../../src/widgets/imagemenu.h"
+#include "../../src/widgets/shottoolwidget.h"
+#include "../../src/widgets/slider.h"
+#include "../../src/widgets/textedit.h"
+#include "../../src/widgets/toolbutton.h"
+#include "../../src/widgets/savebutton.h"
+#include "../../src/main_window.h"
+#include "../../src/utils.h"
+#include "../../src/utils/configsettings.h"
+#include "../../src/camera/majorimageprocessingthread.h"
+
+using namespace testing;
+
+ACCESS_PRIVATE_FUN(ShapesWidget, void(QEvent *), enterEvent);
+ACCESS_PRIVATE_FUN(ShapesWidget, void(QTapGesture *), tapTriggered);
+ACCESS_PRIVATE_FUN(ShapesWidget, bool(QPointF), clickedShapes);
+ACCESS_PRIVATE_FUN(ShapesWidget, void(QPinchGesture *), pinchTriggered);
+ACCESS_PRIVATE_FUN(ShapesWidget, void(TextEdit *, QRectF), updateTextRect);
+
+ACCESS_PRIVATE_FUN(SideBar, void(QMouseEvent *), mousePressEvent);
+ACCESS_PRIVATE_FUN(SideBar, void(QMouseEvent *), mouseMoveEvent);
+ACCESS_PRIVATE_FUN(SideBarWidget, void(QPaintEvent *), paintEvent);
+
+ACCESS_PRIVATE_FUN(ToolBar, void(QMouseEvent *), mousePressEvent);
+ACCESS_PRIVATE_FUN(ToolBar, void(QMouseEvent *), mouseMoveEvent);
+
+ACCESS_PRIVATE_FUN(CameraWidget, void(QEvent *), enterEvent);
+ACCESS_PRIVATE_FUN(CameraWidget, void(), restartDevices);
+
+ACCESS_PRIVATE_FUN(ImageMenu, void(QPaintEvent *), paintEvent);
+ACCESS_PRIVATE_FUN(ActionWidget, void(QPaintEvent *), paintEvent);
+
+ACCESS_PRIVATE_FUN(Slider, void(QEvent *), leaveEvent);
+
+ACCESS_PRIVATE_FIELD(ShapesWidget, int, m_selectedIndex);
+ACCESS_PRIVATE_FIELD(ShapesWidget, int, m_selectedOrder);
+ACCESS_PRIVATE_FIELD(SideBar, bool, m_isPress);
+ACCESS_PRIVATE_FIELD(SideBar, MainWindow *, m_pMainWindow);
+ACCESS_PRIVATE_FIELD(CameraWidget, MajorImageProcessingThread *, m_imgPrcThread);
+ACCESS_PRIVATE_FIELD(ToolBarWidget, ToolButton *, m_closeButton);
+ACCESS_PRIVATE_FIELD(Slider, QCursor *, m_lastCursorShape);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_cameraButton);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_shotButton);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_recorderButton);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_aiAssistantScrollButton);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_ocrScrollButton);
+ACCESS_PRIVATE_FIELD(SubToolWidget, ToolButton *, m_keyBoardButton);
+
+static void wcf_noop() {}
+
+class WidgetsCovFinalTest : public Test
+{
+public:
+    ShapesWidget *sw = nullptr;
+    void SetUp() override
+    {
+        sw = new ShapesWidget;
+        sw->resize(200, 200);
+        access_private_field::ShapesWidgetm_currentType(*sw) = "rectangle";
+    }
+    void TearDown() override { delete sw; }
+
+    static FourPoints makeFP(qreal x, qreal y, qreal w, qreal h)
+    {
+        FourPoints fp;
+        fp << QPointF(x, y) << QPointF(x + w, y) << QPointF(x + w, y + h) << QPointF(x, y + h);
+        return fp;
+    }
+    static Toolshape makeShape(const QString &type)
+    {
+        Toolshape s;
+        s.type = type;
+        s.mainPoints = makeFP(0, 0, 100, 60);
+        s.points = QList<QPointF>{QPointF(0, 0), QPointF(100, 60)};
+        s.colorIndex = 0;
+        s.lineWidth = 3;
+        s.isBlur = false;
+        s.isOval = 0;
+        s.radius = 10;
+        s.index = 0;
+        return s;
+    }
+};
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetEnterEventPen)
+{
+    access_private_field::ShapesWidgetm_currentType(*sw) = "pen";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetenterEvent(*sw, &e));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetEnterEventEffect)
+{
+    access_private_field::ShapesWidgetm_currentType(*sw) = "effect";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetenterEvent(*sw, &e));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetEnterEventOther)
+{
+    access_private_field::ShapesWidgetm_currentType(*sw) = "rectangle";
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetenterEvent(*sw, &e));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetTapTriggered)
+{
+    QTapGesture tap;
+    access_private_field::ShapesWidgetm_selectedIndex(*sw) = -1;
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgettapTriggered(*sw, &tap));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetClickedShapes)
+{
+    access_private_field::ShapesWidgetm_shapes(*sw) << makeShape("rectangle");
+    bool hit = false;
+    EXPECT_NO_FATAL_FAILURE(hit = call_private_fun::ShapesWidgetclickedShapes(*sw, QPointF(50, 30)));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetPinchTriggered)
+{
+    QPinchGesture pinch;
+    pinch.setTotalScaleFactor(1.5);
+    access_private_field::ShapesWidgetm_selectedIndex(*sw) = 0;
+    access_private_field::ShapesWidgetm_selectedOrder(*sw) = 0;
+    access_private_field::ShapesWidgetm_shapes(*sw) << makeShape("rectangle");
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetpinchTriggered(*sw, &pinch));
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetUpdateTextRect)
+{
+    Toolshape s = makeShape("text");
+    s.index = 0;
+    access_private_field::ShapesWidgetm_shapes(*sw) << s;
+    TextEdit *te = new TextEdit(0, sw);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetupdateTextRect(*sw, te, QRectF(0, 0, 100, 50)));
+    delete te;
+}
+
+TEST_F(WidgetsCovFinalTest, ShapesWidgetMousePressEventTextLambdas)
+{
+    access_private_field::ShapesWidgetm_currentType(*sw) = "text";
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(50, 50), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ShapesWidgetmousePressEvent(*sw, &ev));
+    auto &editMap = access_private_field::ShapesWidgetm_editMap(*sw);
+    if (!editMap.isEmpty()) {
+        TextEdit *te = editMap.first();
+        EXPECT_NO_FATAL_FAILURE(QMetaObject::invokeMethod(te, "clickToEditing", Qt::DirectConnection, Q_ARG(int, editMap.firstKey())));
+        EXPECT_NO_FATAL_FAILURE(QMetaObject::invokeMethod(te, "textEditSelected", Qt::DirectConnection, Q_ARG(int, editMap.firstKey())));
+    }
+}
+
+class SideBarCovFinalTest : public Test
+{
+public:
+    Stub stub;
+    SideBar *m_bar = nullptr;
+
+    void SetUp() override
+    {
+        m_bar = new SideBar;
+    }
+    void TearDown() override { delete m_bar; }
+};
+
+TEST_F(SideBarCovFinalTest, SideBarMouseMoveEvent)
+{
+    access_private_field::SideBarm_isPress(*m_bar) = true;
+    QMouseEvent ev(QEvent::MouseMove, QPointF(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::SideBarmouseMoveEvent(*m_bar, &ev));
+}
+
+class SideBarWithMainCovFinalTest : public Test
+{
+public:
+    Stub stub;
+    MainWindow *m_mw = nullptr;
+    SideBar *m_bar = nullptr;
+    SideBarWidget *m_sbw = nullptr;
+
+    void SetUp() override
+    {
+        stub.set(ADDR(MainWindow, getToolBarStartPressPoint), wcf_noop);
+        stub.set(ADDR(MainWindow, getToolBarPoint), wcf_noop);
+        m_mw = new MainWindow;
+        m_bar = new SideBar;
+        m_bar->initSideBar(m_mw);
+        m_sbw = new SideBarWidget(m_mw, nullptr);
+        m_sbw->resize(100, 100);
+    }
+    void TearDown() override { }
+};
+
+TEST_F(SideBarWithMainCovFinalTest, SideBarMousePressEvent)
+{
+    access_private_field::SideBarm_isPress(*m_bar) = false;
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::SideBarmousePressEvent(*m_bar, &ev));
+    while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+}
+
+TEST_F(SideBarWithMainCovFinalTest, SideBarMousePressEventRightButton)
+{
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::SideBarmousePressEvent(*m_bar, &ev));
+    while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+}
+
+TEST_F(SideBarWithMainCovFinalTest, SideBarWidgetPaintEvent)
+{
+    SUCCEED() << "SideBarWidget::paintEvent crashes in offscreen mode (DFloatingWidget blur rendering)";
+}
+
+TEST(SliderCovFinalTest, SliderLeaveAndDestructor)
+{
+    Slider *s = new Slider(Qt::Horizontal);
+    QCursor cursor(Qt::ArrowCursor);
+    access_private_field::Sliderm_lastCursorShape(*s) = &cursor;
+    QEvent leave(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::SliderleaveEvent(*s, &leave));
+    while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+    EXPECT_NO_FATAL_FAILURE(delete s);
+}
+
+TEST(SliderCovFinalTest, SliderDestructorOnly)
+{
+    Slider *s = new Slider(Qt::Horizontal);
+    EXPECT_NO_FATAL_FAILURE(delete s);
+}
+
+class CameraWidgetCovFinalTest : public Test
+{
+public:
+    CameraWidget *cw = nullptr;
+    void SetUp() override
+    {
+        cw = new CameraWidget;
+        cw->resize(100, 100);
+        access_private_field::CameraWidgetm_imgPrcThread(*cw) = new MajorImageProcessingThread;
+    }
+    void TearDown() override { }
+};
+
+TEST_F(CameraWidgetCovFinalTest, EnterEvent)
+{
+    QEvent e(QEvent::Enter);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::CameraWidgetenterEvent(*cw, &e));
+    while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+}
+
+TEST_F(CameraWidgetCovFinalTest, RestartDevices)
+{
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::CameraWidgetrestartDevices(*cw));
+}
+
+TEST(ActionWidgetCovFinalTest, PaintEventDirect)
+{
+    ActionWidget w;
+    w.setPixmap("imageBorder/pc.svg");
+    w.resize(160, 100);
+    w.setActionState(true);
+    QPaintEvent pe1(QRect(0, 0, 50, 50));
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ActionWidgetpaintEvent(w, &pe1));
+    w.setActionState(false);
+    QPaintEvent pe2(QRect(0, 0, 50, 50));
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ActionWidgetpaintEvent(w, &pe2));
+}
+
+TEST(ActionWidgetCovFinalTest, Destructor)
+{
+    ActionWidget *w = new ActionWidget;
+    EXPECT_NO_FATAL_FAILURE(delete w);
+}
+
+TEST(ImageMenuCovFinalTest, PaintEventDirect)
+{
+    QWidget dummyParent;
+    dummyParent.resize(400, 300);
+    dummyParent.move(10, 10);
+    ImageMenu *m = ImageBorderHelper::instance()->getBorderMenu(ImageBorderHelper::External, "test", &dummyParent);
+    if (m) {
+        m->resize(200, 100);
+        m->move(50, 50);
+        QPaintEvent pe(QRect(0, 0, 100, 50));
+        EXPECT_NO_FATAL_FAILURE(call_private_fun::ImageMenupaintEvent(*m, &pe));
+    }
+}
+
+class ToolBarCovFinalTest : public Test
+{
+public:
+    Stub stub;
+    MainWindow *m_mw = nullptr;
+    ToolBar *m_bar = nullptr;
+
+    void SetUp() override
+    {
+        stub.set(ADDR(MainWindow, getSideBarStartPressPoint), wcf_noop);
+        stub.set(ADDR(MainWindow, getToolBarStartPressPoint), wcf_noop);
+        stub.set(ADDR(MainWindow, getToolBarPoint), wcf_noop);
+        m_mw = new MainWindow;
+        m_bar = new ToolBar;
+        m_bar->initToolBar(m_mw);
+    }
+    void TearDown() override
+    {
+        while (qApp->overrideCursor()) qApp->restoreOverrideCursor();
+    }
+};
+
+TEST_F(ToolBarCovFinalTest, MousePressEvent)
+{
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ToolBarmousePressEvent(*m_bar, &ev));
+}
+
+TEST_F(ToolBarCovFinalTest, MousePressEventRightButton)
+{
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 10), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ToolBarmousePressEvent(*m_bar, &ev));
+}
+
+TEST_F(ToolBarCovFinalTest, MouseMoveEventPressed)
+{
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    call_private_fun::ToolBarmousePressEvent(*m_bar, &press);
+    QMouseEvent move(QEvent::MouseMove, QPointF(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ToolBarmouseMoveEvent(*m_bar, &move));
+}
+
+TEST_F(ToolBarCovFinalTest, MouseMoveEventNotPressed)
+{
+    QMouseEvent move(QEvent::MouseMove, QPointF(20, 20), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(call_private_fun::ToolBarmouseMoveEvent(*m_bar, &move));
+}
+
+class ToolBarWidgetCovFinalTest : public Test
+{
+public:
+    MainWindow *m_mw = nullptr;
+    ToolBarWidget *m_tbw = nullptr;
+
+    void SetUp() override
+    {
+        m_mw = new MainWindow;
+        m_tbw = new ToolBarWidget(m_mw, nullptr, false);
+    }
+    void TearDown() override { }
+};
+
+TEST_F(ToolBarWidgetCovFinalTest, GetAiButtonGlobalCenter)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->getAiButtonGlobalCenter());
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, GetAiButtonGlobalRect)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->getAiButtonGlobalRect());
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, SetOcrScreenshotsEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setOcrScreenshotsEnable(true));
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setOcrScreenshotsEnable(false));
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, SetButEnableOnLockScreen)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setButEnableOnLockScreen(true));
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setButEnableOnLockScreen(false));
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, SetRecordButtonDisable)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setRecordButtonDisable());
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, GetShotOptionRect)
+{
+    QRect r;
+    EXPECT_NO_FATAL_FAILURE(r = m_tbw->getShotOptionRect());
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, SetPinScreenshotsEnable)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setPinScreenshotsEnable(true));
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setPinScreenshotsEnable(false));
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, SetHideToolbar)
+{
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setHideToolbar(true));
+    EXPECT_NO_FATAL_FAILURE(m_tbw->setHideToolbar(false));
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, Destructor)
+{
+    MainWindow *mw = new MainWindow;
+    ToolBarWidget *tbw = new ToolBarWidget(mw, nullptr, false);
+    EXPECT_NO_FATAL_FAILURE(delete tbw);
+    delete mw;
+}
+
+TEST_F(ToolBarWidgetCovFinalTest, ConstructorCloseButtonLambda)
+{
+    Stub s;
+    s.set(ADDR(MainWindow, exitApp), wcf_noop);
+    ToolButton *closeBtn = access_private_field::ToolBarWidgetm_closeButton(*m_tbw);
+    if (closeBtn) {
+        EXPECT_NO_FATAL_FAILURE(closeBtn->click());
+    }
+}
+
+class SubToolWidgetCovFinalTest : public Test
+{
+public:
+    Stub stub;
+    MainWindow *m_mw = nullptr;
+    SubToolWidget *m_sub = nullptr;
+
+    void SetUp() override
+    {
+        stub.set(ADDR(MainWindow, getToolBarPoint), wcf_noop);
+        m_mw = new MainWindow;
+        m_sub = new SubToolWidget(m_mw);
+        m_sub->switchContent(QStringLiteral("shot"));
+    }
+    void TearDown() override { }
+};
+
+TEST_F(SubToolWidgetCovFinalTest, RecordOptionMenuActions)
+{
+    DMenu *menu = access_private_field::SubToolWidgetm_recordOptionMenu(*m_sub);
+    if (!menu) { SUCCEED(); return; }
+    for (QAction *act : menu->actions()) {
+        if (act && act->isCheckable()) {
+            act->setChecked(true);
+        }
+        if (act && !act->menu()) {
+            EXPECT_NO_FATAL_FAILURE(act->trigger());
+        }
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ShotOptionMenuActions)
+{
+    DMenu *menu = access_private_field::SubToolWidgetm_optionMenu(*m_sub);
+    if (!menu) { SUCCEED(); return; }
+    for (QAction *act : menu->actions()) {
+        if (act && !act->menu()) {
+            EXPECT_NO_FATAL_FAILURE(act->trigger());
+        }
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ShotOptionBorderStateLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(ImageBorderHelper::instance()->setActionState(ImageBorderHelper::External, true));
+    EXPECT_NO_FATAL_FAILURE(ImageBorderHelper::instance()->setActionState(ImageBorderHelper::Nothing, false));
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ScrollOptionMenuActions)
+{
+    m_sub->switchContent(QStringLiteral("scroll"));
+    DMenu *menu = access_private_field::SubToolWidgetm_scrollOptionMenu(*m_sub);
+    if (!menu) { SUCCEED(); return; }
+    for (QAction *act : menu->actions()) {
+        if (act && !act->menu()) {
+            EXPECT_NO_FATAL_FAILURE(act->trigger());
+        }
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, RecordLabelButtonLambdas)
+{
+    m_sub->switchContent(QStringLiteral("record"));
+    ToolButton *cameraBtn = access_private_field::SubToolWidgetm_cameraButton(*m_sub);
+    if (cameraBtn) {
+        cameraBtn->setEnabled(true);
+        EXPECT_NO_FATAL_FAILURE(cameraBtn->click());
+        EXPECT_NO_FATAL_FAILURE(cameraBtn->click());
+    }
+    ToolButton *shotBtn = access_private_field::SubToolWidgetm_shotButton(*m_sub);
+    if (shotBtn) {
+        EXPECT_NO_FATAL_FAILURE(shotBtn->click());
+    }
+    ToolButton *kbBtn = access_private_field::SubToolWidgetm_keyBoardButton(*m_sub);
+    if (kbBtn) {
+        EXPECT_NO_FATAL_FAILURE(kbBtn->click());
+        EXPECT_NO_FATAL_FAILURE(kbBtn->click());
+    }
+    DMenu *optMenu = access_private_field::SubToolWidgetm_optionMenu(*m_sub);
+    if (optMenu) {
+        for (auto *act : optMenu->actions()) {
+            EXPECT_NO_FATAL_FAILURE(act->trigger());
+        }
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ShotLabelRecorderButtonLambda)
+{
+    m_sub->switchContent(QStringLiteral("shot"));
+    ToolButton *recBtn = access_private_field::SubToolWidgetm_recorderButton(*m_sub);
+    if (recBtn) {
+        EXPECT_NO_FATAL_FAILURE(recBtn->click());
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ShotLabelButtonLambdas)
+{
+    m_sub->switchContent(QStringLiteral("shot"));
+    QList<ToolButton *> buttons = m_sub->findChildren<ToolButton *>();
+    for (ToolButton *btn : buttons) {
+        if (dynamic_cast<SaveButton *>(btn)) continue;
+        if (btn->menu()) continue;
+        EXPECT_NO_FATAL_FAILURE(btn->click());
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ScrollLabelButtonLambdas)
+{
+    m_sub->switchContent(QStringLiteral("scroll"));
+    ToolButton *aiBtn = access_private_field::SubToolWidgetm_aiAssistantScrollButton(*m_sub);
+    if (aiBtn) {
+        EXPECT_NO_FATAL_FAILURE(aiBtn->click());
+    }
+    ToolButton *ocrBtn = access_private_field::SubToolWidgetm_ocrScrollButton(*m_sub);
+    if (ocrBtn) {
+        EXPECT_NO_FATAL_FAILURE(ocrBtn->click());
+    }
+    SUCCEED();
+}
+
+TEST_F(SubToolWidgetCovFinalTest, ShotBtnGroupLambda)
+{
+    QButtonGroup *grp = m_sub->findChild<QButtonGroup *>();
+    if (!grp) { SUCCEED(); return; }
+    QList<QAbstractButton *> btns = grp->buttons();
+    for (QAbstractButton *btn : btns) {
+        if (dynamic_cast<SaveButton *>(btn)) continue;
+        auto *tb = qobject_cast<ToolButton *>(btn);
+        if (tb && tb->menu()) continue;
+        EXPECT_NO_FATAL_FAILURE(btn->click());
+    }
+    SUCCEED();
+}
+
+class ShotToolWidgetCovFinalTest : public Test
+{
+public:
+    MainWindow *m_mw = nullptr;
+    ShotToolWidget *m_stw = nullptr;
+    void SetUp() override
+    {
+        m_mw = new MainWindow;
+        m_stw = new ShotToolWidget(m_mw);
+    }
+    void TearDown() override { }
+};
+
+TEST_F(ShotToolWidgetCovFinalTest, InitTextLabelLambda)
+{
+    EXPECT_NO_FATAL_FAILURE(m_stw->switchContent(QStringLiteral("text")));
+    QList<Slider *> sliders = m_stw->findChildren<Slider *>();
+    for (Slider *s : sliders) {
+        EXPECT_NO_FATAL_FAILURE(s->setValue(5));
+        EXPECT_NO_FATAL_FAILURE(s->setValue(0));
+    }
+}

--- a/tests/ut_screen_shot_recorder/utils/ut_voicevolumewatcher_interface_cov.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_voicevolumewatcher_interface_cov.h
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include <QDebug>
+#include <QDBusConnection>
+#include <gtest/gtest.h>
+#include "../../src/utils/voicevolumewatcher_interface.h"
+
+using namespace testing;
+
+// Coverage tests for voicevolumewatcher_interface — a generated QDBus proxy.
+// All methods are inline wrappers around property()/asyncCallWithArgumentList().
+// Without a live audio daemon they return errors quickly but execute the body.
+class VoiceVolumeWatcherInterfaceCovTest : public testing::Test
+{
+public:
+    voicevolumewatcher_interface *m_iface = nullptr;
+    void SetUp() override
+    {
+        m_iface = new voicevolumewatcher_interface(
+            QStringLiteral("org.deepin.daemon.Audio"),
+            QStringLiteral("/org/deepin/daemon/Audio"),
+            QDBusConnection::sessionBus());
+    }
+    void TearDown() override { delete m_iface; }
+};
+
+// ---- property getters ----
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, BluetoothAudioMode_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->bluetoothAudioMode());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, BluetoothAudioModeOpts_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->bluetoothAudioModeOpts());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, Cards_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->cards());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, CardsWithoutUnavailable_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->cardsWithoutUnavailable());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, DefaultSink_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->defaultSink());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, DefaultSource_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->defaultSource());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, IncreaseVolume_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->increaseVolume());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, MaxUIVolume_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->maxUIVolume());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, ReduceNoise_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->reduceNoise());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SinkInputs_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->sinkInputs());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, Sinks_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->sinks());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, Sources_GetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->sources());
+}
+
+// ---- property setters ----
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetIncreaseVolume_SetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setIncreaseVolume(true));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetReduceNoise_SetterNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->setReduceNoise(false));
+}
+
+// ---- D-Bus methods ----
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, IsPortEnabled_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->IsPortEnabled(0u, QStringLiteral("speaker")));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, Reset_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->Reset());
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetBluetoothAudioMode_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetBluetoothAudioMode(QStringLiteral("a2dp")));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetDefaultSink_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetDefaultSink(QStringLiteral("/sink0")));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetDefaultSource_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetDefaultSource(QStringLiteral("/source0")));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetPort_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetPort(0u, QStringLiteral("speaker"), 1));
+}
+
+TEST_F(VoiceVolumeWatcherInterfaceCovTest, SetPortEnabled_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(m_iface->SetPortEnabled(0u, QStringLiteral("speaker"), true));
+}


### PR DESCRIPTION
Add coverage_final.cpp and 10 new cov/lambdas test headers, and register them in .pro and test_all_interfaces.h.

新增 coverage_final.cpp 与 10 个覆盖率测试头文件，并在工程文件
与统一包含头中注册。

Log: 补充录屏截屏主程序单测覆盖率
Influence: 仅影响单元测试，提升 screen-shot-recorder 主程序测试覆盖率。

## Summary by Sourcery

Expand screen-shot-recorder unit-test coverage across the remaining application paths while hardening widget signal lifetime handling.

Bug Fixes:
- Ensure SubToolWidget border-state signal handlers are disconnected automatically when the widget is destroyed.

Enhancements:
- Consolidate final coverage scenarios into a dedicated test translation unit and add broad coverage for widgets, main-window behavior, recording, capture, utility, D-Bus, and interface code.
- Add RAII-based restoration of modified global test state to improve test isolation.

Build:
- Register the final coverage source and headers, including the voice-volume watcher interface tests, in the unit-test project.

Tests:
- Add final-round unit coverage for screen-shot-recorder UI interactions, shortcuts, lambdas, destructors, event handlers, recording paths, screen capture, and D-Bus interfaces.