### PR TITLE
test(screen-shot-recorder): fix two failing cases in ut suite

### DIFF
--- a/tests/ut_screen_shot_recorder/ut_smallfiles_cov.h
+++ b/tests/ut_screen_shot_recorder/ut_smallfiles_cov.h
@@ -195,7 +195,9 @@ TEST(AIAssistantWidgetCovTest, onToolButtonClickedEmitsSignal)
 // ---------- voicevolumewatcher_interface destructor (0%) ----------
 // voicevolumewatcher_interface is a QDBusAbstractInterface subclass.
 // Heap-allocate + delete to trigger the deleting destructor (D0).
-TEST(VoiceVolumeWatcherInterfaceCovTest, heapDestructor)
+// NOTE: suite name differs from utils/ut_voicevolumewatcher_interface_cov.h
+// on purpose: gtest forbids mixing TEST and TEST_F within one suite.
+TEST(VoiceVolumeWatcherIfaceHeapCovTest, heapDestructor)
 {
     voicevolumewatcher_interface *iface = nullptr;
     EXPECT_NO_FATAL_FAILURE(iface = new voicevolumewatcher_interface(

--- a/tests/ut_screen_shot_recorder/utils/ut_screengrabber_cov.h
+++ b/tests/ut_screen_shot_recorder/utils/ut_screengrabber_cov.h
@@ -38,14 +38,25 @@ public:
 };
 
 // Non-wayland, non-xcb dispatcher delegates to grabX11Screenshot -> findIntersectingScreens.
-// With a wide rect at origin it intersects all offscreen screens and routes to
-// grabMultipleScreens; with a far-off rect it routes to grabPrimaryScreenFallback.
+// A rect covering the whole virtual desktop intersects every screen: on multi-screen
+// hosts it routes to grabMultipleScreens (ok is unconditionally true there); on
+// single-screen hosts it routes to grabSingleScreen with an in-bounds rect, which
+// also succeeds. A far-off rect (e.g. -50000,-50000,100000x100000) must NOT be used
+// here: on a single-screen host it dispatches to grabSingleScreen with out-of-range
+// relative coordinates and QScreen::grabWindow returns a null pixmap (ok=false).
 TEST_F(ScreenGrabberCovTest, grabEntireDesktopWideRectDispatchesToMultiple)
 {
+    const QList<QScreen *> screens = QGuiApplication::screens();
+    if (screens.isEmpty()) {
+        GTEST_SKIP() << "no screens available";
+    }
+    QRect virtualGeometry = screens.first()->geometry();
+    for (QScreen *s : screens)
+        virtualGeometry = virtualGeometry.united(s->geometry());
+
     ScreenGrabber g;
     bool ok = false;
-    // A huge rect should intersect every screen -> multi-screen path.
-    EXPECT_NO_FATAL_FAILURE(g.grabEntireDesktop(ok, QRect(-50000, -50000, 100000, 100000), 1.0));
+    EXPECT_NO_FATAL_FAILURE(g.grabEntireDesktop(ok, virtualGeometry, 1.0));
     EXPECT_TRUE(ok);
 }
 


### PR DESCRIPTION
Rename VoiceVolumeWatcherInterfaceCovTest.heapDestructor suite to avoid illegal TEST/TEST_F mixing within one gtest suite.

重命名 heapDestructor 用例套件，避免同一 gtest 套件内混用 TEST 与 TEST_F。

Use the united virtual-desktop rect in grabEntireDesktopWideRect test so it no longer fails on single-screen hosts (grabSingleScreen path).

改用虚拟桌面联合矩形，使多屏分发用例在单屏主机上不再失败。

Log: 修复两个单元测试失败用例
Influence: ut_screen_shot_recorder 1714 用例全部通过，不再受主机屏幕数量影响。

## Summary by Sourcery

Stabilize screen-shot recorder unit tests across host display configurations and GoogleTest suite rules.

Bug Fixes:
- Fix screen-grabber coverage tests so desktop-wide capture succeeds consistently on both single-screen and multi-screen hosts.
- Avoid GoogleTest suite conflicts that caused the voice-volume watcher destructor test to fail.

Tests:
- Stabilize screen-shot recorder unit coverage by using the actual virtual desktop geometry and isolating the destructor test in its own suite.