### PR TITLE
fix(scrollshot): add scroll effectiveness diagnostics and differentiated error for zero displacement

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -5588,6 +5588,10 @@ void MainWindow::onScrollShotMerageImgState(PixMergeThread::MergeErrorValue stat
         //拼接失败立即保存当前的截图
         //saveScreenShot();
     }
+    //state = 0: 自动滚动未使页面产生位移
+    else if (state == PixMergeThread::MergeErrorValue::ScrollNoMove) {
+        m_scrollShotTip->showTip(TipType::ScrollNoMoveTip);
+    }
     //state = 2：滚动到底部
     else if (state == PixMergeThread::MergeErrorValue::ReachBottom) {
         m_scrollShotTip->showTip(TipType::EndScrollShotTip);

--- a/src/utils/pixmergethread.cpp
+++ b/src/utils/pixmergethread.cpp
@@ -364,7 +364,7 @@ bool PixMergeThread::splicePictureDown(const cv::Mat &image)
     if (!m_isManualScrollModel && m_MeragerCount == 1 && maxVal >= thresholdv && maxLoc.y == 0) {
         if (++m_firstFrameRetryCount > FIRST_FRAME_RETRY_LIMIT) {
             qDebug() << "2 自动滚动首帧多次未产生位移";
-            emit merageError(Failed);
+            emit merageError(ScrollNoMove);
         } else {
             qDebug() << "2 自动滚动首帧未产生位移，等待下一次滚动";
         }

--- a/src/utils/pixmergethread.h
+++ b/src/utils/pixmergethread.h
@@ -30,6 +30,7 @@ public:
         MaxHeight,      // 最大高度
         InvalidArea,    //无效区域，点击调整捕捉区域
         RoollingTooFast, //滚动速度过快
+        ScrollNoMove,   // 自动滚动未使页面产生位移（合成滚轮事件未被目标窗口响应）
     };
 
     enum PictureDirection {//滚动方向

--- a/src/utils/scrollScreenshot.cpp
+++ b/src/utils/scrollScreenshot.cpp
@@ -28,10 +28,18 @@ ScrollScreenshot::ScrollScreenshot(QObject *parent)  : QObject(parent)
         {
             // 发送滚轮事件， 自动滚动
             static Display *m_display = XOpenDisplay(nullptr);
-            XTestFakeButtonEvent(m_display, Button5, 1, CurrentTime);
-            XFlush(m_display);
-            XTestFakeButtonEvent(m_display, Button5, 0, CurrentTime);
-            XFlush(m_display);
+            if (!m_display) {
+                qWarning() << "scrollScreenshot: XOpenDisplay failed, cannot inject wheel events";
+            } else {
+                if (!XTestFakeButtonEvent(m_display, Button5, 1, CurrentTime)) {
+                    qWarning() << "scrollScreenshot: XTestFakeButtonEvent press failed";
+                }
+                XFlush(m_display);
+                if (!XTestFakeButtonEvent(m_display, Button5, 0, CurrentTime)) {
+                    qWarning() << "scrollScreenshot: XTestFakeButtonEvent release failed";
+                }
+                XFlush(m_display);
+            }
         } else
         {
 #ifdef KF5_WAYLAND_FLAGE_ON

--- a/src/utils/waylandscrollmonitor.cpp
+++ b/src/utils/waylandscrollmonitor.cpp
@@ -51,10 +51,14 @@ void WaylandScrollMonitor::setupRegistry()
 // 初始化Fakeinput
 void WaylandScrollMonitor::setupFakeinput(quint32 name, quint32 version)
 {
+    qDebug() << "waylandscrollmonitor: FakeInput announced, name=" << name << "version=" << version;
     if (m_fakeinput == nullptr) {
         m_fakeinput = new KWayland::Client::FakeInput(this);
         m_fakeinput->setup(m_registry->bindFakeInput(name, version));
         m_fakeinput->authenticate(qAppName(), "wayland scroll monitor");
+        qDebug() << "waylandscrollmonitor: FakeInput setup complete, authenticate requested";
+    } else {
+        qDebug() << "waylandscrollmonitor: FakeInput already initialized";
     }
 }
 
@@ -116,5 +120,7 @@ void WaylandScrollMonitor::doWaylandAutoScroll()
     if (m_fakeinput != nullptr) {
         // Qt::Vertical 垂直滚动，正值代表向下滚动
         m_fakeinput->requestPointerAxisForCapture(Qt::Vertical, SCROLL_DOWN);
+    } else {
+        qWarning() << "waylandscrollmonitor: FakeInput not available (compositor did not announce it), auto scroll will have no effect";
     }
 }

--- a/src/widgets/scrollshottip.cpp
+++ b/src/widgets/scrollshottip.cpp
@@ -103,6 +103,9 @@ void ScrollShotTip::showTip(TipType tipType)
     case TipType::InvalidAreaShotTip:
         showInvalidAreaShotTip();
         break;
+    case TipType::ScrollNoMoveTip:
+        showScrollNoMoveTip();
+        break;
     }
 
 }
@@ -330,6 +333,23 @@ void ScrollShotTip::showInvalidAreaShotTip()
     //qDebug() << "1111 >> m_tipTextLable->width(): " << m_tipTextLable->width() <<"m_tipTextLable->height(): " << m_tipTextLable->height() ;
     //qDebug() << "1111 >> m_scrollShotAdjust->width(): " << m_scrollShotAdjust->width() <<"m_scrollShotAdjust->height(): " << m_scrollShotAdjust->height() ;
     //qDebug() << "1111 >> this->width(): " << this->width() <<"this->height(): " << this->height() ;
+}
+
+void ScrollShotTip::showScrollNoMoveTip()
+{
+    m_tipText = tr("Auto scroll failed to move the page, please try manual scroll");
+    int width = 0;
+    m_tipTextLable->setText(m_tipText);
+    QFontMetrics labFontMetrics(m_tipTextLable->font());
+    m_tipTextLable->resize(labFontMetrics.width(m_tipTextLable->text()), m_tipTextLable->height());
+    m_warmingIconButton->show();
+    QFontMetrics helpFontMetrics(m_scrollShotHelp->font());
+    m_scrollShotHelp->resize(helpFontMetrics.width(m_scrollShotHelp->text()), m_scrollShotHelp->height());
+    m_scrollShotHelp->show();
+    m_scrollShotAdjust->hide();
+    width = m_warmingIconButton->width() + 10 + m_tipTextLable->width() + 30 + m_scrollShotHelp->width();
+    setFixedSize(width, TIP_HEIGHT);
+    update();
 }
 
 ScrollShotTip::~ScrollShotTip()

--- a/src/widgets/scrollshottip.h
+++ b/src/widgets/scrollshottip.h
@@ -23,7 +23,8 @@ enum TipType {
     EndScrollShotTip,     //滚动截图到底部出现的提示
     QuickScrollShotTip,    //滚动速度过快出现的提示
     MaxLengthScrollShotTip,  //滚动截图拼接已到达最大长度
-    InvalidAreaShotTip      //无效区域,点击调整捕捉区域
+    InvalidAreaShotTip,      //无效区域,点击调整捕捉区域
+    ScrollNoMoveTip          //自动滚动未使页面滚动，提示切换手动模式
 };
 
 /**
@@ -102,6 +103,7 @@ protected:
      * @brief 显示无效区域,调整捕捉区域提示
      */
     void showInvalidAreaShotTip();
+    void showScrollNoMoveTip();
 
     void paintEvent(QPaintEvent *event);
 


### PR DESCRIPTION
fix(scrollshot): add scroll effectiveness diagnostics and differentiated error for zero displacement

1. X11: 检查 XOpenDisplay 与 XTestFakeButtonEvent 返回值，失败时 qWarning 日志;
2. Wayland: setupFakeinput 增加 FakeInput 公告/初始化日志，doWaylandAutoScroll 在 m_fakeinput 为 null 时 qWarning;
3. 新增 ScrollNoMove 错误类型与 ScrollNoMoveTip 提示，零位移重试耗尽时提示用户切换手动模式;

=====================================

1. X11: check XOpenDisplay and XTestFakeButtonEvent return values, log qWarning on failure;
2. Wayland: add FakeInput announcement/initialization logging, warn when m_fakeinput is null;
3. add ScrollNoMove error type and ScrollNoMoveTip, prompt user to switch manual mode on zero displacement;

Log: 网页滚动截图自动模式合成滚轮事件未响应导致截图失败，增加滚动有效性诊断与差异化错误提示
Bug: https://pms.uniontech.com/bug-view-364917.html

## Summary by Sourcery

Improve scrollshot reliability diagnostics and guide users to manual scrolling when automatic scrolling has no effect.

New Features:
- Add differentiated handling and user guidance for automatic scroll attempts that produce no page movement.

Bug Fixes:
- Improve detection and reporting of failed scroll-event injection on X11 and Wayland platforms.

Enhancements:
- Add diagnostic logging for display, wheel-event, and Wayland FakeInput availability and initialization failures.