### PR TITLE
fix: drag not following cursor on HiDPI screen

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -5038,7 +5038,7 @@ void MainWindow::onMouseMove(int x, int y)
     //启动截图或者录屏后第一次鼠标移动时需要通过此方法，后面都不会在进入此方法
     if (!isFirstMove) {
         QMouseEvent *mouseMove;
-        mouseMove = new QMouseEvent(QEvent::MouseMove, QPoint(x, y), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+        mouseMove = new QMouseEvent(QEvent::MouseMove, QPoint(int(x / m_pixelRatio), int(y / m_pixelRatio)), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
         QApplication::sendEvent(QWidget::focusWidget(), mouseMove);
     }
 }


### PR DESCRIPTION
## Root Cause Analysis

On X11, `EventMonitor` captures `rootX`/`rootY` as physical pixel coordinates via XRecord. When `MainWindow::onMouseMove` synthesizes a `QMouseEvent` for the selection widget (the `!isFirstMove` branch), it passes these physical coords directly as `QPoint(x, y)` without dividing by `m_pixelRatio`. Under 4K + 2x scaling, `m_pixelRatio = 2.0`, so the synthesized cursor position is 2x larger than the real logical coordinate, making the screenshot selection drag not follow the cursor. The sibling branches in the same function (`isFirstMove`, `src/main_window.cpp:5020`) and `onMouseDrag`/`onMouseRelease` shapesWidget branches (`src/main_window.cpp:4965`, `:5000`) already apply the `/ m_pixelRatio` conversion, confirming the `!isFirstMove` branch is the single missing case.

## Fix Approach

Apply the same coordinate conversion already used by the adjacent branches: change `QPoint(x, y)` to `QPoint(int(x / m_pixelRatio), int(y / m_pixelRatio))` at `src/main_window.cpp:5041`. This normalizes the X11 physical-pixel input to Qt logical coordinates before the synthetic `QMouseEvent` is forwarded to the focus widget. On standard DPI (`m_pixelRatio = 1.0`) dividing by 1.0 is a no-op, so existing behavior is unchanged.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Single-line local change inside `onMouseMove`; no signature change, no public API removal, no caller depends on the altered behavior. The target code was introduced by commit `28ab36601` to fix BUG-117255 (cursor at top-left corner not detected); this change does not revert that fix — it only adds the missing physical→logical pixel conversion at the synthesized coordinate.
- `onMouseMove` has a single direct reference (`src/main_window.h:469`, the declaration); it is triggered by `EventMonitor`'s X11 `mouseMove` signal whose params remain physical-pixel coords, so the only affected path is the internal coordinate synthesis.

### Business Impact Scope

- **Screenshot selection drag**: after starting a screenshot, the first mouse move drives selection-region dragging through `onMouseMove`. On 4K + 2x scaling the selection border previously moved twice the cursor distance; after the fix it follows the cursor 1:1. On 1080p (`m_pixelRatio = 1.0`) behavior is unchanged.
- Affected scenario: screenshot region selection dragging on HiDPI displays.

### Verification Suggestion

Test screenshot region-selection dragging on a 4K + 2x scaling environment (border follows cursor), and regression-test on 1080p (`m_pixelRatio = 1.0`) to confirm no behavior change. Optionally verify multi-monitor mixed-scaling setups.

---

## 根因分析

X11 下 `EventMonitor` 通过 XRecord 捕获的 `rootX`/`rootY` 为物理像素坐标。`MainWindow::onMouseMove` 在 `!isFirstMove` 分支合成转发给选区控件的 `QMouseEvent` 时，直接用 `QPoint(x, y)` 传入物理坐标，未除以 `m_pixelRatio`。4K + 2 倍缩放下 `m_pixelRatio = 2.0`，合成坐标被放大 2 倍，导致截图选区拖拽不跟手。同函数 `isFirstMove` 分支（`src/main_window.cpp:5020`）及 `onMouseDrag`/`onMouseRelease` shapesWidget 分支（`src/main_window.cpp:4965`、`:5000`）均已正确做 `/ m_pixelRatio` 转换，证明 `!isFirstMove` 分支是唯一遗漏点。

## 修复方案

在 `src/main_window.cpp:5041` 处补齐与相邻分支一致的坐标转换：将 `QPoint(x, y)` 改为 `QPoint(int(x / m_pixelRatio), int(y / m_pixelRatio))`，在合成 `QMouseEvent` 前将 X11 物理像素归一为 Qt 逻辑坐标。普通 DPI 环境（`m_pixelRatio = 1.0`）除以 1.0 等价无变化，现有行为不受影响。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 单行局部改动，不修改函数签名、不删除公开 API、无调用者依赖被改行为。目标代码由 commit `28ab36601` 为修复 BUG-117255（光标在桌面左上角时截图未识别桌面）引入；本次改动不撤销该历史修复，仅在合成坐标处补齐物理→逻辑像素转换。
- `onMouseMove` 仅有 1 处直接引用（`src/main_window.h:469` 声明），由 `EventMonitor` 的 X11 `mouseMove` 信号触发，参数仍为物理像素坐标，受影响路径仅为内部坐标合成。

### 业务影响范围

- **截图选区拖拽**：截图启动后首次鼠标移动通过 `onMouseMove` 驱动选区拖拽。4K + 2 倍缩放下修复前选区边框移动距离是光标的 2 倍，修复后与光标 1:1 跟手；1080p（`m_pixelRatio = 1.0`）行为不变。
- 受影响场景：高分屏截图选区拖拽。

### 验证建议

在 4K + 2 倍缩放环境测试截图选区拖拽跟手，在 1080p（`m_pixelRatio = 1.0`）环境回归验证行为不变，可选验证多显示器不同缩放比场景。

PMS: BUG-301057

## Summary by Sourcery

Bug Fixes:
- Correct screenshot selection dragging on HiDPI displays by converting captured physical mouse coordinates to Qt logical coordinates before forwarding mouse events.