### PR TITLE
fix: fix toolbar off-screen on dual-screen with non-integer scaling

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -2485,52 +2485,49 @@ void MainWindow::updateToolBarPos()
     //qDebug() << "工具栏坐标: " << toolbarPoint.x() << toolbarPoint.y() ;
 
     bool toolIsInScreen = false; //
-    QRect tempScreen ;//捕捉区域所在的屏幕，以捕捉区域左上角为准
+    QRect tempScreen ;//捕捉区域所在的屏幕（逻辑坐标），以捕捉区域左上角为准
     // 根据屏幕的具体实际坐标修正Y值
     // 多屏情况下，横向，有可能在屏幕外面。
+    // 注意：m_screenInfo 中 x/y 为逻辑原点，width/height 为物理尺寸（构造时乘了 m_pixelRatio），
+    // 故此处统一换算为逻辑 QRect 再做归属判定，避免逻辑/物理坐标混用导致出屏。
     if (m_isScreenVertical == false && m_screenInfo.size() >= 2) {
         for (int i = 0; i < m_screenInfo.size(); ++i) {
             //qDebug() << "屏幕: " << m_screenInfo[i].name <<  m_screenInfo[i].x << m_screenInfo[i].y << m_screenInfo[i].width << m_screenInfo[i].height;
+            //当前屏幕的逻辑 QRect（toolbarPoint/recordX/recordY 均为逻辑坐标，同空间比较）
+            QRect screenRect(m_screenInfo[i].x, m_screenInfo[i].y,
+                             static_cast<int>(m_screenInfo[i].width / m_pixelRatio),
+                             static_cast<int>(m_screenInfo[i].height / m_pixelRatio));
             //工具栏是否在屏幕内
-            toolIsInScreen = toolbarPoint.x() * m_pixelRatio >= m_screenInfo[i].x &&
-                             toolbarPoint.x() * m_pixelRatio  < (m_screenInfo[i].x + m_screenInfo[i].width) &&
-                             (toolbarPoint.y() - m_screenInfo[i].height) / m_pixelRatio + m_screenInfo[i].height >= m_screenInfo[i].y &&
-                             (toolbarPoint.y() - m_screenInfo[i].height) / m_pixelRatio + m_screenInfo[i].height < (m_screenInfo[i].y + m_screenInfo[i].height);
-            bool recordIsInScreen =  recordX * m_pixelRatio >= m_screenInfo[i].x &&
-                                     recordX * m_pixelRatio < (m_screenInfo[i].x + m_screenInfo[i].width) &&
-                                     recordY * m_pixelRatio >= m_screenInfo[i].y - 1 &&
-                                     recordY * m_pixelRatio < (m_screenInfo[i].y + m_screenInfo[i].height);
+            toolIsInScreen = screenRect.contains(toolbarPoint);
+            bool recordIsInScreen =  screenRect.contains(QPoint(recordX, recordY));
             //qDebug() << "工具栏是否在屏幕（"<< m_screenInfo[i].name<<"）内 ? " << toolIsInScreen;
             //qDebug() << "捕捉区域是否在屏幕（"<< m_screenInfo[i].name<<"）内 ? " << recordIsInScreen;
             //取出捕捉区域所在的屏幕
             if (recordIsInScreen) {
-                tempScreen.setX(m_screenInfo[i].x);
-                tempScreen.setY(m_screenInfo[i].y);
-                tempScreen.setWidth(m_screenInfo[i].width);
-                tempScreen.setHeight(m_screenInfo[i].height);
+                tempScreen = screenRect;
             }
             //判断工具栏左上角在哪块屏幕上
             if (toolIsInScreen) {
                 //qDebug() << "工具栏是否在屏幕（"<< m_screenInfo[i].name<<"）内 ? " << toolIsInScreen;
                 //qDebug() << "屏幕: " << m_screenInfo[i].name <<  m_screenInfo[i].x << m_screenInfo[i].y << m_screenInfo[i].width<<m_screenInfo[i].height;
 
-                if (toolbarPoint.y() < m_screenInfo[i].y + TOOLBAR_Y_SPACING) {
+                if (toolbarPoint.y() < screenRect.y() + TOOLBAR_Y_SPACING) {
                     // 屏幕上超出
                     toolbarPoint.setY(recordY + TOOLBAR_Y_SPACING);
-                    //toolbarPoint.setY(m_screenInfo[i].y + TOOLBAR_Y_SPACING);
+                    //toolbarPoint.setY(screenRect.y() + TOOLBAR_Y_SPACING);
                     //qDebug() << "工具栏位置超出屏幕上边缘，已矫正 >>> toolbarPoint: " << toolbarPoint;
-                } else if (toolbarPoint.y() > m_screenInfo[i].y / m_pixelRatio + m_screenInfo[i].height / m_pixelRatio - m_toolBar->height() - TOOLBAR_Y_SPACING) {
+                } else if (toolbarPoint.y() > screenRect.bottom() - m_toolBar->height() - TOOLBAR_Y_SPACING) {
                     // 屏幕下超出
                     int y = std::max(recordY - m_toolBar->height() - TOOLBAR_Y_SPACING, 0);
                     //qDebug() << ">>> y: " << y;
-                    if (y > m_screenInfo[i].y + m_screenInfo[i].height / m_pixelRatio - m_toolBar->height() - TOOLBAR_Y_SPACING)
-                        y = m_screenInfo[i].y + static_cast<int>(m_screenInfo[i].height / m_pixelRatio) - m_toolBar->height() - TOOLBAR_Y_SPACING;
+                    if (y > screenRect.bottom() - m_toolBar->height() - TOOLBAR_Y_SPACING)
+                        y = screenRect.bottom() - m_toolBar->height() - TOOLBAR_Y_SPACING;
 
                     //已经调整工具栏位置之后，发现工具栏位置超出屏幕上边缘
-                    if (y < m_screenInfo[i].y) {
+                    if (y < screenRect.y()) {
                         y = recordY + TOOLBAR_Y_SPACING;
                     }
-                    if (recordY - m_screenInfo[i].y < m_toolBar->height() + TOOLBAR_Y_SPACING) {
+                    if (recordY - screenRect.y() < m_toolBar->height() + TOOLBAR_Y_SPACING) {
                         y = recordY + TOOLBAR_Y_SPACING;
                     }
                     toolbarPoint.setY(y);
@@ -2556,6 +2553,17 @@ void MainWindow::updateToolBarPos()
             } else {
                 toolbarPoint.setX(m_toolbarLastPoint.x());
                 toolbarPoint.setY(m_toolbarLastPoint.y());
+            }
+            // 兜底：将工具栏双向钳制到捕捉区域所在屏幕（逻辑边界）内，避免出屏
+            if (!tempScreen.isNull()) {
+                int minX = tempScreen.x() + TOOLBAR_Y_SPACING;
+                int maxX = tempScreen.right() - m_toolBar->width() - TOOLBAR_Y_SPACING;
+                int minY = tempScreen.y() + TOOLBAR_Y_SPACING;
+                int maxY = tempScreen.bottom() - m_toolBar->height() - TOOLBAR_Y_SPACING;
+                if (minX <= maxX)
+                    toolbarPoint.setX(qBound(minX, toolbarPoint.x(), maxX));
+                if (minY <= maxY)
+                    toolbarPoint.setY(qBound(minY, toolbarPoint.y(), maxY));
             }
         }
     }
@@ -2609,11 +2617,12 @@ void MainWindow::updateSideBarPos()
                 if (m_screenCount > 1) {
                     int i = 0;
                     for (; i < m_screenCount; ++i) {
-                        if (m_screenInfo[i].x <= sidebarPoint.x() && m_screenInfo[i].x + m_screenInfo[i].width >= sidebarPoint.x()) {
+                        // sidebarPoint 为逻辑坐标，屏幕右边界用逻辑宽（物理宽 / m_pixelRatio）
+                        if (m_screenInfo[i].x <= sidebarPoint.x() && m_screenInfo[i].x + static_cast<int>(m_screenInfo[i].width / m_pixelRatio) >= sidebarPoint.x()) {
                             break;
                         }
                     }
-                    curCurScreenH = m_screenInfo[i].height;
+                    curCurScreenH = static_cast<int>(m_screenInfo[i].height / m_pixelRatio);
                 }
                 if (sidebarPoint.y() + m_sideBar->height() > curCurScreenH) {
                     sidebarPoint.setX(recordX - m_sideBar->width() - SIDEBAR_X_SPACING);
@@ -2698,14 +2707,18 @@ void MainWindow::updateSideBarPos()
 
     // 根据屏幕的具体实际坐标修正Y值
     // 多屏情况下， 右下角有可能在屏幕外面。
+    // sidebarPoint 为逻辑坐标，屏幕边界统一用逻辑宽高（物理 / m_pixelRatio）。
     for (int i = 0; i < m_screenInfo.size(); ++i) {
-        if (sidebarPoint.x() + m_sideBar->width() >= m_screenInfo[i].x && sidebarPoint.x() + m_sideBar->width() <= m_screenInfo[i].x + m_screenInfo[i].width) {
-            if (sidebarPoint.y() < m_screenInfo[i].y + TOOLBAR_Y_SPACING) {
+        QRect screenRect(m_screenInfo[i].x, m_screenInfo[i].y,
+                         static_cast<int>(m_screenInfo[i].width / m_pixelRatio),
+                         static_cast<int>(m_screenInfo[i].height / m_pixelRatio));
+        if (sidebarPoint.x() + m_sideBar->width() >= screenRect.x() && sidebarPoint.x() + m_sideBar->width() <= screenRect.right()) {
+            if (sidebarPoint.y() < screenRect.y() + TOOLBAR_Y_SPACING) {
                 // 屏幕上超出
-                sidebarPoint.setY(m_screenInfo[i].y + TOOLBAR_Y_SPACING);
-            } else if (sidebarPoint.y() > m_screenInfo[i].y + m_screenInfo[i].height - m_sideBar->height() - TOOLBAR_Y_SPACING) {
+                sidebarPoint.setY(screenRect.y() + TOOLBAR_Y_SPACING);
+            } else if (sidebarPoint.y() > screenRect.bottom() - m_sideBar->height() - TOOLBAR_Y_SPACING) {
                 // 屏幕下超出
-                sidebarPoint.setY(m_screenInfo[i].y + m_screenInfo[i].height - m_sideBar->height() - TOOLBAR_Y_SPACING);
+                sidebarPoint.setY(screenRect.bottom() - m_sideBar->height() - TOOLBAR_Y_SPACING);
             }
             break;
         }
@@ -2877,15 +2890,24 @@ void MainWindow::updateCameraWidgetPos()
 QPoint MainWindow::getTwoScreenIntersectPos(QPoint rawPos)
 {
     // 1. fix the error screen list
+    // 注意：m_screenInfo 的 width/height 为物理尺寸（构造时乘了 m_pixelRatio），x/y 为逻辑原点。
+    // 本函数全程在逻辑坐标空间运算（recordX/Y/W/H、toolbar、m_toolBar 尺寸均为逻辑），
+    // 故此处将 tmp_screenInfo 的 width/height 换算为逻辑，避免逻辑/物理坐标混用导致出屏。
+    auto logicalScreenInfo = [this](const ScreenInfo &info) {
+        ScreenInfo logical = info;
+        logical.width = static_cast<int>(info.width / m_pixelRatio);
+        logical.height = static_cast<int>(info.height / m_pixelRatio);
+        return logical;
+    };
     QList<ScreenInfo> tmp_screenInfo;
     QPoint toolbarPoint = rawPos;
 
     if (m_screenInfo.at(0).x == 0) {
-        tmp_screenInfo.append(m_screenInfo.at(0));
-        tmp_screenInfo.append(m_screenInfo.at(1));
+        tmp_screenInfo.append(logicalScreenInfo(m_screenInfo.at(0)));
+        tmp_screenInfo.append(logicalScreenInfo(m_screenInfo.at(1)));
     } else {
-        tmp_screenInfo.append(m_screenInfo.at(1));
-        tmp_screenInfo.append(m_screenInfo.at(0));
+        tmp_screenInfo.append(logicalScreenInfo(m_screenInfo.at(1)));
+        tmp_screenInfo.append(logicalScreenInfo(m_screenInfo.at(0)));
     }
 
     // 2. get the cross area


### PR DESCRIPTION
## 根因分析

`ScreenInfo` 结构体构造时混用逻辑/物理坐标：`x/y` 取 `QScreen::geometry()` 逻辑原点，`width/height` 却乘 `m_pixelRatio` 得物理尺寸。工具栏位置计算的屏幕归属判定在该混合空间做边界比较，右边界 `x + width` 既非逻辑也非物理，`pixelRatio != 1` 时归属判定失败，工具栏被置于真实屏外。`pixelRatio == 1` 时逻辑==物理、混合空间塌缩为正确值，故 1 倍缩放不复现。

关键证据（基线 `b862d59` @ release/eagle）：
- `src/main_window.cpp:188-192` — `ScreenInfo` 混合坐标（逻辑原点 + 物理尺寸）
- `src/main_window.cpp:2493-2501`（改前）— `updateToolBarPos` 以物理化 X 比较混合右边界 `x + width`，归属判定对所有屏恒假
- `src/main_window.cpp:2553-2558`（改前）— 归属失败回退 `m_toolbarLastPoint`（默认 (0,0)），X 出屏无钳制
- `src/main_window.cpp:2884-2886`（改前）— `getTwoScreenIntersectPos` 用混合 `screen_1/2` 求交集

历史：本问题为复发 bug（PMS #151133/2022、#311839/2025 均为混合空间内增量 ratio 补丁），本次为坐标空间统一根因修复。

## 修复方案

在 `updateToolBarPos` / `getTwoScreenIntersectPos` / `updateSideBarPos` 三个归属判定函数内，将屏幕几何构造为**纯逻辑 QRect**（`QRect(x, y, width/m_pixelRatio, height/m_pixelRatio)`），与逻辑坐标的 `toolbarPoint` / `recordX` / `sidebarPoint` 同空间用 `QRect::contains` 比较；`getTwoScreenIntersectPos` 在构造 `tmp_screenInfo` 时即将 width/height 换算为逻辑，使整函数在逻辑空间运算；工具栏归属失败兜底增加双向钳制到捕获区所在屏幕逻辑边界。

> 说明：未改动 `ScreenInfo` 结构存储语义（即未去掉构造处 `*m_pixelRatio`）。改动安全评估（见附件 change-safety.md）发现该改动属高风险（影响 >5 处调用者，且会破坏依赖物理 width/height 的滚动截图提示定位 `:1418-1468` 与多屏缩放窗口偏移 `:398-420` 等未测试路径），按 skill 4.1.5 硬阻断规则暂缓，留待独立测试覆盖后专项重构。本次采用低风险的局部逻辑 QRect 方案，直接修复报告 bug 的触发路径。

## 改动安全评估

- 风险等级：**低风险**（本次修复范围）
- 函数签名不变，仅内部判定逻辑改为逻辑坐标，调用方无感
- 未触及 `ScreenInfo` 结构、`m_screenSize`、滚动截图、多屏偏移、鼠标判定等消费者
- 历史无冲突：取代 `9f7ee982babe` 等 Y 判定 ratio 补丁，不撤销有效历史修复

## 验证建议

- 双屏扩展 + 4K + 缩放 1.25 倍（必现路径）
- 回归：1 倍缩放、单屏、对角/垂直错位双屏
- 项目存在已有测试 `tests/ut_screen_shot_recorder/`，建议自行运行验证

## Summary by Sourcery

Fix multi-monitor toolbar and sidebar positioning by consistently evaluating screen geometry in logical coordinates.

Bug Fixes:
- Prevent toolbar placement from going off-screen on multi-monitor setups with non-integer display scaling.
- Keep sidebar and two-screen intersection positioning consistent across display scaling configurations.

Enhancements:
- Unify screen-boundary calculations in affected positioning logic by using logical coordinate geometry.
- Clamp fallback toolbar positions to the logical bounds of the capture screen.