### PR TITLE
perf: reduce recording CPU by fixing busy-wait

### DIFF
--- a/src/gstrecord/gstrecordx.cpp
+++ b/src/gstrecord/gstrecordx.cpp
@@ -77,7 +77,7 @@ void GstRecordX::x11GstStartRecord()
     //这里录制区域有个ximagesrc的bug，endx或者endy只要有一个的大小为显示屏的大小。录制的视频最终结果都是全屏。因此需要减一个像素
     areaList << "ximagesrc"
              << "display-name=" + qgetenv("DISPLAY")
-             << "use-damage=false"
+             << "use-damage=true"
              << "show-pointer=" + m_isRecordMouse //是否录制光标
              << "startx=" + QString::number(m_recordArea.x())
              << "starty=" + QString::number(m_recordArea.y())

--- a/src/waylandrecord/waylandintegration.cpp
+++ b/src/waylandrecord/waylandintegration.cpp
@@ -960,7 +960,7 @@ void WaylandIntegration::WaylandIntegrationPrivate::gstWriteVideoFrame()
                 qWarning() << "m_gstRecordX is nullptr!";
             }
         } else {
-            //qDebug() << "视频缓冲区无数据！";
+            QThread::msleep(10);
         }
     }
     //等待wayland视频环形队列中的视频帧，全部写入管道
@@ -1282,7 +1282,6 @@ void WaylandIntegration::WaylandIntegrationPrivate::appendBuffer(unsigned char *
         //先进先出
         //取队首
         waylandFrame wFrame = m_waylandList.first();
-        memset(wFrame._frame, 0, static_cast<size_t>(size));
         //拷贝当前帧
         memcpy(wFrame._frame, frame, static_cast<size_t>(size));
         wFrame._time = time;
@@ -1306,7 +1305,6 @@ void WaylandIntegration::WaylandIntegrationPrivate::appendBuffer(unsigned char *
             wFrame._index = 0;
             //分配空闲内存
             wFrame._frame = m_freeList.first();
-            memset(wFrame._frame, 0, static_cast<size_t>(size));
             //拷贝wayland推送的视频帧
             memcpy(wFrame._frame, frame, static_cast<size_t>(size));
             m_waylandList.append(wFrame);

--- a/src/waylandrecord/writeframethread.cpp
+++ b/src/waylandrecord/writeframethread.cpp
@@ -27,6 +27,8 @@ void WriteFrameThread::run()
     while (m_context->isWriteVideo()) {
         if (m_context->getFrame(frame)) {
             m_context->m_recordAdmin->m_pOutputStream->writeVideoFrame(frame);
+        } else {
+            QThread::msleep(10);
         }
     }
     m_context->m_recordAdmin->m_cacheMutex.unlock();


### PR DESCRIPTION
## Root Cause Analysis

Recording video consumes ~300% CPU (roughly 3 full cores) due to four compounding issues. The primary cause is busy-wait spinning in the frame-write loops: `gstWriteVideoFrame()` (`waylandintegration.cpp:955-963`) and `WriteFrameThread::run()` (`writeframethread.cpp:27-31`) both poll `getFrame()` at full CPU frequency when the frame queue is empty, with no sleep or condition-variable backoff. Additional overhead comes from redundant per-frame `memset` before `memcpy` in `appendBuffer()`, and X11 full-screen capture with `use-damage=false` disabling dirty-region optimization.

## Fix Approach

Three targeted changes address the actionable root causes: (1) add `QThread::msleep(10)` backoff in the `else` branches of both busy-wait loops to eliminate idle spinning; (2) remove the redundant `memset` calls in `appendBuffer()` that immediately precede a full-buffer `memcpy`; (3) change `ximagesrc` `use-damage` from `false` to `true` to enable incremental screen capture. Software encoding (RC2) is documented as a future platform-dependent change, out of scope for this fix.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- All three changes are local micro-adjustments: adding sleep backoff (pure addition), removing redundant memset before memcpy (no data impact), and changing a single property value. No function signatures, public members, or existing logic paths are modified.
- `use-damage=false` originates from the initial commit (not a bug fix), so enabling it does not revert any historical fix. The msleep additions are consistent with existing `QThread::msleep` usage already present in the same files.

### Business Impact Scope

- **Wayland video recording**: frame-write loops and buffer handling are affected. Users recording on Wayland should see significantly lower CPU usage with no change to recording quality or frame rate.
- **X11 video recording**: `ximagesrc` damage tracking is enabled. Users recording on X11 should see reduced CPU usage; recording area accuracy is unaffected.

### Verification Suggestion

Record video for 30+ seconds on both Wayland and X11, monitor CPU usage for significant reduction. Verify playback has no corruption, frame drops, or A/V sync issues. Confirm stopping recording responds within 1 second.

---

## 根因分析

录制视频 CPU 占用高达约 300%（约满 3 核），由四类问题叠加造成。主因是帧写入循环的忙等待空转：`gstWriteVideoFrame()`（`waylandintegration.cpp:955-963`）和 `WriteFrameThread::run()`（`writeframethread.cpp:27-31`）在帧队列为空时以最高频率轮询 `getFrame()`，无任何 sleep 或条件变量退避。叠加因素包括 `appendBuffer()` 中 `memcpy` 前的冗余 `memset` 全帧清零，以及 X11 全屏采集 `use-damage=false` 禁用了脏区优化。

## 修复方案

针对可操作的根因实施三处改动：(1) 在两处忙等待循环的 `else` 分支增加 `QThread::msleep(10)` 退避，消除空转；(2) 删除 `appendBuffer()` 中紧跟 `memcpy` 前的冗余 `memset`；(3) 将 `ximagesrc` 的 `use-damage` 从 `false` 改为 `true`，启用增量屏幕采集。纯软件编码（RC2）作为未来平台相关改动，本次不修改代码。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 三处改动均为局部微调：增加 sleep 退避（纯增补）、删除冗余 memset（memcpy 已完全覆盖，无数据影响）、修改单个属性值。不修改函数签名、公开成员或已有逻辑路径。
- `use-damage=false` 来自初始提交（非 bug 修复产物），启用不会回退历史修复。新增 `msleep` 与同文件已有的 `QThread::msleep` 调用风格一致。

### 业务影响范围

- **Wayland 视频录制**：帧写入循环和缓冲区处理受影响。Wayland 录制时 CPU 占用显著降低，录制质量和帧率不受影响。
- **X11 视频录制**：启用 `ximagesrc` damage 跟踪。X11 录制时 CPU 占用降低，录制区域准确性不受影响。

### 验证建议

在 Wayland 和 X11 环境下分别录制 30 秒以上，监控 CPU 占用是否显著降低。回放验证无花屏、无丢帧、音画同步正常。确认停止录制响应在 1 秒以内。

## Summary by Sourcery

Reduce video recording CPU consumption by backing off idle frame writes and avoiding unnecessary capture and buffer work.

Bug Fixes:
- Reduce recording CPU usage by preventing frame-writing threads from busy-waiting when no frames are available.
- Enable X11 damage tracking to support more efficient incremental screen capture.

Enhancements:
- Remove redundant frame-buffer clearing before full-frame copies.