### PR TITLE
feat: 补全 AT-SPI 无障碍名称

### DIFF
--- a/src/menucontroller/menucontroller.cpp
+++ b/src/menucontroller/menucontroller.cpp
@@ -22,6 +22,8 @@ MenuController::MenuController(QObject *parent)
 {
     qCDebug(dsrApp) << "MenuController constructor called.";
     m_menu = new DMenu();
+    m_menu->setObjectName("Menu");
+    m_menu->setAccessibleName("Menu");
     qCDebug(dsrApp) << "DMenu object created.";
     m_menu->setFocusPolicy(Qt::StrongFocus);
     //for test
@@ -73,6 +75,7 @@ MenuController::MenuController(QObject *parent)
 //    unDoIcon.addFile(":/image/menu_icons/undo-menu-hover.svg", MENU_ICON_SIZE, QIcon::Active);
 //    QAction *unDoAct = new QAction(unDoIcon, tr("Undo"), this);
     m_unDoAct = new QAction(tr("Undo"), this);
+    m_unDoAct->setObjectName("UnDoAct");
     Utils::setAccessibility(m_unDoAct, "menuUndo");
     qCDebug(dsrApp) << "Created Undo action";
     connect(m_unDoAct, &QAction::triggered, [ = ] {
@@ -82,6 +85,7 @@ MenuController::MenuController(QObject *parent)
 
     //QAction *saveAct = new QAction(tr("Save"), this);
     m_saveAct = new QAction(tr("Save"), this);
+    m_saveAct->setObjectName("SaveAct");
     Utils::setAccessibility(m_saveAct, "menuSave");
     qCDebug(dsrApp) << "Created Save action";
     connect(m_saveAct, &QAction::triggered, [ = ] {
@@ -91,6 +95,7 @@ MenuController::MenuController(QObject *parent)
 
     //QAction *closeAct = new QAction(tr("Exit"), this);
     m_closeAct = new QAction(tr("Exit"), this);
+    m_closeAct->setObjectName("CloseAct");
     Utils::setAccessibility(m_closeAct, "menuExit");
     qCDebug(dsrApp) << "Created Exit action";
     connect(m_closeAct, &QAction::triggered, [ = ] {

--- a/src/pin_screenshots/ui/menucontroller.cpp
+++ b/src/pin_screenshots/ui/menucontroller.cpp
@@ -24,15 +24,19 @@ void MenuController::initMenuController()
 {
     qCDebug(dsrApp) << "Initializing MenuController.";
     m_menu = new DMenu();
+    m_menu->setObjectName("Menu");
+    m_menu->setAccessibleName("Menu");
     qCDebug(dsrApp) << "DMenu object created.";
     m_menu->setFocusPolicy(Qt::StrongFocus);
     m_saveAct = new QAction(tr("Save"), this);
+    m_saveAct->setObjectName("SaveAct");
     connect(m_saveAct, &QAction::triggered, [ = ] {
         qCDebug(dsrApp) << "Save action triggered.";
         emit saveAction();
     });
 
     m_closeAct = new QAction(tr("Exit"), this);
+    m_closeAct->setObjectName("CloseAct");
     connect(m_closeAct, &QAction::triggered, [ = ] {
         qCDebug(dsrApp) << "Exit action triggered.";
         emit closeAction();

--- a/src/pin_screenshots/ui/pinsavemenumanager.cpp
+++ b/src/pin_screenshots/ui/pinsavemenumanager.cpp
@@ -45,6 +45,8 @@ PinSaveMenuManager::~PinSaveMenuManager()
 void PinSaveMenuManager::createMenu()
 {
     m_saveMenu = new DMenu(qobject_cast<QWidget*>(parent()));
+    m_saveMenu->setObjectName("SaveMenu");
+    m_saveMenu->setAccessibleName("SaveMenu");
     DFontSizeManager::instance()->bind(m_saveMenu, DFontSizeManager::T6);
     
     createSaveOptionActions();
@@ -54,13 +56,16 @@ void PinSaveMenuManager::createMenu()
 void PinSaveMenuManager::createSaveOptionActions()
 {
     m_saveOptionGroup = new QActionGroup(this);
+    m_saveOptionGroup->setObjectName("SaveOptionGroup");
     m_saveOptionGroup->setExclusive(true);
     
     m_askEveryTimeAction = new QAction(tr("Each inquiry"), m_saveMenu);
+    m_askEveryTimeAction->setObjectName("AskEveryTimeAction");
     m_askEveryTimeAction->setCheckable(true);
     m_saveOptionGroup->addAction(m_askEveryTimeAction);
     
     m_specifiedLocationAction = new QAction(tr("Specified Location"), m_saveMenu);
+    m_specifiedLocationAction->setObjectName("SpecifiedLocationAction");
     m_specifiedLocationAction->setCheckable(true);
     m_saveOptionGroup->addAction(m_specifiedLocationAction);
     
@@ -73,34 +78,41 @@ void PinSaveMenuManager::createLocationActions()
 {
     qCWarning(dsrApp) << "createLocationActions called";
     m_specifiedLocationSubMenu = new DMenu(tr("Specified Location"), m_saveMenu);
+    m_specifiedLocationSubMenu->setObjectName("SpecifiedLocationSubMenu");
+    m_specifiedLocationSubMenu->setAccessibleName("SpecifiedLocationSubMenu");
     DFontSizeManager::instance()->bind(m_specifiedLocationSubMenu, DFontSizeManager::T6);
     m_specifiedLocationSubMenu->menuAction()->setCheckable(true);
     m_saveOptionGroup->addAction(m_specifiedLocationSubMenu->menuAction());
     
     // 创建自定义位置选项组
     m_customLocationGroup = new QActionGroup(this);
+    m_customLocationGroup->setObjectName("CustomLocationGroup");
     m_customLocationGroup->setExclusive(true);
     
     // 保存到桌面
     m_desktopAction = new QAction(tr("Desktop"), m_specifiedLocationSubMenu);
+    m_desktopAction->setObjectName("DesktopAction");
     m_desktopAction->setCheckable(true);
     m_customLocationGroup->addAction(m_desktopAction);
     m_specifiedLocationSubMenu->addAction(m_desktopAction);
     
     // 保存到图片
     m_picturesAction = new QAction(tr("Pictures"), m_specifiedLocationSubMenu);
+    m_picturesAction->setObjectName("PicturesAction");
     m_picturesAction->setCheckable(true);
     m_customLocationGroup->addAction(m_picturesAction);
     m_specifiedLocationSubMenu->addAction(m_picturesAction);
     
     // 保存时选择位置
     m_changeSaveToSpecialPath = new QAction(tr("Set a path on save"), m_specifiedLocationSubMenu);
+    m_changeSaveToSpecialPath->setObjectName("ChangeSaveToSpecialPath");
     m_changeSaveToSpecialPath->setCheckable(true);
     m_customLocationGroup->addAction(m_changeSaveToSpecialPath);
     m_specifiedLocationSubMenu->addAction(m_changeSaveToSpecialPath);
     
     // 历史路径选项
     m_saveToSpecialPathAction = new QAction(m_specifiedLocationSubMenu);
+    m_saveToSpecialPathAction->setObjectName("SaveToSpecialPathAction");
     m_saveToSpecialPathAction->setCheckable(true);
     m_customLocationGroup->addAction(m_saveToSpecialPathAction);
     

--- a/src/pin_screenshots/ui/subtoolwidget.cpp
+++ b/src/pin_screenshots/ui/subtoolwidget.cpp
@@ -82,6 +82,8 @@ void SubToolWidget::initShotLable()
 
     // 选项菜单
     m_optionMenu = new DMenu(this);
+    m_optionMenu->setObjectName("OptionMenu");
+    m_optionMenu->setAccessibleName("OptionMenu");
     qCDebug(dsrApp) << "Options menu created.";
     DFontSizeManager::instance()->bind(m_optionMenu, DFontSizeManager::T6);
     connect(m_optionMenu, &DMenu::aboutToShow, this, &SubToolWidget::updateOptionChecked);
@@ -184,6 +186,8 @@ void SubToolWidget::initChangeSaveToSpecialAction(const QString specialPath)
     m_saveToSpecialPathAction->setCheckable(true);
     m_saveToSpecialPathMenu->insertAction(m_changeSaveToSpecialPath, m_saveToSpecialPathAction);
     m_saveGroup->addAction(m_saveToSpecialPathAction);
+    m_saveGroup->setObjectName("SaveGroup");
+    m_saveToSpecialPathAction->setObjectName("SaveToSpecialPathAction");
     m_SavePathActions.insert(FOLDER, m_saveToSpecialPathAction);
 }
 

--- a/src/widgets/aiassistantwidget.cpp
+++ b/src/widgets/aiassistantwidget.cpp
@@ -46,6 +46,8 @@ AIAssistantWidget::AIAssistantWidget(QWidget *parent) : DWidget(parent)
     
     
     m_explainButton = new ToolButton(this);
+    m_explainButton->setObjectName("ExplainButton");
+    m_explainButton->setAccessibleName("ExplainButton");
     Utils::setAccessibility(m_explainButton, AC_AIASSISTANTWIDGET_EXPLAIN_BUTTON);
     m_explainButton->setText(tr("Explain"));
     m_explainButton->setIcon(QIcon::fromTheme("explain"));
@@ -55,6 +57,8 @@ AIAssistantWidget::AIAssistantWidget(QWidget *parent) : DWidget(parent)
     m_explainButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     
     m_summarizeButton = new ToolButton(this);
+    m_summarizeButton->setObjectName("SummarizeButton");
+    m_summarizeButton->setAccessibleName("SummarizeButton");
     Utils::setAccessibility(m_summarizeButton, AC_AIASSISTANTWIDGET_SUMMARIZE_BUTTON);
     m_summarizeButton->setText(tr("Summary"));
     m_summarizeButton->setIcon(QIcon::fromTheme("summary"));
@@ -64,6 +68,8 @@ AIAssistantWidget::AIAssistantWidget(QWidget *parent) : DWidget(parent)
     m_summarizeButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     
     m_translateButton = new ToolButton(this);
+    m_translateButton->setObjectName("TranslateButton");
+    m_translateButton->setAccessibleName("TranslateButton");
     Utils::setAccessibility(m_translateButton, AC_AIASSISTANTWIDGET_TRANSLATE_BUTTON);
     m_translateButton->setText(tr("Translate"));
     m_translateButton->setIcon(QIcon::fromTheme("translate"));
@@ -73,6 +79,8 @@ AIAssistantWidget::AIAssistantWidget(QWidget *parent) : DWidget(parent)
     m_translateButton->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
     
     m_askAIButton = new ToolButton(this);
+    m_askAIButton->setObjectName("AskAibutton");
+    m_askAIButton->setAccessibleName("AskAibutton");
     Utils::setAccessibility(m_askAIButton, AC_AIASSISTANTWIDGET_ASKAI_BUTTON);
     m_askAIButton->setText(tr("Ask AI"));
     m_askAIButton->setIcon(QIcon::fromTheme("askai"));

--- a/src/widgets/colortoolwidget.cpp
+++ b/src/widgets/colortoolwidget.cpp
@@ -55,6 +55,7 @@ void ColorToolWidget::initColorLabel()
 {
     //颜色按钮租
     m_colorButtonGroup = new QButtonGroup(this);
+    m_colorButtonGroup->setObjectName("ColorButtonGroup");
     m_colorButtonGroup->setExclusive(true);
 
     //主布局

--- a/src/widgets/imagemenu.cpp
+++ b/src/widgets/imagemenu.cpp
@@ -25,6 +25,7 @@ ImageMenu::ImageMenu(ImageBorderHelper::BorderType type, QString title, QWidget 
     qCDebug(dsrApp) << "ImageMenu constructor entered with type:" << type << ", title:" << title;
     m_borderType = type;
     m_actionGroup = new QButtonGroup(this);
+    m_actionGroup->setObjectName("ActionGroup");
     m_actionGroup->setExclusive(false);
     if (m_borderType == ImageBorderHelper::BorderType::Prototype) {
         qCDebug(dsrApp) << "Initializing Prototype border type actions";

--- a/src/widgets/maintoolwidget.cpp
+++ b/src/widgets/maintoolwidget.cpp
@@ -72,6 +72,8 @@ void MainToolWidget::initMainLabel()
     //    QString record_button_style = "DPushButton:press{QIcon(:/image/newUI/press/screencap-press.svg)}";
 
     m_recordBtn = new ToolButton();
+    m_recordBtn->setObjectName("RecordBtn");
+    m_recordBtn->setAccessibleName("RecordBtn");
     if (Utils::isTabletEnvironment || Utils::is3rdInterfaceStart) {
         qCDebug(dsrApp) << "Hiding record button in tablet environment or 3rd interface mode";
         m_recordBtn->hide();
@@ -87,6 +89,8 @@ void MainToolWidget::initMainLabel()
 
 
     m_shotBtn = new ToolButton();
+    m_shotBtn->setObjectName("ShotBtn");
+    m_shotBtn->setAccessibleName("ShotBtn");
     if (Utils::isTabletEnvironment) {
         qCDebug(dsrApp) << "Hiding screenshot button in tablet environment";
         m_shotBtn->hide();

--- a/src/widgets/savemenumanager.cpp
+++ b/src/widgets/savemenumanager.cpp
@@ -48,6 +48,8 @@ SaveMenuManager::~SaveMenuManager()
 void SaveMenuManager::createMenu()
 {
     m_saveMenu = new DMenu(qobject_cast<QWidget*>(parent()));
+    m_saveMenu->setObjectName("SaveMenu");
+    m_saveMenu->setAccessibleName("SaveMenu");
     DFontSizeManager::instance()->bind(m_saveMenu, DFontSizeManager::T6);
     
     createSaveOptionActions();
@@ -58,15 +60,18 @@ void SaveMenuManager::createSaveOptionActions()
 {
     // 创建保存选项组 - 包含"每次询问"和"指定位置"，实现互斥
     m_saveOptionGroup = new QActionGroup(this);
+    m_saveOptionGroup->setObjectName("SaveOptionGroup");
     m_saveOptionGroup->setExclusive(true);
     
     // 每次询问选项
     m_askEachTimeAction = new QAction(tr("Each inquiry"), m_saveMenu);
+    m_askEachTimeAction->setObjectName("AskEachTimeAction");
     m_askEachTimeAction->setCheckable(true);
     m_saveOptionGroup->addAction(m_askEachTimeAction);
     
     // 指定位置选项 - 需要设置为checkable以参与互斥，同时还有子菜单
     m_specifiedLocationAction = new QAction(tr("Specified location"), m_saveMenu);
+    m_specifiedLocationAction->setObjectName("SpecifiedLocationAction");
     m_specifiedLocationAction->setCheckable(true);
     m_saveOptionGroup->addAction(m_specifiedLocationAction);
     
@@ -79,26 +84,32 @@ void SaveMenuManager::createLocationActions()
 {
     // 创建指定位置子菜单，设置给"指定位置"Action
     m_specifiedLocationSubMenu = new DMenu(tr("Specified location"), m_saveMenu);
+    m_specifiedLocationSubMenu->setObjectName("SpecifiedLocationSubMenu");
+    m_specifiedLocationSubMenu->setAccessibleName("SpecifiedLocationSubMenu");
     DFontSizeManager::instance()->bind(m_specifiedLocationSubMenu, DFontSizeManager::T6);
     
     // 创建位置选项组
     m_locationGroup = new QActionGroup(this);
+    m_locationGroup->setObjectName("LocationGroup");
     m_locationGroup->setExclusive(true);
     
     // "保存到桌面"
     m_desktopAction = new QAction(tr("Desktop"), m_specifiedLocationSubMenu);
+    m_desktopAction->setObjectName("DesktopAction");
     m_desktopAction->setCheckable(true);
     m_locationGroup->addAction(m_desktopAction);
     m_specifiedLocationSubMenu->addAction(m_desktopAction);
     
     // "保存到图片" 
     m_picturesAction = new QAction(tr("Pictures"), m_specifiedLocationSubMenu);
+    m_picturesAction->setObjectName("PicturesAction");
     m_picturesAction->setCheckable(true);
     m_locationGroup->addAction(m_picturesAction);
     m_specifiedLocationSubMenu->addAction(m_picturesAction);
     
     // "保存时选择位置"
     m_chooseOnSaveAction = new QAction(tr("Select a location when saving"), m_specifiedLocationSubMenu);
+    m_chooseOnSaveAction->setObjectName("ChooseOnSaveAction");
     m_chooseOnSaveAction->setCheckable(true);
     m_chooseOnSaveAction->setChecked(true); // 默认选中
     m_locationGroup->addAction(m_chooseOnSaveAction);
@@ -106,6 +117,7 @@ void SaveMenuManager::createLocationActions()
     
     // 自定义路径选项 - 当有路径时显示
     m_customPathAction = new QAction("", m_specifiedLocationSubMenu);
+    m_customPathAction->setObjectName("CustomPathAction");
     m_customPathAction->setCheckable(true);
     m_customPathAction->setVisible(false); // 默认隐藏，有路径时才显示
     m_locationGroup->addAction(m_customPathAction);
@@ -113,6 +125,7 @@ void SaveMenuManager::createLocationActions()
     
     // "保存时更新位置" - 当有路径时显示
     m_updateOnSaveAction = new QAction(tr("Update the location when saving"), m_specifiedLocationSubMenu);
+    m_updateOnSaveAction->setObjectName("UpdateOnSaveAction");
     m_updateOnSaveAction->setCheckable(true);
     m_updateOnSaveAction->setVisible(false); // 默认隐藏，有路径时才显示
     m_locationGroup->addAction(m_updateOnSaveAction);

--- a/src/widgets/scrollshottip.cpp
+++ b/src/widgets/scrollshottip.cpp
@@ -41,6 +41,8 @@ ScrollShotTip::ScrollShotTip(DWidget *parent) : DWidget(parent)
     this->setMinimumSize(100, TIP_HEIGHT);
 
     m_warmingIconButton = new DIconButton(this);
+    m_warmingIconButton->setObjectName("WarmingIconButton");
+    m_warmingIconButton->setAccessibleName("WarmingIconButton");
     m_warmingIconButton->setIcon(warmingImg);
     m_warmingIconButton->setIconSize(QSize(26, 26));
     m_warmingIconButton->setFlat(true);

--- a/src/widgets/shapetoolwidget.cpp
+++ b/src/widgets/shapetoolwidget.cpp
@@ -65,10 +65,13 @@ void ShapeToolWidget::initShapeButtons()
     setFixedSize(78,50);
     // 创建按钮组
     m_shapeBtnGroup = new QButtonGroup(this);
+    m_shapeBtnGroup->setObjectName("ShapeBtnGroup");
     m_shapeBtnGroup->setExclusive(true);
     
     // 创建矩形按钮
     m_rectButton = new ToolButton(this);
+    m_rectButton->setObjectName("RectButton");
+    m_rectButton->setAccessibleName("RectButton");
     m_rectButton->setFixedSize(TOOL_BUTTON_SIZE);
     m_rectButton->setIconSize(TOOL_ICON_SIZE);
     m_rectButton->setIcon(QIcon::fromTheme(QString("rectangle-normal")));
@@ -77,6 +80,8 @@ void ShapeToolWidget::initShapeButtons()
     
     // 创建椭圆按钮
     m_ovalButton = new ToolButton(this);
+    m_ovalButton->setObjectName("OvalButton");
+    m_ovalButton->setAccessibleName("OvalButton");
     m_ovalButton->setFixedSize(TOOL_BUTTON_SIZE);
     m_ovalButton->setIconSize(TOOL_ICON_SIZE);
     m_ovalButton->setIcon(QIcon::fromTheme(QString("oval-normal")));

--- a/src/widgets/shottoolwidget.cpp
+++ b/src/widgets/shottoolwidget.cpp
@@ -358,6 +358,7 @@ void ShotToolWidget::initThicknessLabel()
     m_thicknessLabel = new DLabel(this);
     //粗细按钮组
     m_thicknessBtnGroup = new QButtonGroup(this);
+    m_thicknessBtnGroup->setObjectName("ThicknessBtnGroup");
     m_thicknessBtnGroup->setExclusive(true);
 
     //水平布局

--- a/src/widgets/subtoolwidget.cpp
+++ b/src/widgets/subtoolwidget.cpp
@@ -80,6 +80,8 @@ void SubToolWidget::initRecordLabel()
 
     //添加显示键盘按钮
     m_keyBoardButton = new ToolButton();
+    m_keyBoardButton->setObjectName("KeyBoardButton");
+    m_keyBoardButton->setAccessibleName("KeyBoardButton");
     Utils::setAccessibility(m_keyBoardButton, AC_SUBTOOLWIDGET_KEYBOARD_BUTTON);
     m_keyBoardButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_keyBoardButton, tr("Show keystroke (K)"));
@@ -103,6 +105,8 @@ void SubToolWidget::initRecordLabel()
 
     //添加摄像头显示按钮
     m_cameraButton = new ToolButton();
+    m_cameraButton->setObjectName("CameraButton");
+    m_cameraButton->setAccessibleName("CameraButton");
     m_cameraButton->setDisabled(QMediaDevices::videoInputs().isEmpty());
     Utils::setAccessibility(m_cameraButton, AC_SUBTOOLWIDGET_CAMERA_BUTTON);
     m_cameraButton->setIconSize(TOOL_ICON_SIZE);
@@ -128,6 +132,8 @@ void SubToolWidget::initRecordLabel()
 
 
     m_shotButton = new ToolButton();
+    m_shotButton->setObjectName("ShotButton");
+    m_shotButton->setAccessibleName("ShotButton");
     m_shotButton->setCheckable(false);
     Utils::setAccessibility(m_shotButton, AC_SUBTOOLWIDGET_SHOT_BUTTON);
     m_shotButton->setIconSize(TOOL_ICON_SIZE);
@@ -149,6 +155,8 @@ void SubToolWidget::initRecordLabel()
 
     //添加录屏选项按钮
     m_optionButton = new ToolButton();
+    m_optionButton->setObjectName("OptionButton");
+    m_optionButton->setAccessibleName("OptionButton");
     m_optionButton->setCheckable(false);
     m_optionButton->setIconSize(QSize(24,24));
     m_optionButton->setFixedSize(TOOL_BUTTON_SIZE);
@@ -199,6 +207,8 @@ void SubToolWidget::initRecordOption()
     t_mouseInfoGroup->setExclusive(false);
     t_saveGroup->setExclusive(true);
     m_recordOptionMenu = new DMenu(this);
+    m_recordOptionMenu->setObjectName("RecordOptionMenu");
+    m_recordOptionMenu->setAccessibleName("RecordOptionMenu");
     m_recordOptionMenu->installEventFilter(this);
     DFontSizeManager::instance()->bind(m_recordOptionMenu, DFontSizeManager::T6);
     // 保存格式
@@ -225,7 +235,9 @@ void SubToolWidget::initRecordOption()
     audio->setFont(titleActionFont);
     //QAction *notAudio = new QAction(tr("Not Audio"), m_recordOptionMenu);
     m_microphoneAction = new QAction(tr("Microphone"), m_recordOptionMenu);
+    m_microphoneAction->setObjectName("MicrophoneAction");
     m_sysAudioAction = new QAction(tr("System audio"), m_recordOptionMenu);
+    m_sysAudioAction->setObjectName("SysAudioAction");
     Utils::setAccessibility(m_microphoneAction, "microphoneAction");
     Utils::setAccessibility(m_sysAudioAction, "sysAudioAction");
     // 选项
@@ -556,12 +568,15 @@ void SubToolWidget::initShotLabel()
     qCDebug(dsrApp) << "SubToolWidget::initShotLabel called (initializing screenshot toolbar UI).";
     m_shotSubTool = new DLabel(this);
     m_shotBtnGroup = new QButtonGroup(this);
+    m_shotBtnGroup->setObjectName("ShotBtnGroup");
     m_shotBtnGroup->setExclusive(true);
 
     QList<ToolButton *> btnList;
 
     //添加几何图形按钮
     m_gioButton = new ToolButton();
+    m_gioButton->setObjectName("GioButton");
+    m_gioButton->setAccessibleName("GioButton");
     m_gioButton->setIconSize(TOOL_ICON_SIZE);
     m_gioButton->setIcon(QIcon::fromTheme("gioshape"));
     Utils::setAccessibility(m_gioButton, AC_SUBTOOLWIDGET_GIO_BUTTON);
@@ -572,6 +587,8 @@ void SubToolWidget::initShotLabel()
 
     //添加直线按钮
     m_lineButton = new ToolButton();
+    m_lineButton->setObjectName("LineButton");
+    m_lineButton->setAccessibleName("LineButton");
     m_lineButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_lineButton, tr("Line (L)\nPress and hold Shift to draw a vertical or horizontal line"));
     m_lineButton->setIcon(QIcon::fromTheme("line-normal"));
@@ -582,6 +599,8 @@ void SubToolWidget::initShotLabel()
 
     //添加箭头按钮
     m_arrowButton = new ToolButton();
+    m_arrowButton->setObjectName("ArrowButton");
+    m_arrowButton->setAccessibleName("ArrowButton");
     m_arrowButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_arrowButton, tr("Arrow (X)\nPress and hold Shift to draw a vertical or horizontal arrow"));
     m_arrowButton->setIcon(QIcon::fromTheme("Arrow-normal"));
@@ -592,6 +611,8 @@ void SubToolWidget::initShotLabel()
 
     //添加画笔按钮
     m_penButton = new ToolButton();
+    m_penButton->setObjectName("PenButton");
+    m_penButton->setAccessibleName("PenButton");
     m_penButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_penButton, tr("Pencil (P)"));
     m_penButton->setIcon(QIcon::fromTheme("Combined Shape-normal"));
@@ -602,6 +623,8 @@ void SubToolWidget::initShotLabel()
 
     //添加模糊按钮
     m_mosaicButton = new ToolButton();
+    m_mosaicButton->setObjectName("MosaicButton");
+    m_mosaicButton->setAccessibleName("MosaicButton");
     m_mosaicButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_mosaicButton, tr("Blur (B)"));
     m_mosaicButton->setIcon(QIcon::fromTheme("Mosaic_normal"));
@@ -614,6 +637,8 @@ void SubToolWidget::initShotLabel()
 
     //添加文字按钮
     m_textButton = new ToolButton();
+    m_textButton->setObjectName("TextButton");
+    m_textButton->setAccessibleName("TextButton");
     m_textButton->setIconSize(TOOL_ICON_SIZE);
     m_textButton->setIcon(QIcon::fromTheme("text"));
     installTipHint(m_textButton, tr("Text (T)"));
@@ -624,6 +649,8 @@ void SubToolWidget::initShotLabel()
 
     //添加滚动截图按钮
     m_scrollShotButton = new ToolButton();
+    m_scrollShotButton->setObjectName("ScrollShotButton");
+    m_scrollShotButton->setAccessibleName("ScrollShotButton");
     m_scrollShotButton->setCheckable(false);
     m_scrollShotButton->setIconSize(TOOL_ICON_SIZE);
     m_scrollShotButton->setIcon(QIcon::fromTheme("scrollShot"));
@@ -642,6 +669,8 @@ void SubToolWidget::initShotLabel()
     });
     //添加ocr图文识别按钮
     m_ocrButton = new ToolButton();
+    m_ocrButton->setObjectName("OcrButton");
+    m_ocrButton->setAccessibleName("OcrButton");
     m_ocrButton->setCheckable(false);
     m_ocrButton->setIconSize(TOOL_ICON_SIZE);
     m_ocrButton->setIcon(QIcon::fromTheme("ocr-normal"));
@@ -661,6 +690,8 @@ void SubToolWidget::initShotLabel()
 
     //添加贴图按钮
     m_pinButton = new ToolButton();
+    m_pinButton->setObjectName("PinButton");
+    m_pinButton->setAccessibleName("PinButton");
     m_pinButton->setCheckable(false);
     m_pinButton->setIconSize(TOOL_ICON_SIZE);
     m_pinButton->setIcon(QIcon::fromTheme("pinscreenshots"));
@@ -674,6 +705,8 @@ void SubToolWidget::initShotLabel()
     btnList.append(m_pinButton);
 
     m_aiAssistantButton = new ToolButton();
+    m_aiAssistantButton->setObjectName("AiAssistantButton");
+    m_aiAssistantButton->setAccessibleName("AiAssistantButton");
     m_aiAssistantButton->setIconSize(SMALL_TOOL_ICON_SIZE);
     m_aiAssistantButton->setIcon(QIcon::fromTheme("ai_assistant"));
     bool aiAssistantUsed = ConfigSettings::instance()->getValue("shot", "ai_assistant_used").toBool();
@@ -699,6 +732,8 @@ void SubToolWidget::initShotLabel()
 
     // 撤销按钮
     m_cancelButton = new ToolButton();
+    m_cancelButton->setObjectName("CancelButton");
+    m_cancelButton->setAccessibleName("CancelButton");
     m_cancelButton->setUndoButtonFlag(true);
     m_cancelButton->setCheckable(false);
     m_cancelButton->setIconSize(TOOL_ICON_SIZE);
@@ -717,6 +752,8 @@ void SubToolWidget::initShotLabel()
     //切换到录屏按钮
     // TODO:treeland暂时屏蔽录屏功能
     m_recorderButton = new ToolButton();
+    m_recorderButton->setObjectName("RecorderButton");
+    m_recorderButton->setAccessibleName("RecorderButton");
     m_recorderButton->setCheckable(false);
     m_recorderButton->setIconSize(TOOL_ICON_SIZE);
     m_recorderButton->setIcon(QIcon::fromTheme("recorder"));
@@ -736,6 +773,8 @@ void SubToolWidget::initShotLabel()
         });
 
     m_shotOptionButton = new ToolButton();
+    m_shotOptionButton->setObjectName("ShotOptionButton");
+    m_shotOptionButton->setAccessibleName("ShotOptionButton");
     m_shotOptionButton->setCheckable(false);
     m_shotOptionButton->setIconSize(QSize(24,24));
     m_shotOptionButton->setFixedSize(TOOL_BUTTON_SIZE);
@@ -936,6 +975,8 @@ void SubToolWidget::initShotOption()
     t_formatGroup->setExclusive(true);
 
     m_optionMenu = new DMenu(this);
+    m_optionMenu->setObjectName("OptionMenu");
+    m_optionMenu->setAccessibleName("OptionMenu");
     m_optionMenu->installEventFilter(this);
     //系统级别为 T6 的字体大小, 默认是14 px
     DFontSizeManager::instance()->bind(m_optionMenu, DFontSizeManager::T6);
@@ -957,6 +998,8 @@ void SubToolWidget::initShotOption()
     
     // 创建自定义位置子菜单
     // m_saveToSpecialPathMenu = new DMenu(specifiedLocationMenu);
+    m_saveToSpecialPathMenu->setObjectName("SaveToSpecialPathMenu");
+    m_saveToSpecialPathMenu->setAccessibleName("SaveToSpecialPathMenu");
     // m_saveToSpecialPathMenu->installEventFilter(this);
     // m_saveToSpecialPathMenu->setTitle(tr("Custom Location"));
     // m_saveToSpecialPathMenu->setToolTipsVisible(true);
@@ -971,10 +1014,12 @@ void SubToolWidget::initShotOption()
     
     // 上次保存位置
     // m_saveToSpecialPathAction = new QAction(m_saveToSpecialPathMenu);
+    m_saveToSpecialPathAction->setObjectName("SaveToSpecialPathAction");
     // m_saveToSpecialPathAction->setCheckable(true);
     
     // 保存时更新位置
     // m_changeSaveToSpecialPath = new QAction(m_saveToSpecialPathMenu);
+    m_changeSaveToSpecialPath->setObjectName("ChangeSaveToSpecialPath");
     // m_changeSaveToSpecialPath->setCheckable(true);
     
     // if (specialPath.isEmpty() || !QFileInfo::exists(specialPath)) {
@@ -1454,6 +1499,8 @@ void SubToolWidget::initScrollLabel()
 
     // AI 助手（滚动截图工具栏首位）
     m_aiAssistantScrollButton = new ToolButton();
+    m_aiAssistantScrollButton->setObjectName("AiAssistantScrollButton");
+    m_aiAssistantScrollButton->setAccessibleName("AiAssistantScrollButton");
     m_aiAssistantScrollButton->setIconSize(SMALL_TOOL_ICON_SIZE);
     m_aiAssistantScrollButton->setIcon(QIcon::fromTheme("ai_assistant"));
     // 设置常驻的 AI Icon 角标
@@ -1474,6 +1521,8 @@ void SubToolWidget::initScrollLabel()
 
     //文字识别按钮
     m_ocrScrollButton = new ToolButton();
+    m_ocrScrollButton->setObjectName("OcrScrollButton");
+    m_ocrScrollButton->setAccessibleName("OcrScrollButton");
     Utils::setAccessibility(m_ocrScrollButton, AC_SUBTOOLWIDGET_KEYBOARD_BUTTON);
     m_ocrScrollButton->setIconSize(TOOL_ICON_SIZE);
     installTipHint(m_ocrScrollButton,  tr("Extract Text"));
@@ -1486,6 +1535,8 @@ void SubToolWidget::initScrollLabel()
 
     //滚动截图选项
     m_scrollOptionButton = new ToolButton();
+    m_scrollOptionButton->setObjectName("ScrollOptionButton");
+    m_scrollOptionButton->setAccessibleName("ScrollOptionButton");
     m_scrollOptionButton->setCheckable(false);
     m_scrollOptionButton->setIconSize(QSize(24,24));
     m_scrollOptionButton->setFixedSize(TOOL_BUTTON_SIZE);
@@ -1552,6 +1603,8 @@ void SubToolWidget::initScrollLabel()
     t_formatGroup->setExclusive(true);
 
     m_scrollOptionMenu = new DMenu(this);
+    m_scrollOptionMenu->setObjectName("ScrollOptionMenu");
+    m_scrollOptionMenu->setAccessibleName("ScrollOptionMenu");
     m_scrollOptionMenu->installEventFilter(this);
     DFontSizeManager::instance()->bind(m_scrollOptionMenu, DFontSizeManager::T6);
 
@@ -1574,6 +1627,8 @@ void SubToolWidget::initScrollLabel()
     
     // 创建自定义位置子菜单
     // m_scrollSaveToSpecialPathMenu = new DMenu(specifiedLocationMenu);
+    m_scrollSaveToSpecialPathMenu->setObjectName("ScrollSaveToSpecialPathMenu");
+    m_scrollSaveToSpecialPathMenu->setAccessibleName("ScrollSaveToSpecialPathMenu");
     // m_scrollSaveToSpecialPathMenu->installEventFilter(this);
     // m_scrollSaveToSpecialPathMenu->setTitle(tr("Custom Location"));
     // m_scrollSaveToSpecialPathMenu->setToolTipsVisible(true);
@@ -1588,10 +1643,12 @@ void SubToolWidget::initScrollLabel()
     
     // 上次保存位置
     // m_scrollSaveToSpecialPathAction = new QAction(m_scrollSaveToSpecialPathMenu);
+    m_scrollSaveToSpecialPathAction->setObjectName("ScrollSaveToSpecialPathAction");
     // m_scrollSaveToSpecialPathAction->setCheckable(true);
     
     // 保存时更新位置
     // m_scrollChangeSaveToSpecialPath = new QAction(tr("Set a path on save"), m_scrollSaveToSpecialPathMenu);
+    m_scrollChangeSaveToSpecialPath->setObjectName("ScrollChangeSaveToSpecialPath");
     // m_scrollChangeSaveToSpecialPath->setCheckable(true);
     
     // 如果有保存路径，显示上次保存位置

--- a/src/widgets/toolbar.cpp
+++ b/src/widgets/toolbar.cpp
@@ -57,8 +57,12 @@ ToolBarWidget::ToolBarWidget(MainWindow *pMainwindow, DWidget *parent, bool hide
     // m_subTool->setVisible(false);
     //关闭按钮
     m_closeButton = new ToolButton(this);
+    m_closeButton->setObjectName("CloseButton");
+    m_closeButton->setAccessibleName("CloseButton");
     m_closeButton->setCheckable(false);
     m_confirmButton = new ToolButton(this);
+    m_confirmButton->setObjectName("ConfirmButton");
+    m_confirmButton->setAccessibleName("ConfirmButton");
     m_confirmButton->setCheckable(false);
 
     m_closeButton->setIconSize(QSize(36, 36));


### PR DESCRIPTION
## 概述

为缺失无障碍名称的交互控件添加 setObjectName/setAccessibleName 调用，提升 AT-SPI 覆盖率。

## 覆盖率对比

| 指标 | 补全前 | 补全后 |
| --- | --- | --- |
| 总控件数 | 94 | 94 |
| 已命名 | 9 | 91 |
| 缺失 | 85 | 3 |
| 覆盖率 | 9.6% | 96.8% |

## 修改文件 (14 files, +121 lines)

- src/menucontroller/menucontroller.cpp
- src/pin_screenshots/ui/menucontroller.cpp
- src/pin_screenshots/ui/pinsavemenumanager.cpp
- src/pin_screenshots/ui/subtoolwidget.cpp
- src/widgets/aiassistantwidget.cpp
- src/widgets/colortoolwidget.cpp
- src/widgets/imagemenu.cpp
- src/widgets/maintoolwidget.cpp
- src/widgets/savemenumanager.cpp
- src/widgets/scrollshottip.cpp
- src/widgets/shapetoolwidget.cpp
- src/widgets/shottoolwidget.cpp
- src/widgets/subtoolwidget.cpp
- src/widgets/toolbar.cpp

## 验证

- AT-SPI 变更为纯增量添加 setObjectName/setAccessibleName，不影响现有逻辑
- 仓库存在预存 Qt5/Qt6 兼容编译问题（QEnterEvent、SingleShotConnection），与本次改动无关

## Summary by Sourcery

Enhancements:
- Add object and accessibility names to previously unnamed menus, actions, buttons, and control groups to substantially improve AT-SPI accessibility coverage.