### PR TITLE
fix: include record button headers in accessible factory

### DIFF
--- a/src/accessibility/acObjectList.cpp
+++ b/src/accessibility/acObjectList.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "acObjectList.h"
+#include "accessiblefunctions.h"
+#include "../record_button.h"
+#include "../record_option_panel.h"
+
+SET_FORM_ACCESSIBLE(QWidget, m_w->objectName())
+SET_BUTTON_ACCESSIBLE(RecordButton, "RecordButton")
+SET_BUTTON_ACCESSIBLE(RecordOptionPanel, "RecordOptionPanel")
+
+QAccessibleInterface *accessibleFactory(const QString &classname, QObject *object)
+{
+    QAccessibleInterface *interface = nullptr;
+    USE_ACCESSIBLE(classname, QWidget);
+    USE_ACCESSIBLE(classname, RecordButton);
+    USE_ACCESSIBLE(classname, RecordOptionPanel);
+
+    return interface;
+}

--- a/src/accessibility/acObjectList.h
+++ b/src/accessibility/acObjectList.h
@@ -5,22 +5,13 @@
 #ifndef SHOT_RECORDER_ACCESSIBLE_OBJECT_LIST_H
 #define SHOT_RECORDER_ACCESSIBLE_OBJECT_LIST_H
 
-#include "accessiblefunctions.h"
+#include <QAccessible>
+#include <QString>
 
-// 添加accessible
+class QObject;
+class RecordButton;
+class RecordOptionPanel;
 
-SET_FORM_ACCESSIBLE(QWidget,m_w->objectName())
-SET_BUTTON_ACCESSIBLE(RecordButton, "RecordButton")
-SET_BUTTON_ACCESSIBLE(RecordOptionPanel, "RecordOptionPanel")
-
-QAccessibleInterface *accessibleFactory(const QString &classname, QObject *object)
-{
-    QAccessibleInterface *interface = nullptr;
-    USE_ACCESSIBLE(classname, QWidget);
-    USE_ACCESSIBLE(classname, RecordButton);
-    USE_ACCESSIBLE(classname, RecordOptionPanel);
-
-    return interface;
-}
+QAccessibleInterface *accessibleFactory(const QString &classname, QObject *object);
 
 #endif // SHOT_RECORDER_ACCESSIBLE_OBJECT_LIST_H

--- a/src/accessibility/accessible.pri
+++ b/src/accessibility/accessible.pri
@@ -1,6 +1,6 @@
 INCLUDEPATH += $$PWD
 
-#SOURCES += src/stub_linux/elfio.hpp
+SOURCES += accessibility/acObjectList.cpp
 
 HEADERS += accessibility/accessiblefunctions.h \
             accessibility/acObjectList.h \


### PR DESCRIPTION
Fix build failure introduced by the AT-SPI accessible names change.

`src/accessibility/acObjectList.h` references `RecordButton` and
`RecordOptionPanel` types but did not include their headers, causing:

- `acObjectList.h: 'RecordButton' / 'RecordOptionPanel' does not name a type`
- `accessiblefunctions.h:116: expected ')' before '*' token`
- `accessiblefunctions.h: 'm_w' was not declared in this scope`

Add the missing includes so the accessibility factory compiles standalone.

Log: 修复可访问性工厂缺少头文件导致的编译失败

## Summary by Sourcery

Fix accessibility factory compilation by organizing its implementation and providing the required record control type declarations and headers.

Bug Fixes:
- Restore standalone accessibility factory compilation by separating its implementation and ensuring RecordButton and RecordOptionPanel types are available where needed.

Enhancements:
- Move accessibility factory definitions from the header into a dedicated source file and expose only the factory declaration in the header.

Build:
- Include the new accessibility factory source file in the project build.