### PR TITLE
fix(dock): remove undock menu on right-click of record timer icon

### DIFF
--- a/src/dde-dock-plugins/recordtime/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
+++ b/src/dde-dock-plugins/recordtime/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<schemalist>
+
+  <schema path="/com/deepin/dde/dock/module/deepin-screen-recorder-plugin/" id="com.deepin.dde.dock.module.deepin-screen-recorder-plugin" gettext-domain="deepin-screen-recorder-plugin">
+    <key type="b" name="control">
+      <default>false</default>
+      <summary>Blocking event</summary>
+      <description>
+          Blocking mouse events
+      </description>
+    </key>
+    <key type="b" name="enable">
+      <default>true</default>
+      <summary>Module Enable</summary>
+      <description>
+          Control Module Enable
+      </description>
+    </key>
+    <key type="b" name="menu-enable">
+      <default>false</default>
+      <summary>Menu Enable</summary>
+      <description>
+          Control Menu Enable.
+          录制期计时图标为临时入口：右键即停止并保存录屏（由插件控件自身处理），
+          旧版 dock 不再为其弹出右键菜单（含“禁用插件”等项）。
+      </description>
+    </key>
+    <key type="b" name="visible">
+      <default>true</default>
+      <summary>Module visible</summary>
+      <description>
+          Control Menu pluginsettings visible
+      </description>
+    </key>
+  </schema>
+
+</schemalist>

--- a/src/dde-dock-plugins/recordtime/recordtime.pro
+++ b/src/dde-dock-plugins/recordtime/recordtime.pro
@@ -20,7 +20,9 @@ SOURCES += \
     dbusservice.cpp
 
 target.path = /usr/lib/dde-dock/plugins/
+gschema.files += $$PWD/com.deepin.dde.dock.module.deepin-screen-recorder-plugin.gschema.xml
+gschema.path += /usr/share/glib-2.0/schemas/
 
-INSTALLS += target
+INSTALLS += target gschema
 
 RESOURCES += res.qrc

--- a/src/dde-dock-plugins/recordtime/recordtimeplugin.h
+++ b/src/dde-dock-plugins/recordtime/recordtimeplugin.h
@@ -39,6 +39,8 @@ public:
     //cppcheck误报：此函数从未被使用，其实这个函数由dde-dock框架调用
     /**
      * @brief pluginIsAllowDisable:返回插件是否允许被禁用
+     * 须保持 true：false 会让旧版 dock 跳过插件状态切换，导致录制图标被
+     * 并入折叠箭头；右键菜单的关闭改由模块 gschema 的 menu-enable=false 实现。
      * @return
      */
     bool pluginIsAllowDisable() override { return true; }

--- a/src/dde-dock-plugins/recordtime/timewidget.cpp
+++ b/src/dde-dock-plugins/recordtime/timewidget.cpp
@@ -390,6 +390,15 @@ void TimeWidget::mouseReleaseEvent(QMouseEvent *e)
     m_pressed = false;
     m_hover = false;
     update();
+    if (e->button() == Qt::RightButton) {
+        // 右键已在上方触发停止并保存录屏（stopRecord）。
+        // 此处必须拦截事件、结束传播：1070任务栏中本控件嵌在
+        // trayplugin-loader 的 PluginItem 容器内，右键release一旦
+        // 向上传播，容器会弹出“从任务栏移除”菜单（插件itemContextMenu
+        // 为空，菜单仅含该项），导致“右键保存”的同时弹出驻留/移除菜单。
+        e->accept();
+        return;
+    }
     QWidget::mouseReleaseEvent(e);
     qDebug() << "Mouse release end!";
 


### PR DESCRIPTION
## 问题

录制中右键任务栏计时图标（deepin-screen-recorder-plugin）时，除了停止并保存录屏，还会弹出 dock 自带的“驻留任务栏/从任务栏移除”菜单，误触易导致图标被移除。

Bug: https://pms.uniontech.com/bug-view-376541.html

## 根因

- **1070（dde-shell / trayplugin-loader）**：TimeWidget 的右键 release 事件未 accept，向上传播至 `PluginItem::mouseReleaseEvent` 触发菜单（插件未实现 itemContextMenu，菜单仅含“从任务栏移除”一项）；
- **旧版 dde-dock（5.10.x）**：`PluginsItem` 在右键 press 时依据模块 gsettings 键 `menuEnable` 弹出菜单，插件未提供模块 schema 时该键缺省视为开启。

## 修复

1. `TimeWidget::mouseReleaseEvent` 右键 release 时 `e->accept()` 截断事件传播（Qt 标准事件语义；左键、拖拽路径不受影响）；
2. 新增模块 gschema `com.deepin.dde.dock.module.deepin-screen-recorder-plugin`，`menu-enable=false`，关闭旧版 dock 右键菜单（与 shotstartrecord 插件的 menu-enable 机制一致）；
3. `pluginIsAllowDisable` 保持 `true`、未设置 `pluginFlags` 属性，插件在 dock 中的分类与摆位与官方包行为一致。

## 验证

- 旧版 dock 环境：录制中右键计时图标直接停止并保存录屏，无菜单弹出；图标摆位正常；
- 录制与保存功能正常。

## Summary by Sourcery

Prevent accidental dock menu interactions when stopping and saving a recording via the timer icon’s right-click action.

Bug Fixes:
- Prevent the recording timer icon’s right-click action from propagating to the dock and opening the plugin removal menu.
- Disable the legacy dock context menu for the screen recorder plugin while preserving normal recording and dock placement behavior.

Build:
- Install the screen recorder dock module schema with the record-time plugin.